### PR TITLE
chore: rds_cluster_*: add db_instance_availability_zone to outputs

### DIFF
--- a/byoc-nuon/src/components/rds_cluster_nuon/outputs.tf
+++ b/byoc-nuon/src/components/rds_cluster_nuon/outputs.tf
@@ -25,3 +25,7 @@ output "db_instance_name" {
 output "db_instance_username" {
   value = module.db.db_instance_username
 }
+
+output "db_instance_availability_zone" {
+  value = module.db.db_instance_availability_zone
+}

--- a/byoc-nuon/src/components/rds_cluster_temporal/outputs.tf
+++ b/byoc-nuon/src/components/rds_cluster_temporal/outputs.tf
@@ -25,3 +25,7 @@ output "db_instance_name" {
 output "db_instance_username" {
   value = module.db.db_instance_username
 }
+
+output "db_instance_availability_zone" {
+  value = module.db.db_instance_availability_zone
+}


### PR DESCRIPTION
this can be used to inform where karpenter nodepools should prefer to
stand up nodes
