### PR TITLE
chore: remove port from admin url

### DIFF
--- a/byoc-nuon/actions/ctl_api_create_or_refresh_sa_token.toml
+++ b/byoc-nuon/actions/ctl_api_create_or_refresh_sa_token.toml
@@ -15,6 +15,6 @@ directory = "byoc-nuon/src/actions"
 branch    = "main"
 
 [steps.env_vars]
-ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}:8082"
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
 ORG_ID        = ""
 REFRESH       = "false"

--- a/byoc-nuon/actions/runners_reprovision.toml
+++ b/byoc-nuon/actions/runners_reprovision.toml
@@ -32,4 +32,4 @@ done
 """
 
 [steps.env_vars]
-ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}:8082"
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"

--- a/byoc-nuon/actions/runners_restart.toml
+++ b/byoc-nuon/actions/runners_restart.toml
@@ -30,4 +30,4 @@ done
 """
 
 [steps.env_vars]
-ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}:8082"
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"


### PR DESCRIPTION
we moved to an alb a while back so this is no longer necessary
