### PR TITLE
chore: swap runner auth to use iid

### DIFF
--- a/byoc-nuon/runner.toml
+++ b/byoc-nuon/runner.toml
@@ -2,3 +2,6 @@
 runner_type     = "aws"
 helm_driver     = "configmap"
 init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init-mng.sh"
+
+[env_vars]
+RUNNER_AUTH_METHOD    = "iid"

--- a/byoc-nuon/stack.toml
+++ b/byoc-nuon/stack.toml
@@ -4,4 +4,4 @@ description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.instal
 
 # nested stack
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.1.12/vpc/eks/default/stack.yaml"
-runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.1.12/runner/asg/stack.yaml"
+runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/runner/asg/stack.yaml"


### PR DESCRIPTION
Swaps from our STS based auth to IID. This should alleviate some GuardDuty alerts. 