### PR TITLE
chore: external-secrets: use default image

### DIFF
--- a/byoc-nuon/components/4-image-external_secrets.toml
+++ b/byoc-nuon/components/4-image-external_secrets.toml
@@ -1,6 +1,0 @@
-name   = "img_external_secrets"
-type   = "container_image"
-
-[public]
-image_url = "temporalio/ui"
-tag       = "2.34.0"

--- a/byoc-nuon/components/values/external-secrets.yaml
+++ b/byoc-nuon/components/values/external-secrets.yaml
@@ -21,9 +21,11 @@ bitwarden-sdk-server:
 revisionHistoryLimit: 10
 
 image:
-  # repository: oci.external-secrets.io/external-secrets/external-secrets
-  repository: "{{ .nuon.components.img_external_secrets.outputs.image.repository }}"
-  tag: "{{ .nuon.components.img_external_secrets.outputs.image.tag }}"
+  repository: oci.external-secrets.io/external-secrets/external-secrets
+  tag: "v0.16.2"
+  # TODO: move to our internally managed images
+  # repository: ".nuon.components.img_external_secrets.outputs.image.repository"
+  # tag: ".nuon.components.img_external_secrets.outputs.image.tag"
   pullPolicy: Always
 
 # -- If set, install and upgrade CRDs through helm chart.


### PR DESCRIPTION
instead of one mirrored into our ECR. this is a short term thing until
we sort out the best way to get that image into our ECR via a
`container_image` component.
