### PR TITLE
chore: move ctl-api-init-db into diff nodepool

### DIFF
--- a/byoc-nuon/src/components/ctl_api_init_db/templates/deployment.tpl
+++ b/byoc-nuon/src/components/ctl_api_init_db/templates/deployment.tpl
@@ -44,9 +44,9 @@ spec:
               path: grant_public.sql
       {{/* NodeSelection and Tolerations so this deployment runs on the ctl-api nodepool */}}
       nodeSelector:
-        pool.nuon.co: "ctl-api"
+        pool.nuon.co: "ctl-api-worker"
       tolerations:
         - key: "pool.nuon.co"
           operator: "Equal"
-          value: "ctl-api"
+          value: "ctl-api-worker"
           effect: "NoSchedule"


### PR DESCRIPTION
- **chore: allow destructive queries**
- **chore: allow ctl-api-init to run on any ctl-api nodepool**
