### PR TITLE
fix: update runners section in README to use status_v2

### DIFF
--- a/byoc-nuon/README.md
+++ b/byoc-nuon/README.md
@@ -376,7 +376,8 @@ Secrets can be updated by re-provisioning the stack and updating the secret valu
       {{range $id, $runner := .}}                                                                                                            
           {{ $settings := dig $id "settings" nil $runnerSettings }}
           <tr>                                                                                                                               
-              <td>{{if eq $runner.status "active"}}🟢{{else if eq $runner.status "error"}}🔴{{else}}🟡{{end}}</td>
+              {{ $status := dig "status_v2" "status" "" $runner }}
+              <td>{{if eq $status "active"}}🟢{{else if eq $status "error"}}🔴{{else}}🟡{{end}}</td>
               <td><code>{{$runner.id}}</code></td>                                                                                           
               <td><code>{{$runner.org_id}}</code></td>
               <td><code>{{if $settings}}{{dig "container_image_tag" "" $settings}}{{end}}</code></td>                                        
@@ -407,7 +408,8 @@ Secrets can be updated by re-provisioning the stack and updating the secret valu
       {{range $id, $runner := .}}
           {{ $settings := dig $id "settings" nil $runnerSettings }}
           <tr>                                                                                                                               
-              <td>{{if eq $runner.status "active"}}🟢{{else if eq $runner.status "error"}}🔴{{else}}🟡{{end}}</td>
+              {{ $status := dig "status_v2" "status" "" $runner }}
+              <td>{{if eq $status "active"}}🟢{{else if eq $status "error"}}🔴{{else}}🟡{{end}}</td>
               <td><code>{{$runner.id}}</code></td>                                                                                           
               <td><code>{{$runner.org_id}}</code></td>                                                                                       
               <td><code>{{if $settings}}{{dig "container_image_tag" "" $settings}}{{end}}</code></td>


### PR DESCRIPTION
## Problem

Noticed that we hadn't yet updated the Nuon BYOC README to use the new status object. This PR updates it