### PR TITLE
chore: disable endpoint auditing middleware

### DIFF
--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -2,11 +2,10 @@
 env:
   ENV: byoc
   LOG_LEVEL: INFO
-  MIDDLEWARES: tracer,public_metrics,error,public,size,global,public_audit,auth,org,log,offset_pagination,invites,headers,cors,config,patcher,panicker
-  RUNNER_MIDDLEWARES: tracer,runner_metrics,error,size,public,runner_audit,auth,runner_org,log,offset_pagination,headers,cors,config,panicker
-  INTERNAL_MIDDLEWARES: tracer,internal_metrics,error,size,internal_audit,public,log,global,config,admin,offset_pagination,cors,config,panicker
+  MIDDLEWARES: tracer,public_metrics,error,public,size,global,auth,org,log,offset_pagination,invites,headers,cors,config,patcher,panicker
+  RUNNER_MIDDLEWARES: tracer,runner_metrics,error,size,public,auth,runner_org,log,offset_pagination,headers,cors,config,panicker
+  INTERNAL_MIDDLEWARES: tracer,internal_metrics,error,size,public,log,global,config,admin,offset_pagination,cors,config,panicker
   GIN_MODE: "release"
-  ENABLE_ENDPOINT_AUDITING: "true"
 
   DB_HOST: "{{ .nuon.components.rds_cluster_nuon.outputs.address }}"
   DB_NAME: "ctl_api"      # hardcoded, for now - also, main db not the desired db we created


### PR DESCRIPTION
This is db write intensive. We only need this in lower environments.