### PR TITLE
fix: increase cpu to prevent deadlocked temporal workflows

### DIFF
--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -130,10 +130,10 @@ worker:
       command: ["/bin/service", "worker", "--namespace=installs"]
       resources:
         limits:
-          cpu: 250m
+          cpu: 1000m
           memory: 512Mi
         requests:
-          cpu: 100m
+          cpu: 500m
           memory: 256Mi
     - namespace: releases
       minReplicas: 2


### PR DESCRIPTION
We are seeing some situations with workers that are underutilized, where a Nuon workflow can panic under the hood and
show no user message or error. The temporal workflow just disappears.

Increasing the CPU in cloud has fixed this issue there, so we are rolling this out to BYOC as well. Long term, we are 
investigating different mechanisms of deploying temporal workers to mitigate this.
