### PR TITLE
feat: runner repository

### DIFF
--- a/byoc-nuon/components/0-tf-runner-repository.toml
+++ b/byoc-nuon/components/0-tf-runner-repository.toml
@@ -1,0 +1,17 @@
+# terraform
+name              = "runner_repository"
+type              = "terraform_module"
+terraform_version = "1.11.3"
+
+[public_repo]
+repo      = "nuonco/byoc"
+directory = "byoc-nuon/src/components/runner-repository"
+branch    = "main"
+
+[vars]
+install_id = "{{ .nuon.install.id }}"
+org_id     = "{{ .nuon.org.id }}"
+region     = "{{ .nuon.install_stack.outputs.region }}"
+
+[[var_file]]
+contents = "./values/runner-repository.tfvars"

--- a/byoc-nuon/components/values/runner-repository.tfvars
+++ b/byoc-nuon/components/values/runner-repository.tfvars
@@ -1,0 +1,6 @@
+# passthrough from the sandbox; the public runner repo lives alongside the
+# private app ecr provisioned by the sandbox.
+ecr = {
+  id  = "{{ .nuon.sandbox.outputs.ecr.registry_id }}"
+  arn = "{{ .nuon.sandbox.outputs.ecr.repository_arn }}"
+}

--- a/byoc-nuon/permissions/maintenance_boundary.json
+++ b/byoc-nuon/permissions/maintenance_boundary.json
@@ -10,6 +10,7 @@
         "cloudwatch:*",
         "ec2:*",
         "ecr:*",
+        "ecr-public:*",
         "eks:*",
         "iam:*",
         "kms:*",
@@ -17,7 +18,8 @@
         "rds:*",
         "s3:*",
         "secretsmanager:*",
-        "sqs:*"
+        "sqs:*",
+        "sts:GetServiceBearerToken"
       ],
       "Resource": "*"
     },

--- a/byoc-nuon/src/components/runner-repository/outputs.tf
+++ b/byoc-nuon/src/components/runner-repository/outputs.tf
@@ -1,0 +1,13 @@
+output "runner_repository" {
+  value = {
+    name           = aws_ecrpublic_repository.runner.repository_name
+    arn            = aws_ecrpublic_repository.runner.arn
+    registry_id    = aws_ecrpublic_repository.runner.registry_id
+    repository_uri = aws_ecrpublic_repository.runner.repository_uri
+  }
+}
+
+# convenience: the image url to feed into `runner_image_url`-style inputs
+output "runner_image_url" {
+  value = aws_ecrpublic_repository.runner.repository_uri
+}

--- a/byoc-nuon/src/components/runner-repository/providers.tf
+++ b/byoc-nuon/src/components/runner-repository/providers.tf
@@ -1,0 +1,26 @@
+locals {
+  tags = {
+    "install.nuon.co/id"     = var.install_id
+    "org.nuon.co/id"         = var.org_id
+    "component.nuon.co/name" = "runner-repository"
+    "tier.nuon.co"           = "infra"
+  }
+}
+
+# default provider is the install region. ECR Public is global but the
+# api endpoint is only served from us-east-1, so we use a dedicated alias.
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = local.tags
+  }
+}
+
+# ECR Public api lives only in us-east-1
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+  default_tags {
+    tags = local.tags
+  }
+}

--- a/byoc-nuon/src/components/runner-repository/repository.tf
+++ b/byoc-nuon/src/components/runner-repository/repository.tf
@@ -1,0 +1,21 @@
+#
+# Public ECR repository that hosts the Nuon runner image for this install.
+#
+# - Public: anyone can pull
+# - Single project: the runner only
+# - Tags are semvers (no lifecycle rules trimming images here; semver tags are
+#   immutable in spirit and we keep all historical versions)
+#
+resource "aws_ecrpublic_repository" "runner" {
+  provider = aws.us_east_1
+
+  repository_name = "runner"
+
+  catalog_data {
+    about_text        = "Nuon BYOC runner image. Tags are semver releases of the runner."
+    architectures     = ["x86-64", "ARM 64"]
+    description       = "Nuon BYOC runner"
+    operating_systems = ["Linux"]
+    usage_text        = "Pull a specific semver tag, e.g. `vX.Y.Z`. The `latest` tag is not maintained."
+  }
+}

--- a/byoc-nuon/src/components/runner-repository/variables.tf
+++ b/byoc-nuon/src/components/runner-repository/variables.tf
@@ -1,0 +1,20 @@
+variable "install_id" {
+  type = string
+}
+
+variable "org_id" {
+  type = string
+}
+
+variable "region" {
+  type        = string
+  description = "The install region. ECR Public itself is provisioned in us-east-1, but the install region is used for tagging and consistency with the rest of the install."
+}
+
+variable "ecr" {
+  type = object({
+    id  = string
+    arn = string
+  })
+  description = "The private app ECR details passed through from the sandbox. Not used for the public runner repo, but kept for parity with the management component and to make the relationship explicit."
+}

--- a/byoc-nuon/src/components/runner-repository/versions.tf
+++ b/byoc-nuon/src/components/runner-repository/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.94.1"
+    }
+  }
+}


### PR DESCRIPTION
### Description

Adds a new component `runner-repository` that creates a public ecr repository. 

### TODO
- [x] modify the runner image container to include the `oras` binary (https://github.com/nuonco/nuon/pull/1185)

### Details

There will now be a new public ecr registry for the runner images in us-east-1. We are introducing a new action that uses the `oras-cli` to import images from the nuon public ecr registry into this one. 

### In a future PR
- [ ] add an action that uses the `oras` binary to copy runner images into this registry. 

we split this up so we can land this component on its own first. 