### PR TITLE
chore: components should use the new chart repo

### DIFF
--- a/byoc-nuon/components/92-helm-ctl_api.toml
+++ b/byoc-nuon/components/92-helm-ctl_api.toml
@@ -1,4 +1,4 @@
-#:schema https://api.nuon.co/v1/general/config-schema?type=helm
+# helm
 name           = "ctl_api"
 type           = "helm_chart"
 chart_name     = "ctl-api"
@@ -7,8 +7,8 @@ storage_driver = "configmap"
 dependencies   = ["rds_cluster_nuon", "karpenter_nodepools", "clickhouse_cluster", "temporal", "management", "ctl_api_init_db"]
 
 [public_repo]
-repo      = "nuonco/byoc"
-directory = "shared/src/components/ctl_api"
+repo      = "nuonco/charts"
+directory = "charts/ctl-api"
 branch    = "main"
 
 [[values_file]]

--- a/byoc-nuon/components/93-helm-dashboard_ui.toml
+++ b/byoc-nuon/components/93-helm-dashboard_ui.toml
@@ -1,4 +1,4 @@
-#:schema https://api.nuon.co/v1/general/config-schema?type=helm
+# helm
 name           = "dashboard_ui"
 type           = "helm_chart"
 chart_name     = "dashboard-ui"
@@ -8,8 +8,8 @@ storage_driver = "configmap"
 dependencies = ["ctl_api"]
 
 [public_repo]
-repo      = "nuonco/byoc"
-directory = "shared/src/components/dashboard_ui"
+repo      = "nuonco/charts"
+directory = "charts/dashboard-ui"
 branch    = "main"
 
 [[values_file]]


### PR DESCRIPTION
### Description

Let's let this bake for a bit but after it's merged we can remove the helm for ctl-api and dashboard-ui from this repo, at least for AWS.
