### PR TITLE
feat: add slack app to nuon byoc

### DIFF
--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -54,6 +54,12 @@ env:
   GITHUB_APP_ID: !!string {{ .nuon.inputs.inputs.github_app_id }}
   INTEGRATION_GITHUB_INSTALL_ID: !!string 00000000
 
+  # Slack app config — empty values disable the Slack integration
+  SLACK_HTTP_PORT: !!string 8089
+  SLACK_MIDDLEWARES: "tracer,public_metrics,error,size,log,headers,cors,config,panicker"
+  SLACK_CLIENT_ID: '{{ or .nuon.inputs.inputs.slack_client_id "" }}'
+  SLACK_OAUTH_REDIRECT_URL: '{{ or .nuon.inputs.inputs.slack_oauth_redirect_url "" }}'
+
   INTERNAL_SLACK_WEBHOOK_URL: |-
     https://hooks.slack.com/services/xxxxxxxxxxx/xxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxx
 
@@ -100,6 +106,18 @@ envSecrets:
   - name: "CLICKHOUSE_DB_PASSWORD"
     valueFrom:
       name: clickhouse-cluster-pw
+      key: value
+  - name: "SLACK_CLIENT_SECRET"
+    valueFrom:
+      name: ctl-api-slack-client-secret
+      key: value
+  - name: "SLACK_SIGNING_SECRET"
+    valueFrom:
+      name: ctl-api-slack-signing-secret
+      key: value
+  - name: "SLACK_STATE_JWT_SECRET"
+    valueFrom:
+      name: ctl-api-slack-state-jwt-secret
       key: value
 
 image:
@@ -215,6 +233,15 @@ api:
       maxReplicas: 4
       targetCPUUtilizationPercentage: 80
       targetMemoryUtilizationPercentage: 80
+  slack:
+    enabled: {{ if .nuon.inputs.inputs.slack_client_id }}true{{ else }}false{{ end }}
+    port: 8089
+    domain: "slack.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 2
+      targetCPUUtilizationPercentage: 60
+      targetMemoryUtilizationPercentage: 75
 
 auth:
   enabled: {{ if or (eq "google" .nuon.inputs.inputs.nuon_auth_provider_type) (eq "oidc" .nuon.inputs.inputs.nuon_auth_provider_type) }}true{{ else }}false{{ end }}

--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -234,14 +234,9 @@ api:
       targetCPUUtilizationPercentage: 80
       targetMemoryUtilizationPercentage: 80
   slack:
-    enabled: {{ if .nuon.inputs.inputs.slack_client_id }}true{{ else }}false{{ end }}
+    enabled: true
     port: 8089
     domain: "slack.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
-    autoscaling:
-      minReplicas: 1
-      maxReplicas: 2
-      targetCPUUtilizationPercentage: 60
-      targetMemoryUtilizationPercentage: 75
 
 auth:
   enabled: {{ if or (eq "google" .nuon.inputs.inputs.nuon_auth_provider_type) (eq "oidc" .nuon.inputs.inputs.nuon_auth_provider_type) }}true{{ else }}false{{ end }}

--- a/byoc-nuon-gcp/input_groups/slack.toml
+++ b/byoc-nuon-gcp/input_groups/slack.toml
@@ -1,0 +1,3 @@
+name         = "slack"
+description  = "Configure the Slack App for this BYOC Nuon install. Optional — only required if you plan to enable the Slack integration."
+display_name = "Slack | Nuon configuration"

--- a/byoc-nuon-gcp/inputs/slack/slack_client_id.toml
+++ b/byoc-nuon-gcp/inputs/slack/slack_client_id.toml
@@ -1,0 +1,8 @@
+name         = "slack_client_id"
+description  = "The Slack app's OAuth Client ID. Found on the Slack app's Basic Information page. Leave empty to disable the Slack integration."
+default      = ""
+display_name = "Slack Client ID"
+required     = false
+group        = "slack"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/slack/slack_oauth_redirect_url.toml
+++ b/byoc-nuon-gcp/inputs/slack/slack_oauth_redirect_url.toml
@@ -1,0 +1,8 @@
+name         = "slack_oauth_redirect_url"
+description  = "The Slack OAuth callback URL. Must exactly match a Redirect URL configured in the Slack app's OAuth & Permissions page."
+default      = "https://slack.{{.nuon.inputs.inputs.root_domain}}/slack/oauth/callback"
+display_name = "Slack OAuth Redirect URL"
+required     = false
+group        = "slack"
+
+user_configurable = false

--- a/byoc-nuon-gcp/secrets/slack/client_secret.toml
+++ b/byoc-nuon-gcp/secrets/slack/client_secret.toml
@@ -1,0 +1,10 @@
+name         = "slack_client_secret"
+display_name = "Slack Client Secret"
+description  = "Client Secret from your Slack app's Basic Information page. Leave default to disable the Slack integration."
+default      = "dne" # "empty" value — disables Slack integration
+
+kubernetes_sync             = true
+kubernetes_secret_namespace = "ctl-api"
+kubernetes_secret_name      = "ctl-api-slack-client-secret"
+
+user_configurable = true

--- a/byoc-nuon-gcp/secrets/slack/signing_secret.toml
+++ b/byoc-nuon-gcp/secrets/slack/signing_secret.toml
@@ -1,0 +1,10 @@
+name         = "slack_signing_secret"
+display_name = "Slack Signing Secret"
+description  = "Signing Secret from your Slack app's Basic Information page. Used to verify signed Slack webhook requests (events, slash commands, interactions). Leave default to disable the Slack integration."
+default      = "dne" # "empty" value — disables Slack integration
+
+kubernetes_sync             = true
+kubernetes_secret_namespace = "ctl-api"
+kubernetes_secret_name      = "ctl-api-slack-signing-secret"
+
+user_configurable = true

--- a/byoc-nuon-gcp/secrets/slack/state_jwt_secret.toml
+++ b/byoc-nuon-gcp/secrets/slack/state_jwt_secret.toml
@@ -1,0 +1,10 @@
+name          = "slack_state_jwt_secret"
+display_name  = "Slack State JWT Secret"
+description   = "Auto-generated secret value used to sign the OAuth state JWT during Slack app installation."
+auto_generate = true
+
+kubernetes_sync             = true
+kubernetes_secret_namespace = "ctl-api"
+kubernetes_secret_name      = "ctl-api-slack-state-jwt-secret"
+
+user_configurable = true

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -324,15 +324,10 @@ api:
       targetCPUUtilizationPercentage: 80
       targetMemoryUtilizationPercentage: 80
   slack:
-    enabled: {{ if .nuon.inputs.inputs.slack_client_id }}true{{ else }}false{{ end }}
+    enabled: true
     port: 8089
     domain: "slack.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
     domain_certificate: "{{ .nuon.components.certificate_wildcard_public.outputs.public_domain_certificate_arn }}"
-    autoscaling:
-      minReplicas: 1
-      maxReplicas: 2
-      targetCPUUtilizationPercentage: 60
-      targetMemoryUtilizationPercentage: 75
 
   # topology spread
   minDomains: 2

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -63,6 +63,12 @@ env:
 
   INTEGRATION_GITHUB_INSTALL_ID: !!string 00000000
 
+  # Slack app config — empty values disable the Slack integration
+  SLACK_HTTP_PORT: !!string 8089
+  SLACK_MIDDLEWARES: "tracer,public_metrics,error,size,log,headers,cors,config,panicker"
+  SLACK_CLIENT_ID: '{{ or .nuon.inputs.inputs.slack_client_id "" }}'
+  SLACK_OAUTH_REDIRECT_URL: '{{ or .nuon.inputs.inputs.slack_oauth_redirect_url "" }}'
+
 
   INTERNAL_SLACK_WEBHOOK_URL: |-
     https://hooks.slack.com/services/xxxxxxxxxxx/xxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxx
@@ -119,6 +125,18 @@ envSecrets:
   - name: "CLICKHOUSE_DB_PASSWORD"
     valueFrom:
       name: clickhouse-cluster-pw
+      key: value
+  - name: "SLACK_CLIENT_SECRET"
+    valueFrom:
+      name: ctl-api-slack-client-secret
+      key: value
+  - name: "SLACK_SIGNING_SECRET"
+    valueFrom:
+      name: ctl-api-slack-signing-secret
+      key: value
+  - name: "SLACK_STATE_JWT_SECRET"
+    valueFrom:
+      name: ctl-api-slack-state-jwt-secret
       key: value
 
 image:
@@ -305,6 +323,16 @@ api:
       maxReplicas: 4
       targetCPUUtilizationPercentage: 80
       targetMemoryUtilizationPercentage: 80
+  slack:
+    enabled: {{ if .nuon.inputs.inputs.slack_client_id }}true{{ else }}false{{ end }}
+    port: 8089
+    domain: "slack.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
+    domain_certificate: "{{ .nuon.components.certificate_wildcard_public.outputs.public_domain_certificate_arn }}"
+    autoscaling:
+      minReplicas: 1
+      maxReplicas: 2
+      targetCPUUtilizationPercentage: 60
+      targetMemoryUtilizationPercentage: 75
 
   # topology spread
   minDomains: 2

--- a/byoc-nuon/input_groups/github.toml
+++ b/byoc-nuon/input_groups/github.toml
@@ -1,3 +1,3 @@
 name         = "github"
 description  = "Configure the GitHub Application for this BYOC Nuon install."
-display_name = "Github | Nuon configuration"
+display_name = "Github configuration"

--- a/byoc-nuon/input_groups/slack.toml
+++ b/byoc-nuon/input_groups/slack.toml
@@ -1,0 +1,3 @@
+name         = "slack"
+description  = "Configure the Slack App for this BYOC Nuon install. Optional — only required if you plan to enable the Slack integration."
+display_name = "Slack configuration"

--- a/byoc-nuon/inputs/slack/slack_client_id.toml
+++ b/byoc-nuon/inputs/slack/slack_client_id.toml
@@ -1,0 +1,8 @@
+name         = "slack_client_id"
+description  = "The Slack app's OAuth Client ID. Found on the Slack app's Basic Information page. Leave empty to disable the Slack integration."
+default      = ""
+display_name = "Slack Client ID"
+required     = false
+group        = "slack"
+
+user_configurable = false

--- a/byoc-nuon/inputs/slack/slack_oauth_redirect_url.toml
+++ b/byoc-nuon/inputs/slack/slack_oauth_redirect_url.toml
@@ -1,0 +1,8 @@
+name         = "slack_oauth_redirect_url"
+description  = "The Slack OAuth callback URL. Must exactly match a Redirect URL configured in the Slack app's OAuth & Permissions page."
+default      = "https://slack.{{.nuon.inputs.inputs.root_domain}}/slack/oauth/callback"
+display_name = "Slack OAuth Redirect URL"
+required     = false
+group        = "slack"
+
+user_configurable = false

--- a/byoc-nuon/secrets/slack/client_secret.toml
+++ b/byoc-nuon/secrets/slack/client_secret.toml
@@ -1,0 +1,10 @@
+name         = "slack_client_secret"
+display_name = "Slack Client Secret"
+description  = "Client Secret from your Slack app's Basic Information page. Leave default to disable the Slack integration."
+default      = "dne" # "empty" value — disables Slack integration
+
+kubernetes_sync             = true
+kubernetes_secret_namespace = "ctl-api"
+kubernetes_secret_name      = "ctl-api-slack-client-secret"
+
+user_configurable = true

--- a/byoc-nuon/secrets/slack/signing_secret.toml
+++ b/byoc-nuon/secrets/slack/signing_secret.toml
@@ -1,0 +1,10 @@
+name         = "slack_signing_secret"
+display_name = "Slack Signing Secret"
+description  = "Signing Secret from your Slack app's Basic Information page. Used to verify signed Slack webhook requests (events, slash commands, interactions). Leave default to disable the Slack integration."
+default      = "dne" # "empty" value — disables Slack integration
+
+kubernetes_sync             = true
+kubernetes_secret_namespace = "ctl-api"
+kubernetes_secret_name      = "ctl-api-slack-signing-secret"
+
+user_configurable = true

--- a/byoc-nuon/secrets/slack/state_jwt_secret.toml
+++ b/byoc-nuon/secrets/slack/state_jwt_secret.toml
@@ -1,0 +1,10 @@
+name          = "slack_state_jwt_secret"
+display_name  = "Slack State JWT Secret"
+description   = "Auto-generated secret value used to sign the OAuth state JWT during Slack app installation."
+auto_generate = true
+
+kubernetes_sync             = true
+kubernetes_secret_namespace = "ctl-api"
+kubernetes_secret_name      = "ctl-api-slack-state-jwt-secret"
+
+user_configurable = true

--- a/shared/src/components/ctl_api/Chart.yaml
+++ b/shared/src/components/ctl_api/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: ctl-api
 description: A helm chart for deploying the ctl-api (api and workers).
 type: application
-version: v0.0.3
+version: v0.0.4
 appVersion: "0.0.1"
 
 dependencies: []

--- a/shared/src/components/ctl_api/templates/api_slack_alb.tpl
+++ b/shared/src/components/ctl_api/templates/api_slack_alb.tpl
@@ -1,0 +1,36 @@
+{{- if .Values.api.slack.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "common.fullname" . }}-slack
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.apiLabels" . | nindent 4 }}
+    app.nuon.co/name: {{ include "common.fullname" . }}-slack
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.api.slack.domain_certificate }}
+    alb.ingress.kubernetes.io/aws-load-balancer-ssl-ports: https
+    alb.ingress.kubernetes.io/healthcheck-path: /livez
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '5'
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '2'
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/tags: 'service=ctl-api,service_type=api,service_deployment=slack,env={{ .Values.env.ENV }}'
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.api.slack.domain }}
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "common.fullname" . }}-slack
+                port:
+                  name: http
+{{- end }}

--- a/shared/src/components/ctl_api/templates/api_slack_deployment.tpl
+++ b/shared/src/components/ctl_api/templates/api_slack_deployment.tpl
@@ -1,0 +1,133 @@
+{{- if .Values.api.slack.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "common.fullname" . }}-slack
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.apiLabels" . | nindent 4 }}
+    app.nuon.co/name: {{ include "common.fullname" . }}-slack
+spec:
+  selector:
+    matchLabels:
+      {{- include "common.apiSelectorLabels" . | nindent 6 }}
+      app.nuon.co/name: {{ include "common.fullname" . }}-slack
+  template:
+    metadata:
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+      labels:
+        {{- include "common.apiSelectorLabels" . | nindent 8 }}
+        app.nuon.co/name: {{ include "common.fullname" . }}-slack
+        tags.datadoghq.com/service: ctl-api
+      annotations:
+        ad.datadoghq.com/tags: '{"service_type":"api","service_deployment":"slack"}'
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: true
+
+      # start: NodePool Selection
+      nodeSelector:
+        pool.nuon.co: "public"
+      tolerations:
+        - key: "pool.nuon.co"
+          operator: "Equal"
+          value: "public"
+          effect: "NoSchedule"
+        - key: "pool.nuon.co/public" # this taint is being renamed and deprecated
+          operator: "Exists"
+          effect: "NoSchedule"
+      # end: NodePool Selection
+
+      # start: Topology Spread Constraints
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- /* plucked from common.apiSelectorLabels */}}
+              app.nuon.co/name: {{ include "common.fullname" . }}-slack
+        - maxSkew: 2
+          minDomains: {{ .Values.api.minDomains }}
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              {{- /* plucked from common.apiSelectorLabels */}}
+              app.nuon.co/name: {{ include "common.fullname" . }}-slack
+      # end: Topology Spread Constraints
+      containers:
+        - name: {{ include "common.fullname" . }}-slack
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command:
+            - /bin/service
+            - api-slack
+          ports:
+            - name: http-internal
+              containerPort: {{ .Values.api.slack.port }}
+              protocol: TCP
+            - name: pprof
+              containerPort: 6060
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.api.readiness_probe }}
+              port: http-internal
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.api.liveness_probe }}
+              port: http-internal
+          resources:
+            limits:
+              cpu: {{ .Values.api.resources.limits.cpu }}
+              memory: {{ .Values.api.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.api.resources.requests.cpu }}
+              memory: {{ .Values.api.resources.requests.memory }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "common.fullname" . }}
+          env:
+          {{- range $envSecret := .Values.envSecrets }}
+            - name: {{ $envSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $envSecret.valueFrom.name }}
+                  key: {{ $envSecret.valueFrom.key }}
+          {{- end}}
+            - name: HOST_IP
+              valueFrom:
+                  fieldRef:
+                      fieldPath: status.hostIP
+            - name: HOST_NAME
+              valueFrom:
+                  fieldRef:
+                      fieldPath: spec.nodeName
+            - name: DD_SERVICE
+              value: ctl-api
+            - name: SERVICE_TYPE
+              value: api
+            - name: SERVICE_DEPLOYMENT
+              value: slack
+          lifecycle:
+            preStop:
+              exec:
+                # sleep: during this time, the api can finish processing requests.
+                command: [
+                  "/bin/sh", "-c", "sleep 20"
+                ]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.fullname" . }}-slack
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "common.apiSelectorLabels" . | nindent 6 }}
+      app.nuon.co/name: {{ include "common.fullname" . }}-slack
+{{- end }}

--- a/shared/src/components/ctl_api/templates/api_slack_service.tpl
+++ b/shared/src/components/ctl_api/templates/api_slack_service.tpl
@@ -1,0 +1,19 @@
+{{- if .Values.api.slack.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.fullname" . }}-slack
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.apiLabels" . | nindent 4 }}
+    app.nuon.co/name: {{ include "common.fullname" . }}-slack
+spec:
+  selector:
+    {{- include "common.apiSelectorLabels" . | nindent 4 }}
+    app.nuon.co/name: {{ include "common.fullname" . }}-slack
+  ports:
+    - name: http
+      port: 80
+      targetPort: http-internal
+{{- end }}


### PR DESCRIPTION
## Description

This PR updates the AWS and GCP app configs to support using the new Slack app in Nuon BYOC installs. It:

- Adds inputs for the Slack app configuration.
- Updates the ctl api helm chart for GCP to add a deployment for the Slack app API.
- Updates the AWS component to use the updated ctl api helm chart from this PR: https://github.com/nuonco/charts/pull/10

The charts PR should be merged first. Then we can update this PR to switch back to the main branch before merging.