### PR TITLE
fix: runners scripts handles large amount of runners

### DIFF
--- a/byoc-nuon/README.md
+++ b/byoc-nuon/README.md
@@ -439,7 +439,6 @@ Secrets can be updated by re-provisioning the stack and updating the secret valu
   <li><strong>Sentry:</strong> {{dig "enable_sentry" "" $runner.settings}}</li>                                                              
   <li><strong>Metrics:</strong> {{dig "enable_metrics" "" $runner.settings}}</li>
   <li><strong>Heartbeat Timeout:</strong> {{dig "heart_beat_timeout" "" $runner.settings}}</li>                                              
-  <li><strong>Groups:</strong> {{dig "groups" "" $runner.settings}}</li>       
   <li><strong>Runner API URL:</strong> {{dig "runner_api_url" "" $runner.settings}}</li>                                                     
   <li><strong>Runner Group ID:</strong> <code>{{dig "runner_group_id" "" $runner.settings}}</code></li>
   <li><strong>Created:</strong> {{dig "created_at" "" $runner.settings}}</li>                                                                

--- a/byoc-nuon/actions/src/runners/admin-get.sh
+++ b/byoc-nuon/actions/src/runners/admin-get.sh
@@ -14,4 +14,4 @@ url="$admin_api_addr/v1/runners?type=$type&limit=100"
 curl --max-time 5 -q -s $url    \
   -H 'accept: application/json' \
   -H 'X-Nuon-Admin-Email: jon@nuon.co' \
-  | jq -c 'map({(.id): .}) | add // {}' >> $NUON_ACTIONS_OUTPUT_FILEPATH
+  | jq -c '.[] | {(.id): .}' >> $NUON_ACTIONS_OUTPUT_FILEPATH

--- a/byoc-nuon/actions/src/runners/settings.sh
+++ b/byoc-nuon/actions/src/runners/settings.sh
@@ -6,9 +6,6 @@ set -u
 
 admin_api_addr="$ADMIN_API_URL"
 
-# prepare outputs
-OUTPUTS='{}'
-
 # get org runners
 org_runners=$(curl --max-time 5 -q -s \
   "$admin_api_addr/v1/runners?type=org&limit=100" \
@@ -24,6 +21,8 @@ install_runners=$(curl --max-time 5 -q -s \
 # merge into single list
 runners=$(echo "$org_runners" "$install_runners" | jq -s 'add')
 
+# emit one JSON object per runner — keeps each output line well under
+# the runner's bufio.Scanner token limit even with many/large settings.
 for runner_id in $(echo "$runners" | jq -r '.[].id'); do
   org_id=$(echo "$runners" | jq -r --arg id "$runner_id" '.[] | select(.id == $id) | .org_id')
   settings=$(curl --max-time 5 -q -s \
@@ -31,8 +30,33 @@ for runner_id in $(echo "$runners" | jq -r '.[].id'); do
     -H 'accept: application/json' \
     -H 'X-Nuon-Admin-Email: jon@nuon.co')
 
-  OUTPUTS=$(echo "$OUTPUTS" | jq -c --arg id "$runner_id" --arg org "$org_id" --argjson settings "$settings" \
-    '. + {($id): {org_id: $org, type: ($settings.metadata["runner.type"] // "unknown"), settings: $settings}}')
+  # project only the fields the README renders — keeps each line well under
+  # the runner's bufio.Scanner token limit regardless of how large the full
+  # settings doc (metadata, groups, etc.) grows.
+  jq -nc --arg id "$runner_id" --arg org "$org_id" --argjson settings "$settings" \
+    '{($id): {
+       org_id: $org,
+       type: ($settings.metadata["runner.type"] // "unknown"),
+       settings: {
+         container_image_url:       $settings.container_image_url,
+         container_image_tag:       $settings.container_image_tag,
+         aws_instance_type:         $settings.aws_instance_type,
+         aws_max_instance_lifetime: $settings.aws_max_instance_lifetime,
+         enable_logging:            $settings.enable_logging,
+         logging_level:             $settings.logging_level,
+         enable_sentry:             $settings.enable_sentry,
+         enable_metrics:            $settings.enable_metrics,
+         heart_beat_timeout:        $settings.heart_beat_timeout,
+         runner_api_url:            $settings.runner_api_url,
+         runner_group_id:           $settings.runner_group_id,
+         created_at:                $settings.created_at,
+         updated_at:                $settings.updated_at,
+         metadata: {
+           "org.name":       ($settings.metadata["org.name"]       // "unknown"),
+           "runner.platform":($settings.metadata["runner.platform"]// "unknown"),
+           "runner.type":    ($settings.metadata["runner.type"]    // "unknown")
+         }
+       }
+     }}' \
+    >> $NUON_ACTIONS_OUTPUT_FILEPATH
 done
-
-echo "$OUTPUTS" >> $NUON_ACTIONS_OUTPUT_FILEPATH


### PR DESCRIPTION
## Problem

In the "settings" step of the "runners" action, it was trying to save the settings for all runners at once in an env var. This was too much data at once and caused the step to fail, leaving the runners section in the README empty.

## Solution

This PR updates the settings step to write each runner's settings one at a time to the action's output file.