### PR TITLE
feat: temporal status in AWS README

### DIFF
--- a/byoc-nuon/README.md
+++ b/byoc-nuon/README.md
@@ -33,7 +33,7 @@ $public_domain }}/docs/index.html)</small>
         <tbody>
         {{ if .nuon.actions.populated }}
             {{range $name, $action := .nuon.actions.workflows}}
-                {{if contains "healthcheck" $name}}
+                {{if and (contains "healthcheck" $name) (ne $name "healthcheck_temporal")}}
                     <tr>
                         <td style="width: 1rem">
                         {{with $action.status}}
@@ -57,6 +57,39 @@ $public_domain }}/docs/index.html)</small>
     </table>
 
 </div>
+
+{{ with index .nuon.actions.workflows "temporal_status" }}
+{{ $data := .outputs }}
+<details>
+<summary><nuon-group gap="8" align="center" justify="start"><strong>Temporal Status</strong>{{ with index $.nuon.actions.workflows "healthcheck_temporal" }}{{ if eq .status "error" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else if eq .status "finished" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}{{ end }}</nuon-group></summary>
+
+<nuon-tabs>
+{{ range (dig "namespace_names" (list) $data) }}
+{{ $ns := . }}
+{{ $count := index $data (printf "ns_%s_count" $ns) | default 0 | int }}
+{{ $total := 0 }}{{ $running := 0 }}{{ $failed := 0 }}{{ $completed := 0 }}{{ $other := 0 }}
+{{ range $i, $_ := until $count }}{{ $chunk := index $data (printf "ns_%s_chunk_%d" $ns $i) }}{{ range $chunk }}{{ $total = add $total 1 }}{{ if eq .status "running" }}{{ $running = add $running 1 }}{{ else if or (eq .status "failed") (eq .status "terminated") (eq .status "timedout") }}{{ $failed = add $failed 1 }}{{ else if eq .status "completed" }}{{ $completed = add $completed 1 }}{{ else }}{{ $other = add $other 1 }}{{ end }}{{ end }}{{ end }}
+<nuon-tab name="{{ $ns }}">
+
+<div style="padding-top: 1rem;"><nuon-group gap="8" align="center" justify="start">
+<nuon-label-badge label="total:{{ $total }}"></nuon-label-badge>
+{{ if gt $running 0 }}<nuon-label-badge label="running:{{ $running }}" theme="success"></nuon-label-badge>{{ end }}
+{{ if gt $failed 0 }}<nuon-label-badge label="failed:{{ $failed }}" theme="error"></nuon-label-badge>{{ end }}
+{{ if gt $completed 0 }}<nuon-label-badge label="completed:{{ $completed }}"></nuon-label-badge>{{ end }}
+{{ if gt $other 0 }}<nuon-label-badge label="other:{{ $other }}" theme="warn"></nuon-label-badge>{{ end }}
+</nuon-group></div>
+
+| Status | Workflow ID | Workflow Type | Started |
+|---|---|---|---|
+{{ range $i, $_ := until $count }}{{ $chunk := index $data (printf "ns_%s_chunk_%d" $ns $i) }}{{ range $chunk }}| {{ if eq .status "running" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if or (eq .status "failed") (eq .status "terminated") (eq .status "timedout") }}<nuon-status status="error" variant="badge"></nuon-status>{{ else if eq .status "completed" }}<nuon-status status="inactive" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }} | {{ .workflow_id }} | {{ .workflow_type }} | {{ date "Jan 2, 2006 15:04 UTC" (toDate "2006-01-02T15:04:05.999999999Z07:00" .start_time) }} |
+{{ end }}{{ end }}
+
+</nuon-tab>
+{{ end }}
+</nuon-tabs>
+
+</details>
+{{ end }}
 
 
 <details>

--- a/byoc-nuon/actions/src/temporal/fetch_status.sh
+++ b/byoc-nuon/actions/src/temporal/fetch_status.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Lists active Temporal workflows per namespace and writes a trimmed
+# JSON summary to the action outputs. Consumed by the "Temporal Status"
+# section in README.md.
+
+set -e
+set -o pipefail
+set -u
+
+# Namespaces mirror temporalWorkerNamespaces in ctl-api:
+# internal/app/admin-dashboard/service/temporal_workers.go.
+namespaces=(
+  general
+  installs
+  runners
+  orgs
+  components
+  apps
+  actions
+  vcs
+  onboardings
+)
+
+kubectl config set-context --current --namespace=temporal >/dev/null
+pod=$(kubectl get pods -l app.kubernetes.io/component=admintools \
+  -o custom-columns=NAME:.metadata.name --no-headers | head -n1)
+
+list_workflows() {
+  local ns="$1"
+  kubectl exec -i "$pod" -- temporal workflow list \
+    --namespace "$ns" \
+    --query "ExecutionStatus='Running'" \
+    --limit 0 \
+    --output json
+}
+
+# The runner parses outputs line-by-line (bufio.Scanner, ~64 KB per line) and
+# merges all lines into one map. Emit small JSON objects, one per line:
+# - {"generated_at": "..."}
+# - {"namespace_names": [...]}
+# - per namespace: {"ns_<n>_count": N} plus N chunks {"ns_<n>_chunk_<i>": [...wfs...]}
+# Chunking keeps any single line well under the scanner limit even when a
+# namespace has thousands of running workflows.
+
+chunk_size=100
+
+generated_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+jq -cn --arg t "$generated_at" '{ generated_at: $t }' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+printf '%s\n' "${namespaces[@]}" \
+  | jq -cR --slurp 'split("\n") | map(select(length > 0)) | { namespace_names: . }' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+for ns in "${namespaces[@]}"; do
+  echo >&2 "listing workflows for namespace=${ns}..."
+  raw=$(list_workflows "$ns" 2>/dev/null || echo '[]')
+
+  trimmed=$(echo "$raw" | jq -c '
+    map({
+      workflow_id:   .execution.workflowId,
+      workflow_type: .type.name,
+      status:        (.status | ascii_downcase | sub("^workflow_execution_status_"; "")),
+      start_time:    .startTime,
+    })
+  ')
+
+  total=$(echo "$trimmed" | jq 'length')
+  chunks=$(( (total + chunk_size - 1) / chunk_size ))
+  [ "$chunks" -eq 0 ] && chunks=0
+
+  jq -cn --arg ns "$ns" --argjson c "$chunks" \
+    '{ ("ns_" + $ns + "_count"): $c }' \
+    >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+  i=0
+  while [ "$i" -lt "$chunks" ]; do
+    echo "$trimmed" | jq -c --arg ns "$ns" --argjson i "$i" --argjson cs "$chunk_size" '
+      { ("ns_" + $ns + "_chunk_" + ($i | tostring)): .[($i * $cs):(($i + 1) * $cs)] }
+    ' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+    i=$((i + 1))
+  done
+done
+echo >&2 "wrote temporal status outputs"

--- a/byoc-nuon/actions/temporal_status.toml
+++ b/byoc-nuon/actions/temporal_status.toml
@@ -1,0 +1,16 @@
+# action
+# description: lists active Temporal workflows per namespace for the
+# "Temporal Status" README section.
+name    = "temporal_status"
+timeout = "5m"
+
+[[triggers]]
+type          = "cron"
+cron_schedule = "0 * * * *"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "fetch temporal status"
+inline_contents = "./src/temporal/fetch_status.sh"

--- a/shared/actions/healthcheck_temporal.toml
+++ b/shared/actions/healthcheck_temporal.toml
@@ -1,5 +1,5 @@
 # action
-# description: checks Temporal cluster health every 15 minutes via tctl.
+# description: checks Temporal cluster health every 15 minutes.
 name    = "healthcheck_temporal"
 timeout = "30s"
 
@@ -11,7 +11,7 @@ cron_schedule = "*/15 */1 * * *"
 type = "manual"
 
 [[steps]]
-name    = "tctl cluster health"
+name    = "temporal cluster health"
 inline_contents = """
 #!/usr/bin/env sh
 
@@ -22,7 +22,7 @@ set -u
 echo >&2 "checking temporal cluster health..."
 kubectl config set-context --current --namespace=temporal
 POD_NAME=$(kubectl get pods -l app.kubernetes.io/component=admintools -o custom-columns=NAME:.metadata.name --no-headers)
-STATUS=$(kubectl exec -i $POD_NAME -- tctl cluster health)
+STATUS=$(kubectl exec -i $POD_NAME -- temporal operator cluster health)
 
 # determine status
 if [[ "$STATUS" == *"SERVING"* ]]; then


### PR DESCRIPTION
## Problem

We need it to be easier to inspect the status of the Temporal workflows for a Nuon BYOC install.

## Solution

Add an action to fetch temporal workflow info, and display that info the README.