### PR TITLE
feat: action and perms for asg instance refresh

### DIFF
--- a/byoc-nuon/actions/runner_instance_refresh.toml
+++ b/byoc-nuon/actions/runner_instance_refresh.toml
@@ -1,0 +1,18 @@
+#:schema https://api.nuon.co/v1/general/config-schema?source=action
+name    = "runner_asg_instance_refresh"
+timeout = "1m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name    = "runner_asg_instance_refresh"
+command = "./aws/runner-asg-instance-refresh.sh"
+
+[steps.public_repo]
+repo      = "nuonco/byoc"
+directory = "byoc-nuon/src/actions"
+branch    = "main"
+
+[steps.env_vars]
+DRY_RUN = "true"

--- a/byoc-nuon/permissions/maintenance.toml
+++ b/byoc-nuon/permissions/maintenance.toml
@@ -7,7 +7,7 @@ permissions_boundary = "./maintenance_boundary.json"
 [[policies]]
 managed_policy_name = "AdministratorAccess"
 
-# NOTE: the tag in this policy is determined by the rds_cluster_* component config. the format is known ahead of time by 
+# NOTE: the tag in this policy is determined by the rds_cluster_* component config. the format is known ahead of time by
 # convention.
 [[policies]]
 name = "{{ .nuon.install.id }}-limited-secrets-manage-rds"

--- a/byoc-nuon/permissions/maintenance_boundary.json
+++ b/byoc-nuon/permissions/maintenance_boundary.json
@@ -4,21 +4,32 @@
     {
       "Effect": "Allow",
       "Action": [
+        "Route53:*",
+        "acm:*",
+        "autoscaling:DescribeAutoScalingGroups",
         "cloudwatch:*",
         "ec2:*",
+        "ecr:*",
         "eks:*",
         "iam:*",
+        "kms:*",
+        "organizations:DescribeOrganization",
         "rds:*",
         "s3:*",
         "secretsmanager:*",
-        "sqs:*",
-        "ecr:*",
-        "acm:*",
-        "Route53:*",
-        "kms:*",
-        "organizations:DescribeOrganization"
+        "sqs:*"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["autoscaling:StartInstanceRefresh"],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/nuon_install_id": "{{ .nuon.install.id }}"
+        }
+      }
     }
   ]
 }

--- a/byoc-nuon/src/actions/aws/runner-asg-instance-refresh.sh
+++ b/byoc-nuon/src/actions/aws/runner-asg-instance-refresh.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+dry_run="${DRY_RUN:-false}"
+
+# disable pager
+export AWS_PAGER=""
+
+# search for asg by install id in tag value.
+# NOTE: future runners ASGs will have additional tags we can search by
+echo 'searching for ASGs for this install'
+asgs=`aws autoscaling describe-auto-scaling-groups --filters "Name=tag-value,Values=$NUON_INSTALL_ID" | jq '.AutoScalingGroups'`
+count=`echo $asgs | jq length`
+
+echo "Found $count ASGs for this Install"
+echo $asgs | jq -r '.[] | "> \(.AutoScalingGroupName)\n\(.AutoScalingGroupARN)" '
+
+if [[ "$dry_run" != "true" ]]; then
+  echo 'executing instance-refresh'
+  for name in `echo $asgs | jq -r ".[].AutoScalingGroupName"`; do
+    echo "  > refreshing: $name"
+    aws autoscaling start-instance-refresh --auto-scaling-group-name $name
+  done
+else
+  echo '[dry-run] will not execute'
+  for name in `echo $asgs | jq -r ".[].AutoScalingGroupName"`; do
+    echo "aws autoscaling start-instance-refresh --auto-scaling-group-name $name"
+  done
+fi


### PR DESCRIPTION
### Description
update permission boundary to allow
1. listing all autoscaling groups
2. calling `StartInstanceRefresh` on ASGs w/ the tag-value `{{ .nuon.install.id }}`. this scopes it to only those ASGs in use or created by this install's stack.

adds an action to start and instance refresh on the runner ASG. 

### Notes

The scope is effectively that one tag value. This is fine for our use-case in byoc nuon because there are no additional ASGs in play. But we need to modify the cloudformation stack to add an additional tag so we can ensure we can run an action that acts solely on the runner ASG. 

### Commits
- **feat: new action to refresh the runner asg instance**
- **feat: add minimal autoscaling perms**
