### PR TITLE
feat: datadog component

### DIFF
--- a/byoc-nuon/components/99-tf-datadog.toml
+++ b/byoc-nuon/components/99-tf-datadog.toml
@@ -1,0 +1,21 @@
+name              = "datadog"
+type              = "terraform_module"
+terraform_version = "1.11.3"
+dependencies      = ["temporal", "ctl_api", "dashboard_ui"]
+
+[public_repo]
+repo      = "nuonco/byoc"
+directory = "byoc-nuon/src/components/datadog"
+branch    = "main"
+
+[vars]
+cluster_name                       = "{{ .nuon.install.sandbox.outputs.cluster.name }}"
+cluster_endpoint                   = "{{ .nuon.install.sandbox.outputs.cluster.endpoint }}"
+cluster_certificate_authority_data = "{{ .nuon.install.sandbox.outputs.cluster.certificate_authority_data }}"
+region                             = "{{ .nuon.install_stack.outputs.region }}"
+
+env             = "{{ .nuon.install.name }}"
+install_id      = "{{ .nuon.install.id }}"
+root_domain     = "{{ .nuon.inputs.inputs.root_domain }}"
+datadog_api_key = "{{ .nuon.inputs.inputs.datadog_api_key }}"
+datadog_app_key = "{{ .nuon.inputs.inputs.datadog_app_key }}"

--- a/byoc-nuon/input_groups/aws.toml
+++ b/byoc-nuon/input_groups/aws.toml
@@ -1,4 +1,0 @@
-name         = "aws"
-description  = "Configure your AWS deployment of Nuon"
-display_name = "AWS configuration"
-

--- a/byoc-nuon/input_groups/datadog.toml
+++ b/byoc-nuon/input_groups/datadog.toml
@@ -1,0 +1,3 @@
+name         = "datadog"
+display_name = "Datadog"
+description  = "Optional configuration for datadog"

--- a/byoc-nuon/inputs/aws/private_subnet_ids.toml
+++ b/byoc-nuon/inputs/aws/private_subnet_ids.toml
@@ -1,6 +1,0 @@
-name         = "private_subnet_ids"
-description  = "The subnets you want private Nuon resources deployed in."
-sensitive    = false
-display_name = "Private subnet IDs"
-group        = "aws"
-

--- a/byoc-nuon/inputs/aws/public_subnet_ids.toml
+++ b/byoc-nuon/inputs/aws/public_subnet_ids.toml
@@ -1,6 +1,0 @@
-name         = "public_subnet_ids"
-description  = "The subnets you want public Nuon resources deployed in."
-sensitive    = false
-display_name = "Public subnet IDs"
-group        = "aws"
-

--- a/byoc-nuon/inputs/aws/vpc.toml
+++ b/byoc-nuon/inputs/aws/vpc.toml
@@ -1,6 +1,0 @@
-name         = "vpc_id"
-description  = "The VPC you want to deploy Nuon in."
-sensitive    = false
-display_name = "VPC ID"
-group        = "aws"
-

--- a/byoc-nuon/inputs/datadog/datadog_api_key.toml
+++ b/byoc-nuon/inputs/datadog/datadog_api_key.toml
@@ -1,0 +1,5 @@
+name         = "datadog_api_key"
+description  = "Datadog API Key"
+default      = ""
+display_name = "Datadog API Key"
+group        = "datadog"

--- a/byoc-nuon/inputs/datadog/datadog_app_key.toml
+++ b/byoc-nuon/inputs/datadog/datadog_app_key.toml
@@ -1,0 +1,5 @@
+name         = "datadog_app_key"
+description  = "Datadog App Key"
+default      = ""
+display_name = "Datadog App Key"
+group        = "datadog"

--- a/byoc-nuon/src/components/datadog/.yamllint.yaml
+++ b/byoc-nuon/src/components/datadog/.yamllint.yaml
@@ -1,0 +1,10 @@
+---
+
+extends: default
+
+ignore:
+  .terraform
+
+rules:
+  line-length:
+    max: 140

--- a/byoc-nuon/src/components/datadog/README.md
+++ b/byoc-nuon/src/components/datadog/README.md
@@ -1,0 +1,4 @@
+# datadog
+
+Datadog, but only the cluster parts. Mirrors the nuon cloud offering version of the datadog terraform minus the AWS
+integration itself. So cluster-only.

--- a/byoc-nuon/src/components/datadog/helm.tf
+++ b/byoc-nuon/src/components/datadog/helm.tf
@@ -1,0 +1,28 @@
+locals {
+  datadog = {
+    value_file = "values/datadog.yaml"
+  }
+}
+
+resource "helm_release" "datadog" {
+  count = local.enabled ? 1 : 0
+
+  name             = local.name
+  namespace        = local.namespace
+  create_namespace = true
+
+  repository = "https://helm.datadoghq.com"
+  chart      = "datadog"
+  version    = "3.54.2"
+
+  values = [
+    file(local.datadog.value_file),
+    yamlencode({
+      datadog = {
+        apiKey      = var.datadog_api_key
+        tags        = ["env:${var.env}"]
+        clusterName = var.env
+      }
+    })
+  ]
+}

--- a/byoc-nuon/src/components/datadog/outputs.tf
+++ b/byoc-nuon/src/components/datadog/outputs.tf
@@ -1,0 +1,4 @@
+// TODO(jm): output the tags that we set / environment.
+output "enabled" {
+  value = local.enabled
+}

--- a/byoc-nuon/src/components/datadog/providers.tf
+++ b/byoc-nuon/src/components/datadog/providers.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = {
+      "component.nuon.co/name" = "datadog"
+      "install.nuon.co/id"     = var.install_id
+    }
+  }
+}
+
+provider "datadog" {
+  api_key = var.datadog_api_key
+  app_key = var.datadog_app_key
+  api_url = "https://api.us5.datadoghq.com/"
+}
+
+provider "helm" {
+  helm_driver = "configmap"
+
+  kubernetes {
+    host                   = var.cluster_endpoint
+    cluster_ca_certificate = base64decode(var.cluster_certificate_authority_data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "--region", var.region, "get-token", "--cluster-name", var.cluster_name]
+    }
+  }
+}

--- a/byoc-nuon/src/components/datadog/values/datadog.yaml
+++ b/byoc-nuon/src/components/datadog/values/datadog.yaml
@@ -1,0 +1,44 @@
+---
+targetSystem: "linux"
+datadog:
+  site: us5.datadoghq.com
+  confd:
+    "temporal.yaml": |-
+      init_config:
+      instances:
+        - openmetrics_endpoint: "http://temporal-frontend-headless.temporal.svc.cluster.local:9090/metrics"
+        - openmetrics_endpoint: "http://temporal-worker-headless.temporal.svc.cluster.local:9090/metrics"
+        - openmetrics_endpoint: "http://temporal-matching-headless.temporal.svc.cluster.local:9090/metrics"
+        - openmetrics_endpoint: "http://temporal-history-headless.temporal.svc.cluster.local:9090/metrics"
+  logs:
+    enabled: true
+    containerCollectAll: true
+  apm:
+    portEnabled: true
+    socketPath: /var/run/datadog/apm.socket
+    hostSocketPath: /var/run/datadog/
+  processAgent:
+    enabled: true
+    processCollection: false
+  systemProbe:
+    enableTCPQueueLength: false
+    enableOOMKill: true
+    collectDNSStats: false
+  dogstatsd:
+    useHostPort: true
+    port: 8125
+agents:
+  tolerations:
+    - effect: NoSchedule
+      key: CriticalAddonsOnly
+      value: "true"
+    - key: "deployment"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "installation"
+      operator: "Equal"
+      value: "clickhouse-installation"
+      effect: "NoSchedule"
+    - key: "pool.nuon.co"
+      operator: "Exists"
+      effect: "NoSchedule"

--- a/byoc-nuon/src/components/datadog/variables.tf
+++ b/byoc-nuon/src/components/datadog/variables.tf
@@ -1,0 +1,46 @@
+locals {
+  name      = "datadog-agent"
+  namespace = "datadog"
+  enabled   = (var.datadog_api_key != "" && var.datadog_app_key != "")
+}
+
+variable "env" {
+  type        = string
+  description = "The environment to use. Typically one of dev, stage, prod. In this case, the installation name."
+}
+
+variable "datadog_api_key" {
+  type        = string
+  description = "The datadog api key - used by the agents."
+}
+
+variable "datadog_app_key" {
+  type        = string
+  description = "The datadog app key"
+}
+
+variable "install_id" {
+  type        = string
+  description = "Install ID"
+}
+# Cluster Info
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "AWS EKS Cluster name"
+}
+
+variable "cluster_endpoint" {
+  type        = string
+  description = "AWS EKS Cluster Endpoint"
+}
+
+variable "cluster_certificate_authority_data" {
+  type        = string
+  description = "AWS EKS Cluster CA Data"
+}
+

--- a/byoc-nuon/src/components/datadog/versions.tf
+++ b/byoc-nuon/src/components/datadog/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.7.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.67.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.17.0"
+    }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 0.17.23"
+    }
+    datadog = {
+      source  = "DataDog/datadog"
+      version = "3.44.1"
+    }
+  }
+}


### PR DESCRIPTION
### Description

Component to install the datadog agent. Introduces two new inputs:

- datadog_api_key
- datadog_app_key

Deploys datadog agent to install cluster.

> [!IMPORTANT]
> Not concerned with any AWS Datadog integrations. Simply the kubernetes agent.

To uninstall, set both inputs to empty strings. 
