### PR TITLE
chore: use region from install stack

### DIFF
--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -184,8 +184,8 @@ worker:
       - t3a.xlarge
   zones:
     # TODO: Template / load this dynamically
-    - us-west-2a
-    - us-west-2b
+    - {{.nuon.install_stack.outputs.region}}a
+    - {{.nuon.install_stack.outputs.region}}b
 
 api:
   liveness_probe: /livez

--- a/byoc-nuon/components/values/karpenter-nodepools.yaml
+++ b/byoc-nuon/components/values/karpenter-nodepools.yaml
@@ -97,7 +97,7 @@ nodepools:
       consolidationPolicy: "WhenEmptyOrUnderutilized"
       consolidateAfter: "30s"
     zones:
-      - us-west-2a
+      - {{.nuon.install_stack.outputs.region}}a
 
   - name: public
     instance_types:


### PR DESCRIPTION
the values files should use the region provided by the install stack
