### PR TITLE
chore: update ctl-api values for new chart version

### DIFF
--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -144,6 +144,13 @@ worker:
       operator: "Equal"
       value: ctl-api-worker
       effect: "NoSchedule"
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: "topology.kubernetes.io/zone"
+      whenUnsatisfiable: DoNotSchedule
+    - maxSkew: 2
+      topologyKey: "kubernetes.io/hostname"
+      whenUnsatisfiable: ScheduleAnyway
   instances:
     - namespace: orgs
       minReplicas: 2
@@ -264,6 +271,14 @@ api:
       operator: "Equal"
       value: "public"
       effect: "NoSchedule"
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: "topology.kubernetes.io/zone"
+      whenUnsatisfiable: ScheduleAnyway
+    - maxSkew: 2
+      minDomains: 3
+      topologyKey: "kubernetes.io/hostname"
+      whenUnsatisfiable: DoNotSchedule
   liveness_probe: /livez
   readiness_probe: /readyz
 


### PR DESCRIPTION
### Description

The upstream ctl-api chart is being refactored for more flexible `topologySpreadConstraints`. This PR updates the `values/ctl-api.yaml` file to match the new format.