### PR TITLE
chore(byoc-nuon): use m3 instead of t3a on aws

### DIFF
--- a/byoc-nuon/sandbox.toml
+++ b/byoc-nuon/sandbox.toml
@@ -16,5 +16,7 @@ internal_root_domain = "internal.{{ .nuon.inputs.inputs.root_domain }}"
 
 karpenter_version = "1.7.4"
 
+default_instance_type = "m3.medium"
+
 [[var_file]]
 contents = "./sandbox.tfvars"


### PR DESCRIPTION
we see some issues with t3a on busy deployments so we're switching this
out. `coredns` may be running hot and the burstables aren't helping.
