### PR TITLE
fix: nuon-byoc README handles error response from runners action

### DIFF
--- a/byoc-nuon/README.md
+++ b/byoc-nuon/README.md
@@ -354,7 +354,7 @@ Secrets can be updated by re-provisioning the stack and updating the secret valu
 <summary><strong>Runners</strong></summary>
 
 {{ with .nuon.actions.workflows.runners }}
-{{ if .populated }}
+{{ if and .populated (eq .status "finished") }}
 {{ $runnerSettings := .outputs.steps.settings }}
 
 <nuon-tabs>                                                                                                                                


### PR DESCRIPTION
## Problem

When the runners action fails due to auth or network issues, `.populated` in the runners section in the README will be `true`. This causes the README to try to render the runners action data and fail.

## Solution

We need to also check that `.status` is not `error`, to ensure, not only that the runners action completed, but that it returned data we can use.