### PR TITLE
chore(aws): configure vpc-cni addon in sandbox

### DIFF
--- a/byoc-nuon/sandbox.tfvars
+++ b/byoc-nuon/sandbox.tfvars
@@ -19,3 +19,39 @@ additional_namespaces = [
   "ctl-api",
   "dashboard-ui",
 ]
+
+cluster_addons = {
+  coredns = {
+    configuration_values = {
+      tolerations = [
+        # Allows CoreDNS to run on the same nodes as the Karpenter controller
+        # for use during cluster creation when Karpenter nodes do not yet exist
+        #
+        {
+          key    = "karpenter.sh/controller"
+          value  = "true"
+          effect = "NoSchedule"
+        },
+        {
+          key : "CriticalAddonsOnly"
+          value : "true"
+          effect : "NoSchedule"
+        },
+      ]
+    }
+  }
+  eks-pod-identity-agent = {}
+  kube-proxy             = {}
+  vpc-cni = {
+    most_recent = true
+    preserve    = true
+    configuration_values = {
+      env = {
+        WARM_IP_TARGET    = "2"
+        MINIMUM_IP_TARGET = "12"
+        # ENABLE_PREFIX_DELEGATION = "true"
+        # WARM_PREFIX_TARGET = "1"
+      }
+    }
+  }
+}

--- a/byoc-nuon/sandbox.toml
+++ b/byoc-nuon/sandbox.toml
@@ -4,7 +4,7 @@ terraform_version = "1.11.3"
 [public_repo]
 directory = "."
 repo      = "nuonco/aws-eks-karpenter-sandbox"
-branch    = "main"
+branch    = "fd/chore/easier-addon-overrides-with-defaults"
 
 [vars]
 cluster_version = "1.33"


### PR DESCRIPTION
### Description

Use a new version of the sandbox to configure the vpc cni addon in order to set the following:
- `WARM_IP_TARGET`
- `MINIMUM_IP_TARGET`

This is in order to prevent subnet ip address depletion.

Docs: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/eni-and-ip-target.md