### PR TITLE
feat: add datadog tagging to components

### DIFF
--- a/byoc-nuon/components/99-tf-datadog.toml
+++ b/byoc-nuon/components/99-tf-datadog.toml
@@ -16,6 +16,8 @@ region                             = "{{ .nuon.install_stack.outputs.region }}"
 
 install_name = "{{ .nuon.install.name }}"
 install_id   = "{{ .nuon.install.id }}"
+org_id       = "{{ .nuon.org.id }}"
+org_name     = "{{ .nuon.org.name }}"
 
 datadog_api_key = "{{ .nuon.inputs.inputs.datadog_api_key }}"
 datadog_app_key = "{{ .nuon.inputs.inputs.datadog_app_key }}"

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -1,7 +1,6 @@
 ---
 env:
   ENV: byoc
-  METRICS_TAGS: "org_id:{{ .nuon.org.id }},org_name:{{ .nuon.org.name }}"
   LOG_LEVEL: INFO
   MIDDLEWARES: tracer,log,error,public_metrics,public,size,global,auth,org,offset_pagination,invites,headers,cors,config,patcher,panicker
   RUNNER_MIDDLEWARES: tracer,log,runner_metrics,error,public,size,auth,runner_org,offset_pagination,headers,cors,config,panicker

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -1,6 +1,7 @@
 ---
 env:
-  ENV: prod
+  ENV: byoc
+  METRICS_TAGS: "org_id:{{ .nuon.org.id }},org_name:{{ .nuon.org.name }}"
   LOG_LEVEL: INFO
   MIDDLEWARES: tracer,log,error,public_metrics,public,size,global,auth,org,offset_pagination,invites,headers,cors,config,patcher,panicker
   RUNNER_MIDDLEWARES: tracer,log,runner_metrics,error,public,size,auth,runner_org,offset_pagination,headers,cors,config,panicker

--- a/byoc-nuon/components/values/dashboard-ui.yaml
+++ b/byoc-nuon/components/values/dashboard-ui.yaml
@@ -8,6 +8,9 @@ image:
   tag: "{{ .nuon.components.img_nuon_dashboard_ui.outputs.image.tag }}"
 
 env:
+  ENV: byoc
+  METRICS_TAGS: "org_id:{{ .nuon.org.id }},org_name:{{ .nuon.org.name }}"
+
   NEXT_PUBLIC_API_URL: "https://api.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
 
   NEXT_PUBLIC_DATADOG_ENV: "byoc-nuon"
@@ -69,14 +72,14 @@ ui:
 
   alb:
     public_domain: "app.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
-    public_domain_certificate: "{{ .nuon.components.certificate_wildcard_public.outputs.public_domain_certificate_arn }}"
+    public_domain_certificate:
+      "{{ .nuon.components.certificate_wildcard_public.outputs.public_domain_certificate_arn }}"
 
   autoscaling:
     minReplicas: 2
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
-
 
 serviceAccount:
   name: dashboard-ui

--- a/byoc-nuon/src/components/ctl_api/templates/api_admin_alb.tpl
+++ b/byoc-nuon/src/components/ctl_api/templates/api_admin_alb.tpl
@@ -17,6 +17,7 @@ metadata:
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '2'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
     alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/tags: 'service=ctl-api,service_type=api,service_deployment=admin,env={{ .Values.env.ENV }}'
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.api.admin.domain }}
 spec:
   ingressClassName: alb

--- a/byoc-nuon/src/components/ctl_api/templates/api_admin_deployment.tpl
+++ b/byoc-nuon/src/components/ctl_api/templates/api_admin_deployment.tpl
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "common.apiLabels" . | nindent 4 }}
     app.nuon.co/name: {{ include "common.fullname" . }}-admin
+    tags.datadoghq.com/service: ctl-api
+    tags.datadoghq.com/service_type: api
+    tags.datadoghq.com/service_deployment: admin
 spec:
   selector:
     matchLabels:
@@ -17,6 +20,9 @@ spec:
       labels:
         {{- include "common.apiSelectorLabels" . | nindent 8 }}
         app.nuon.co/name: {{ include "common.fullname" . }}-admin
+        tags.datadoghq.com/service: ctl-api
+        tags.datadoghq.com/service_type: api
+        tags.datadoghq.com/service_deployment: admin
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: true
@@ -61,11 +67,11 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: {{ .Values.api.readiness_probe}}
+              path: {{ .Values.api.readiness_probe }}
               port: http-internal
           livenessProbe:
             httpGet:
-              path: {{ .Values.api.liveness_probe}}
+              path: {{ .Values.api.liveness_probe }}
               port: http-internal
           resources:
             limits:
@@ -93,6 +99,12 @@ spec:
               valueFrom:
                   fieldRef:
                       fieldPath: spec.nodeName
+            - name: DD_SERVICE
+              value: ctl-api
+            - name: SERVICE_TYPE
+              value: api
+            - name: SERVICE_DEPLOYMENT
+              value: admin
           lifecycle:
             preStop:
               exec:

--- a/byoc-nuon/src/components/ctl_api/templates/api_public_alb.tpl
+++ b/byoc-nuon/src/components/ctl_api/templates/api_public_alb.tpl
@@ -18,6 +18,7 @@ metadata:
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '2'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
     alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/tags: 'service=ctl-api,service_type=api,service_deployment=public,env={{ .Values.env.ENV }}'
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.api.public.domain }}
 spec:
   ingressClassName: alb

--- a/byoc-nuon/src/components/ctl_api/templates/api_public_deployment.tpl
+++ b/byoc-nuon/src/components/ctl_api/templates/api_public_deployment.tpl
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "common.apiLabels" . | nindent 4 }}
     app.nuon.co/name: {{ include "common.fullname" . }}-public
+    tags.datadoghq.com/service: ctl-api
+    tags.datadoghq.com/service_type: api
+    tags.datadoghq.com/service_deployment: public
 spec:
   selector:
     matchLabels:
@@ -17,6 +20,9 @@ spec:
       labels:
         {{- include "common.apiSelectorLabels" . | nindent 8 }}
         app.nuon.co/name: {{ include "common.fullname" . }}-public
+        tags.datadoghq.com/service: ctl-api
+        tags.datadoghq.com/service_type: api
+        tags.datadoghq.com/service_deployment: public
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: true
@@ -100,6 +106,12 @@ spec:
               valueFrom:
                   fieldRef:
                       fieldPath: spec.nodeName
+            - name: DD_SERVICE
+              value: ctl-api
+            - name: SERVICE_TYPE
+              value: api
+            - name: SERVICE_DEPLOYMENT
+              value: public
           lifecycle:
             preStop:
               exec:

--- a/byoc-nuon/src/components/ctl_api/templates/api_runner_alb.tpl
+++ b/byoc-nuon/src/components/ctl_api/templates/api_runner_alb.tpl
@@ -18,6 +18,7 @@ metadata:
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '2'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
     alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/tags: 'service=ctl-api,service_type=api,service_deployment=runner,env={{ .Values.env.ENV }}'
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.api.runner.domain }}
 spec:
   ingressClassName: alb

--- a/byoc-nuon/src/components/ctl_api/templates/api_runner_deployment.tpl
+++ b/byoc-nuon/src/components/ctl_api/templates/api_runner_deployment.tpl
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "common.apiLabels" . | nindent 4 }}
     app.nuon.co/name: {{ include "common.fullname" . }}-runner
+    tags.datadoghq.com/service: ctl-api
+    tags.datadoghq.com/service_type: api
+    tags.datadoghq.com/service_deployment: runner
 spec:
   selector:
     matchLabels:
@@ -17,6 +20,9 @@ spec:
       labels:
         {{- include "common.apiSelectorLabels" . | nindent 8 }}
         app.nuon.co/name: {{ include "common.fullname" . }}-runner
+        tags.datadoghq.com/service: ctl-api
+        tags.datadoghq.com/service_type: api
+        tags.datadoghq.com/service_deployment: runner
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: true
@@ -96,6 +102,12 @@ spec:
               valueFrom:
                   fieldRef:
                       fieldPath: spec.nodeName
+            - name: DD_SERVICE
+              value: ctl-api
+            - name: SERVICE_TYPE
+              value: api
+            - name: SERVICE_DEPLOYMENT
+              value: runner
           lifecycle:
             preStop:
               exec:

--- a/byoc-nuon/src/components/ctl_api/templates/deployment_startup.tpl
+++ b/byoc-nuon/src/components/ctl_api/templates/deployment_startup.tpl
@@ -7,6 +7,8 @@ metadata:
   labels:
     {{- include "common.apiLabels" . | nindent 4 }}
     app.nuon.co/name: {{ include "common.fullname" . }}-startup
+    tags.datadoghq.com/service: ctl-api
+    tags.datadoghq.com/service_type: startup
 spec:
   replicas: 1
   selector:
@@ -18,6 +20,8 @@ spec:
       labels:
         {{- include "common.apiSelectorLabels" . | nindent 8 }}
         app.nuon.co/name: {{ include "common.fullname" . }}-startup
+        tags.datadoghq.com/service: ctl-api
+        tags.datadoghq.com/service_type: startup
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: true
@@ -84,3 +88,7 @@ spec:
               valueFrom:
                   fieldRef:
                       fieldPath: spec.nodeName
+            - name: DD_SERVICE
+              value: ctl-api
+            - name: SERVICE_TYPE
+              value: startup

--- a/byoc-nuon/src/components/ctl_api/templates/lib/_config_map.tpl
+++ b/byoc-nuon/src/components/ctl_api/templates/lib/_config_map.tpl
@@ -4,4 +4,6 @@ ENV: {{ .Values.environment | quote }}
 CONTAINER_PLATFORM: "EKS"
 SERVICE_NAME: {{ .Chart.Name }}
 SERVICE_VERSION: {{ .Chart.Version }}
+DD_ENV: byoc
+DD_SERVICE: ctl-api
 {{- end -}}

--- a/byoc-nuon/src/components/ctl_api/templates/worker_deployments.tpl
+++ b/byoc-nuon/src/components/ctl_api/templates/worker_deployments.tpl
@@ -8,6 +8,10 @@ metadata:
   labels:
     {{- include "common.workerLabels" $ | nindent 4 }}
     app.nuon.co/worker-namespace: {{ .namespace }}
+    tags.datadoghq.com/service:  ctl-api
+    tags.datadoghq.com/service_type: worker
+    tags.datadoghq.com/service_deployment: {{ .namespace }}
+    tags.datadoghq.com/temporal_namespace: {{ .namespace }}
 spec:
   selector:
     matchLabels:
@@ -18,6 +22,10 @@ spec:
       labels:
         {{- include "common.workerSelectorLabels" $ | nindent 8 }}
         app.nuon.co/worker-namespace: {{ .namespace }}
+        tags.datadoghq.com/service:  ctl-api
+        tags.datadoghq.com/service_type: worker
+        tags.datadoghq.com/service_deployment: {{ .namespace }}
+        tags.datadoghq.com/temporal_namespace: {{ .namespace }}
     spec:
       serviceAccountName: {{ $.Values.serviceAccount.name }}
       automountServiceAccountToken: true
@@ -73,4 +81,13 @@ spec:
               valueFrom:
                   fieldRef:
                       fieldPath: spec.nodeName
+            - name: DD_SERVICE
+              value: ctl-api
+            - name: SERVICE_TYPE
+              value: worker
+            - name: SERVICE_DEPLOYMENT
+              value: {{ .namespace }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ .namespace }}
+
 {{- end }}

--- a/byoc-nuon/src/components/dashboard_ui/templates/alb.tpl
+++ b/byoc-nuon/src/components/dashboard_ui/templates/alb.tpl
@@ -17,6 +17,7 @@ metadata:
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '2'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
     alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/tags: 'service=dashboard-ui,service_type=ui,env={{ .Values.env.ENV }}'
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.ui.alb.public_domain }}
 spec:
   ingressClassName: alb

--- a/byoc-nuon/src/components/dashboard_ui/templates/deployment.tpl
+++ b/byoc-nuon/src/components/dashboard_ui/templates/deployment.tpl
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
+    tags.datadoghq.com/service: dashboard-ui
+    tags.datadoghq.com/service_type: ui
 spec:
   selector:
     matchLabels:
@@ -14,6 +16,8 @@ spec:
     metadata:
       labels:
         {{- include "common.selectorLabels" . | nindent 8 }}
+        tags.datadoghq.com/service: dashboard-ui
+        tags.datadoghq.com/service_type: ui
     spec:
       # start: NodePool Selection
       nodeSelector:
@@ -87,6 +91,10 @@ spec:
               valueFrom:
                   fieldRef:
                       fieldPath: spec.nodeName
+            - name: DD_SERVICE
+              value: dashboard-ui
+            - name: SERVICE_TYPE
+              value: ui
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/byoc-nuon/src/components/datadog/helm.tf
+++ b/byoc-nuon/src/components/datadog/helm.tf
@@ -19,8 +19,14 @@ resource "helm_release" "datadog" {
     file(local.datadog.value_file),
     yamlencode({
       datadog = {
-        apiKey      = var.datadog_api_key
-        tags        = ["env:byoc", "install.id:${var.install_id}", "install.name:${var.install_name}"]
+        apiKey = var.datadog_api_key
+        tags = [
+          "env:byoc",
+          "install.id:${var.install_id}",
+          "install.name:${var.install_name}",
+          "org.id:${var.org_id}",
+          "org.name:${var.org_name}",
+        ]
         clusterName = var.cluster_name
       }
     })

--- a/byoc-nuon/src/components/datadog/variables.tf
+++ b/byoc-nuon/src/components/datadog/variables.tf
@@ -24,6 +24,16 @@ variable "install_name" {
   description = "Install name"
 }
 
+variable "org_id" {
+  type        = string
+  description = "Organization ID"
+}
+
+variable "org_name" {
+  type        = string
+  description = "Organization Name"
+}
+
 # Cluster Info
 variable "region" {
   type        = string
@@ -44,4 +54,3 @@ variable "cluster_certificate_authority_data" {
   type        = string
   description = "AWS EKS Cluster CA Data"
 }
-


### PR DESCRIPTION
Here we make our metrics a bit more consistent. 

* Set env to `byoc`
* Add `service_type` and `service_deployment` tags
* Clean up `service` tag, so everything under `ctl-api` is grouped together
* Adds `org.id` and `org.name` tags so we can segment metrics per org more easily