### PR TITLE
chore: disable ui metrics for now

### DIFF
--- a/byoc-nuon/src/components/dashboard_ui/templates/deployment.tpl
+++ b/byoc-nuon/src/components/dashboard_ui/templates/deployment.tpl
@@ -96,6 +96,8 @@ spec:
               value: ui
             - name: SERVICE_DEPLOYMENT
               value: dashboard
+            - name: DISABLE_METRICS
+              value: "true"
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
The endpoint metric tag is spiking cardinality in the byoc environments due to pentests/scanning. 

Disabling this in the byoc environments so we can test our route matching in the cloud environments. 