### PR TITLE
chore: add new image for temporary hot patch

### DIFF
--- a/byoc-nuon/components/4-image-nuon_ctl_api.toml
+++ b/byoc-nuon/components/4-image-nuon_ctl_api.toml
@@ -3,6 +3,6 @@ type   = "container_image"
 
 [aws_ecr]
 image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/ctl-api"
-tag          = "0.19.596"
+tag          = "retool-prod-581-patch"
 region       = "us-west-2"
 iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"


### PR DESCRIPTION
This adds a new image that is a temporary patch on top of `v0.19.581`. This image includes a patch that allows us to 
export the stack outputs for an install, to replay the stack for a new reprovision. 
