### PR TITLE
feat(rds): add opt-in read replica for ctl-api Postgres

### DIFF
--- a/byoc-nuon/src/components/rds_cluster_nuon/main.tf
+++ b/byoc-nuon/src/components/rds_cluster_nuon/main.tf
@@ -59,3 +59,37 @@ module "db" {
   depends_on = [resource.aws_security_group.allow_psql]
 }
 
+module "db_replica" {
+  count  = local.read_replica_enabled ? 1 : 0
+  source = "terraform-aws-modules/rds/aws"
+
+  identifier          = "${var.identifier}-replica"
+  replicate_source_db = module.db.db_instance_identifier
+
+  engine         = "postgres"
+  family         = "postgres15"
+  engine_version = "15"
+  instance_class = local.replica_instance_class
+
+  port = var.port
+
+  iam_database_authentication_enabled = local.iam_database_authentication_enabled
+  apply_immediately                   = local.apply_immediately
+
+  create_db_subnet_group = false
+  db_subnet_group_name   = var.subnet_group_id
+  vpc_security_group_ids = [resource.aws_security_group.allow_psql.id]
+
+  maintenance_window = var.maintenance_window
+
+  performance_insights_enabled    = true
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+
+  skip_final_snapshot = true
+  deletion_protection = var.deletion_protection
+  storage_encrypted   = var.storage_encrypted
+
+  create_db_parameter_group = false
+
+  depends_on = [resource.aws_security_group.allow_psql]
+}

--- a/byoc-nuon/src/components/rds_cluster_nuon/outputs.tf
+++ b/byoc-nuon/src/components/rds_cluster_nuon/outputs.tf
@@ -29,3 +29,11 @@ output "db_instance_username" {
 output "db_instance_availability_zone" {
   value = module.db.db_instance_availability_zone
 }
+
+output "replica_endpoint" {
+  value = length(module.db_replica) > 0 ? module.db_replica[0].db_instance_endpoint : null
+}
+
+output "replica_address" {
+  value = length(module.db_replica) > 0 ? module.db_replica[0].db_instance_address : null
+}

--- a/byoc-nuon/src/components/rds_cluster_nuon/variables.tf
+++ b/byoc-nuon/src/components/rds_cluster_nuon/variables.tf
@@ -6,6 +6,8 @@ locals {
   skip_final_snapshot                 = contains(["true", "1"], var.skip_final_snapshot)
   storage_encrypted                   = contains(["true", "1"], var.storage_encrypted)
   apply_immediately                   = contains(["true", "1"], var.apply_immediately)
+  read_replica_enabled                = contains(["true", "1"], var.read_replica_enabled)
+  replica_instance_class              = var.replica_instance_class != "" ? var.replica_instance_class : var.instance_class
   tags = {
     "component.nuon.co/name" = "rds-cluster"
     "install.nuon.co/id"     = var.nuon_id
@@ -91,6 +93,18 @@ variable "multi_az" {
   type        = string
   description = "Enable multi-az."
   default     = "false"
+}
+
+variable "read_replica_enabled" {
+  type        = string
+  description = "Whether to provision a single in-region read replica of the primary instance."
+  default     = "false"
+}
+
+variable "replica_instance_class" {
+  type        = string
+  description = "Instance class for the read replica. Defaults to the primary's instance_class when empty."
+  default     = ""
 }
 
 variable "backup_retention_period" {


### PR DESCRIPTION
## Summary
- Adds a second `db_replica` invocation of `terraform-aws-modules/rds/aws` inside `byoc-nuon/src/components/rds_cluster_nuon`, gated by a new `read_replica_enabled` variable (default `"false"`, opt-in like `multi_az`).
- Replica's instance class defaults to the primary's `instance_class`; override via the new `replica_instance_class` variable.
- Exposes `replica_endpoint` and `replica_address` outputs (null when the replica is disabled).
- No consumer wiring yet — ctl-api still points at the writer via `address`. Reads can be routed via a follow-up once the app honors a `DB_READ_HOST`-style env.

## Test plan
- [ ] `terraform validate` passes in `byoc-nuon/src/components/rds_cluster_nuon` (verified locally).
- [ ] `terraform plan` on a sandbox install with defaults shows no replica resources (gate stays off).
- [ ] `terraform plan` with `read_replica_enabled = "true"` shows one new `aws_db_instance` named `<identifier>-replica` and `replica_endpoint` populated.
- [ ] Confirm replica reaches `available` in AWS and `replicate_source_db` points at the primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)