### PR TITLE
chore: fix mapping of CI accounts

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,6 @@ defaults:
   run:
     shell: bash
 env:
-  NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN }}
   NUON_DEBUG: "${{ github.event.inputs.NUON_DEBUG }}"
 
 jobs:
@@ -31,15 +30,19 @@ jobs:
       - name: Install CLI
         id: cli
         run: ./scripts/install-cli.sh
+
       - name: Sync to org4f5hq4tyo44legra6r4nm18
         id: sync_to_org4f5hq4tyo44legra6r4nm18
         working-directory: byoc-nuon
         run: nuon apps sync .
         env:
           NUON_ORG_ID: org4f5hq4tyo44legra6r4nm18
+          NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN_org4f5hq4tyo44legra6r4nm18 }}
+
       - name: Sync to orggxqsc8f5zns1jra0oplc0ff
         id: sync_to_orggxqsc8f5zns1jra0oplc0ff
         working-directory: byoc-nuon
         run: nuon apps sync .
         env:
           NUON_ORG_ID: orggxqsc8f5zns1jra0oplc0ff
+          NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN_orggxqsc8f5zns1jra0oplc0ff }}


### PR DESCRIPTION
Fixing the CI mapping, so that each org has it's own API token.