### PR TITLE
feat: temporarily disable temporal_status outputs to clear state

### DIFF
--- a/byoc-nuon/README.md
+++ b/byoc-nuon/README.md
@@ -104,6 +104,7 @@ aws --region {{ .nuon.install_stack.outputs.region }} \
 
 {{ with index .nuon.actions.workflows "temporal_status" }}
 {{ $data := dict }}{{ with .outputs }}{{ $data = . }}{{ end }}
+{{ if false }}
 <details>
 <summary><nuon-group gap="2" align="center" justify="start"><strong>Temporal Status</strong>{{ with index $.nuon.actions.workflows "healthcheck_temporal" }}{{ if eq .status "error" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else if eq .status "finished" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}{{ end }}</nuon-group></summary>
 
@@ -131,6 +132,7 @@ aws --region {{ .nuon.install_stack.outputs.region }} \
 </nuon-tabs>
 
 </details>
+{{ end }}
 {{ end }}
 
 

--- a/byoc-nuon/actions/src/temporal/fetch_status.sh
+++ b/byoc-nuon/actions/src/temporal/fetch_status.sh
@@ -8,6 +8,11 @@ set -e
 set -o pipefail
 set -u
 
+# Temporarily disabled: this action's outputs were inflating install state size.
+# Skip all kubectl/temporal calls and write no outputs.
+echo >&2 "temporal_status outputs temporarily disabled to reduce install state size"
+exit 0
+
 # Namespaces mirror temporalWorkerNamespaces in ctl-api:
 # internal/app/admin-dashboard/service/temporal_workers.go.
 namespaces=(


### PR DESCRIPTION
The amount of data being stored by the temporal_status action was slowing down state rendering too much. This PR disables the outputs to reduce the state size.