### PR TITLE
ci: publish "main" action from main branch

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches: main
+    paths:
+      - "byoc-nuon/**"
+  workflow_dispatch:
+defaults:
+  run:
+    shell: bash
+env:
+  NUON_ORG_ID: ${{ secrets.NUON_ORG_ID }}
+  NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    name: Push to Nuon
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install CLI
+        id: cli
+        run: ./scripts/install-cli.sh
+      - name: Sync configs
+        id: sync
+        run: |
+          nuon apps sync-dir ./byoc-nuon
+    env:
+      NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN }}
+      NUON_ORG_ID: ${{ secrets.NUON_ORG_ID }}

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+if [ "$NUON_DEBUG" = "true" ]
+then
+  set -x
+fi
+
+set -e
+set -o pipefail
+set -u
+
+BASE_URL=https://nuon-artifacts.s3.us-west-2.amazonaws.com/cli
+NAME=nuon
+
+DIR=~/bin
+if [ ! -d "$DIR" ]; then
+  DIR=/usr/local/bin
+
+  # fall back to /usr/local/bin
+  if [ ! -d $DIR ]; then
+    # fall back to /bin
+    DIR=/bin
+  fi
+fi
+
+echo "Installing nuon cli into $DIR"
+
+echo "checking OS and Architecture..."
+set +e
+dpkg_path=$(which dpkg)
+set -e
+if [ "$dpkg_path" = "" ]
+then
+  ARCH=$(uname -m)
+else
+  ARCH=$(dpkg --print-architecture)
+fi
+
+if [ "$ARCH" = "x86_64" ]; then
+  ARCH=amd64
+fi
+
+OS=$(uname -s |  awk '{print tolower($0)}')
+echo "✅ using version ${OS}_${ARCH}..."
+
+echo "calculating latest version..."
+VERSION=$(curl -s $BASE_URL/latest.txt)
+echo "✅ using version ${VERSION}..."
+
+echo "fetching binary for ${OS} ${ARCH}..."
+curl -s -o $DIR/$NAME $BASE_URL/$VERSION/${NAME}_${OS}_${ARCH}
+echo "✅ fetching binary for ${OS} ${ARCH}..."
+
+echo "making binary executable..."
+chmod +x $DIR/$NAME
+echo "✅ nuon should be ready to use"


### PR DESCRIPTION
To ensure the latest app config is always in sync with the main branch, we want to sync from main whenever it's pushed to.