### PR TITLE
chore(ctl-api): scope slack envSecrets + add temporal_reset_namespaces action

### DIFF
--- a/byoc-nuon/actions/temporal_reset_namespaces.toml
+++ b/byoc-nuon/actions/temporal_reset_namespaces.toml
@@ -1,0 +1,20 @@
+# action
+# description: deletes and recreates Temporal namespaces. DESTRUCTIVE - workflow history is lost.
+# if the NAMESPACE env var is set, only that namespace is reset; otherwise all namespaces are reset.
+name    = "temporal_reset_namespaces"
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name    = "Resetting Namespaces"
+command = "./temporal/reset_namespaces.sh"
+
+[steps.public_repo]
+repo      = "nuonco/byoc"
+directory = "shared/src/actions"
+branch    = "main"
+
+[steps.env_vars]
+NAMESPACE = ""

--- a/byoc-nuon/components/92-helm-ctl_api.toml
+++ b/byoc-nuon/components/92-helm-ctl_api.toml
@@ -9,7 +9,7 @@ dependencies   = ["rds_cluster_nuon", "karpenter_nodepools", "clickhouse_cluster
 [public_repo]
 repo      = "nuonco/charts"
 directory = "charts/ctl-api"
-branch    = "sk/fx-admin-dash"
+branch    = "am/slack-envsecrets-scope"
 
 [[values_file]]
 contents = "./values/ctl-api.yaml"

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -323,10 +323,23 @@ api:
       targetCPUUtilizationPercentage: 80
       targetMemoryUtilizationPercentage: 80
   slack:
-    enabled: true
+    enabled: false
     port: 8089
     domain: "slack.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
     domain_certificate: "{{ .nuon.components.certificate_wildcard_public.outputs.public_domain_certificate_arn }}"
+    envSecrets:
+      - name: "SLACK_CLIENT_SECRET"
+        valueFrom:
+          name: ctl-api-slack-client-secret
+          key: value
+      - name: "SLACK_SIGNING_SECRET"
+        valueFrom:
+          name: ctl-api-slack-signing-secret
+          key: value
+      - name: "SLACK_STATE_JWT_SECRET"
+        valueFrom:
+          name: ctl-api-slack-state-jwt-secret
+          key: value
 
   # topology spread
   minDomains: 2

--- a/shared/src/actions/temporal/reset_namespaces.sh
+++ b/shared/src/actions/temporal/reset_namespaces.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# NOTE: this script deletes and recreates Temporal namespaces. it is DESTRUCTIVE -
+# any in-flight workflow history in the affected namespace(s) will be lost.
+# if the NAMESPACE env var is set, only that namespace is reset. otherwise all
+# namespaces are reset.
+
+set -uo pipefail
+
+DEFAULT_RETENTION="3d"
+LONG_RETENTION="30d"
+
+# Namespaces that use the default short retention.
+declare -a default_namespaces=(
+  "general"
+  "orgs"
+  "apps"
+  "installs"
+  "runners"
+  "actions"
+  "components"
+  "releases"
+  "app-branches"
+  "onboardings"
+)
+
+# Namespaces that need a longer retention period.
+declare -a long_namespaces=(
+  "vcs"
+  "emitters"
+)
+
+function delete_namespace() {
+  local name="$1"
+
+  echo >&2 " > deleting namespace: $name"
+  kubectl -n temporal exec -i deployment/temporal-admintools -- \
+    temporal operator namespace delete \
+         --namespace "$name"           \
+         --yes
+}
+
+function create_namespace() {
+  local name="$1"
+  local retention="$2"
+  local description="$3"
+
+  echo >&2 " > creating namespace: $name (retention: $retention)"
+  kubectl -n temporal exec -i deployment/temporal-admintools -- \
+    temporal operator namespace create \
+         --namespace   "$name"         \
+         --description "$description"  \
+         --retention   "$retention"
+}
+
+function retention_for() {
+  local name="$1"
+  for ns in "${long_namespaces[@]}"; do
+    if [[ "$ns" == "$name" ]]; then
+      echo "$LONG_RETENTION"
+      return
+    fi
+  done
+  echo "$DEFAULT_RETENTION"
+}
+
+TARGET_NAMESPACE="${NAMESPACE:-}"
+
+if [[ -n "$TARGET_NAMESPACE" ]]; then
+  found=false
+  for ns in "${default_namespaces[@]}" "${long_namespaces[@]}"; do
+    if [[ "$ns" == "$TARGET_NAMESPACE" ]]; then
+      found=true
+      break
+    fi
+  done
+  if [[ "$found" == "false" ]]; then
+    echo >&2 "unknown namespace: $TARGET_NAMESPACE"
+    echo >&2 "valid namespaces: ${default_namespaces[*]} ${long_namespaces[*]}"
+    exit 1
+  fi
+  declare -a namespaces=("$TARGET_NAMESPACE")
+else
+  declare -a namespaces=("${default_namespaces[@]}" "${long_namespaces[@]}")
+fi
+
+echo >&2 "resetting namespaces: ${namespaces[*]}"
+
+for namespace in "${namespaces[@]}"
+do
+  retention="$(retention_for "$namespace")"
+  echo >&2 "resetting namespace $namespace (retention: $retention)"
+  delete_namespace "$namespace" || echo >&2 " > delete failed (namespace may not exist), continuing"
+  create_namespace "$namespace" "$retention" "$namespace for byoc nuon"
+done
+
+exit 0

--- a/shared/src/components/ctl_api/templates/api_slack_deployment.tpl
+++ b/shared/src/components/ctl_api/templates/api_slack_deployment.tpl
@@ -97,6 +97,14 @@ spec:
                   name: {{ $envSecret.valueFrom.name }}
                   key: {{ $envSecret.valueFrom.key }}
           {{- end}}
+          {{/* additional secrets for the slack service */}}
+          {{- range $envSecret := .Values.api.slack.envSecrets }}
+            - name: {{ $envSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $envSecret.valueFrom.name }}
+                  key: {{ $envSecret.valueFrom.key }}
+          {{- end}}
             - name: HOST_IP
               valueFrom:
                   fieldRef:


### PR DESCRIPTION
Scopes SLACK_* envSecrets to the api-slack pod only (mirroring the auth pattern) and disables the slack listener in byoc-nuon for now. Pairs with chart branch `am/slack-envsecrets-scope` in nuonco/charts (helm component repointed at it).

Also adds a manual `temporal_reset_namespaces` action — destructive, deletes + recreates temporal namespaces. NAMESPACE env var to target one, otherwise resets all.