### PR TITLE
chore: all workloads should run on nodes in private subnets

### DIFF
--- a/byoc-nuon/src/components/karpenter-nodepools/templates/nodeclass.tpl
+++ b/byoc-nuon/src/components/karpenter-nodepools/templates/nodeclass.tpl
@@ -15,6 +15,7 @@ spec:
   - tags:
       "{{ $.Values.karpenter.discovery_key }}": "{{ $.Values.karpenter.discovery_value }}"
       "kubernetes.io/cluster/{{$.Values.cluster_name}}": shared
+      "network.nuon.co/domain": internal # specific to nuon's public cloudformation template
   tags:
     "{{ $.Values.karpenter.discovery_key }}": "{{ $.Values.karpenter.discovery_value }}"
 {{- end }}


### PR DESCRIPTION
so we had to add a tag to let the node class know where to deploy them
