### PR TITLE
feat: test gcp support

### DIFF
--- a/byoc-nuon/components/4-image-nuon_ctl_api.toml
+++ b/byoc-nuon/components/4-image-nuon_ctl_api.toml
@@ -3,6 +3,6 @@ type = "container_image"
 
 [aws_ecr]
 image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/ctl-api"
-tag          = "0.19.800"
+tag          = "d46ce82"
 region       = "us-west-2"
 iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"

--- a/byoc-nuon/components/4-image-nuon_dashboard_ui.toml
+++ b/byoc-nuon/components/4-image-nuon_dashboard_ui.toml
@@ -3,6 +3,6 @@ type = "container_image"
 
 [aws_ecr]
 image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/dashboard-ui"
-tag          = "0.19.800"
+tag          = "d46ce82"
 region       = "us-west-2"
 iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -52,7 +52,7 @@ env:
   INTERNAL_HTTP_PORT: !!string 8082
   RUNNER_HTTP_PORT: !!string 8083
   GRACEFUL_SHUTDOWN_TIMEOUT: 10s
-  RUNNER_CONTAINER_IMAGE_TAG: "0.19.800"
+  RUNNER_CONTAINER_IMAGE_TAG: "d46ce82"
   RUNNER_CONTAINER_IMAGE_URL: "{{ .nuon.inputs.inputs.runner_image_url }}"
 
   GITHUB_APP_ID: !!string {{ .nuon.inputs.inputs.github_app_id }}


### PR DESCRIPTION
This PR configures the BYOC app config to use a temporary tag with GCP support, for ctl-api, dashboard-ui, and the runner.