### PR TITLE
chore(aws): use the install's runner repository

### DIFF
--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -57,7 +57,7 @@ env:
   RUNNER_HTTP_PORT: !!string 8083
   GRACEFUL_SHUTDOWN_TIMEOUT: 10s
   RUNNER_CONTAINER_IMAGE_TAG: "0.19.943"
-  RUNNER_CONTAINER_IMAGE_URL: "{{ .nuon.inputs.inputs.runner_image_url }}"
+  RUNNER_CONTAINER_IMAGE_URL: "{{ .nuon.components.runner_repository.outputs.runner_repository.repository_uri }}"
 
   GITHUB_APP_ID: !!string {{ .nuon.inputs.inputs.github_app_id }}
 

--- a/byoc-nuon/inputs/nuon/runner-image-url.toml
+++ b/byoc-nuon/inputs/nuon/runner-image-url.toml
@@ -1,6 +1,0 @@
-name         = "runner_image_url"
-description  = "The image url for the new runners"
-default      = "public.ecr.aws/p7e3r5y0/runner"
-display_name = "Runner Image URL"
-group        = "nuon"
-required     = true

--- a/shared/actions/src/runners/update-version.sh
+++ b/shared/actions/src/runners/update-version.sh
@@ -15,6 +15,11 @@ RUNNER_CONTAINER_IMAGE_TAG=$(kubectl get -n ctl-api configmaps ctl-api -o yaml |
   cut -d ':' -f 2 |\
   sed 's/ //g')
 
+RUNNER_CONTAINER_IMAGE_URL=$(kubectl get -n ctl-api configmaps ctl-api -o yaml |\
+  grep RUNNER_CONTAINER_IMAGE_URL |\
+  cut -d ':' -f 2 |\
+  sed 's/ //g')
+
 # update_runners iterates a list of runner ids and PATCHes each runner's
 # settings to the current RUNNER_CONTAINER_IMAGE_TAG. Per-runner-type results
 # accumulate into RESPONSE_COUNTS.[$type_key] as {<http_code>: N, errors: [..]}.
@@ -35,7 +40,7 @@ update_runners() {
     curl_rc=0
     http_code=$(curl -s --max-time 10 -X PATCH "$url" \
       -H "Content-Type: application/json" \
-      -d "{\"container_image_tag\": \"$RUNNER_CONTAINER_IMAGE_TAG\", \"binary_version\": \"$RUNNER_CONTAINER_IMAGE_TAG\"}" \
+      -d "{\"container_image_tag\": \"$RUNNER_CONTAINER_IMAGE_TAG\", \"binary_version\": \"$RUNNER_CONTAINER_IMAGE_TAG\", \"container_image_url\":\"$RUNNER_CONTAINER_IMAGE_URL\"}" \
       -w "\n%{http_code}" \
       -o /tmp/response_body.json) || curl_rc=$?
 


### PR DESCRIPTION
### Description

Use the Runner Repository that corresponds to the install instead of using the default public ECR. 

### Note

- Do not merge until after https://github.com/nuonco/byoc/pull/572. 
- We can get rid of the `inputs.runner_image_url` input in AWS and use the nuon public reg as a fallback if desired or in its place. but the public registry is only relevent as the source from which we copy the images. 
- The action is shared so we need to test some things first before we accept this action change. 
