### PR TITLE
feat: warn on RDS destructive changes, public ingress, and public EKS

### DIFF
--- a/byoc-nuon/policies.toml
+++ b/byoc-nuon/policies.toml
@@ -1,0 +1,24 @@
+# policies
+
+[[policy]]
+type       = "terraform_module"
+engine     = "opa"
+components = ["rds_cluster_nuon", "rds_cluster_temporal"]
+contents   = "./policies/warn-db-destructive.rego"
+
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/warn-public-eks-endpoint.rego"
+
+[[policy]]
+type       = "helm_chart"
+engine     = "opa"
+components = ["*"]
+contents   = "./policies/warn-public-ingress.rego"
+
+[[policy]]
+type       = "helm_chart"
+engine     = "opa"
+components = ["*"]
+contents   = "./policies/warn-loadbalancer-service.rego"

--- a/byoc-nuon/policies/warn-db-destructive.rego
+++ b/byoc-nuon/policies/warn-db-destructive.rego
@@ -1,0 +1,66 @@
+# warns on destructive changes to managed RDS databases. covers both
+# rds_cluster_nuon and rds_cluster_temporal, which use the
+# terraform-aws-modules/rds/aws module and produce aws_db_instance resources
+# (not aws_rds_cluster, despite the component name).
+#
+# warn-only for the initial rollout; intent is to surface destructive plans
+# during review without blocking deploys.
+
+package nuon
+
+# delete: outright removal of the DB instance
+warn contains msg if {
+	resource := input.plan.resource_changes[_]
+	resource.type == "aws_db_instance"
+	resource.change.actions[_] == "delete"
+	msg := sprintf("RDS deletion: '%s' is being deleted, which would destroy the database", [resource.address])
+}
+
+# replace: delete + create in the same plan (e.g. identifier change,
+# engine version downgrade, storage type change forcing replacement)
+warn contains msg if {
+	resource := input.plan.resource_changes[_]
+	resource.type == "aws_db_instance"
+	actions := {a | a := resource.change.actions[_]}
+	actions["delete"]
+	actions["create"]
+	msg := sprintf("RDS replacement: '%s' is being replaced (delete + create), which would destroy the database", [resource.address])
+}
+
+# storage shrink: AWS forbids this in-place and will force a replacement
+warn contains msg if {
+	resource := input.plan.resource_changes[_]
+	resource.type == "aws_db_instance"
+	resource.change.actions[_] == "update"
+	resource.change.after.allocated_storage < resource.change.before.allocated_storage
+	msg := sprintf("RDS storage shrink: '%s' allocated_storage going from %d to %d would force replacement", [resource.address, resource.change.before.allocated_storage, resource.change.after.allocated_storage])
+}
+
+# backups disabled: going from any positive retention to 0 turns off
+# automated backups
+warn contains msg if {
+	resource := input.plan.resource_changes[_]
+	resource.type == "aws_db_instance"
+	resource.change.before.backup_retention_period > 0
+	resource.change.after.backup_retention_period == 0
+	msg := sprintf("RDS backups disabled: '%s' backup_retention_period going from %d to 0 would turn off automated backups", [resource.address, resource.change.before.backup_retention_period])
+}
+
+# deletion_protection flipped off: usually a precursor to a delete
+warn contains msg if {
+	resource := input.plan.resource_changes[_]
+	resource.type == "aws_db_instance"
+	resource.change.before.deletion_protection == true
+	resource.change.after.deletion_protection == false
+	msg := sprintf("RDS deletion_protection disabled on '%s'", [resource.address])
+}
+
+# skip_final_snapshot during a delete: caller is opting out of the safety
+# net that would otherwise let us recover
+warn contains msg if {
+	resource := input.plan.resource_changes[_]
+	resource.type == "aws_db_instance"
+	resource.change.actions[_] == "delete"
+	resource.change.after.skip_final_snapshot == true
+	msg := sprintf("RDS '%s' is being deleted with skip_final_snapshot=true; no final snapshot will be taken", [resource.address])
+}

--- a/byoc-nuon/policies/warn-loadbalancer-service.rego
+++ b/byoc-nuon/policies/warn-loadbalancer-service.rego
@@ -1,0 +1,13 @@
+# warns when a Helm chart deploys a Kubernetes Service of type LoadBalancer.
+# such a Service triggers the cloud controller to provision a cloud load
+# balancer (in our case a public NLB by default), bypassing the sandbox's
+# managed ingress path. all north-south traffic should go through
+# ingress-nginx or the AWS Load Balancer Controller via an Ingress.
+
+package nuon
+
+warn contains msg if {
+	input.review.kind.kind == "Service"
+	input.review.object.spec.type == "LoadBalancer"
+	msg := sprintf("Service '%s' is type=LoadBalancer; route through an Ingress instead", [input.review.object.metadata.name])
+}

--- a/byoc-nuon/policies/warn-public-eks-endpoint.rego
+++ b/byoc-nuon/policies/warn-public-eks-endpoint.rego
@@ -1,0 +1,14 @@
+# warns when the EKS cluster has its API server endpoint exposed publicly.
+# the sandbox controls this via `cluster_endpoint_public_access` in
+# sandbox.tfvars, so this policy is scoped to type = "sandbox".
+
+package nuon
+
+warn contains msg if {
+	resource := input.plan.resource_changes[_]
+	resource.type == "aws_eks_cluster"
+	resource.mode == "managed"
+	vpc := resource.change.after.vpc_config[_]
+	vpc.endpoint_public_access == true
+	msg := sprintf("EKS cluster '%s' has public endpoint access enabled", [resource.address])
+}

--- a/byoc-nuon/policies/warn-public-ingress.rego
+++ b/byoc-nuon/policies/warn-public-ingress.rego
@@ -1,0 +1,23 @@
+# warns when a Helm chart deploys an Ingress that is publicly exposed.
+#
+# the sandbox provisions both ingress-nginx (ingressClassName "nginx") and
+# the AWS Load Balancer Controller. that gives two ways to make an Ingress
+# public:
+#   1. AWS LBC: `alb.ingress.kubernetes.io/scheme: internet-facing` annotation
+#      provisions a public ALB.
+#   2. ingress-nginx: `cert-manager.io/cluster-issuer: public-issuer`
+#      annotation routes through the public hosted zone.
+
+package nuon
+
+warn contains msg if {
+	input.review.kind.kind == "Ingress"
+	input.review.object.metadata.annotations["alb.ingress.kubernetes.io/scheme"] == "internet-facing"
+	msg := sprintf("Ingress '%s' provisions a public ALB (alb.ingress.kubernetes.io/scheme=internet-facing); confirm this is intentional", [input.review.object.metadata.name])
+}
+
+warn contains msg if {
+	input.review.kind.kind == "Ingress"
+	input.review.object.metadata.annotations["cert-manager.io/cluster-issuer"] == "public-issuer"
+	msg := sprintf("Ingress '%s' is public (cert-manager.io/cluster-issuer=public-issuer); confirm this is intentional", [input.review.object.metadata.name])
+}


### PR DESCRIPTION
Adds [`byoc-nuon/policies.toml`](byoc-nuon/policies.toml) wiring four OPA `warn` policies:

| Policy | Triggers on |
| --- | --- |
| `warn-db-destructive.rego` | `aws_db_instance` delete, replace, storage shrink, backups → 0, `deletion_protection` flipped off, delete with `skip_final_snapshot` |
| `warn-public-eks-endpoint.rego` | `aws_eks_cluster` with `endpoint_public_access = true` |
| `warn-public-ingress.rego` | `Ingress` with `alb.ingress.kubernetes.io/scheme: internet-facing` or `cert-manager.io/cluster-issuer: public-issuer` |
| `warn-loadbalancer-service.rego` | `Service` with `type: LoadBalancer` |

## Notes

- `warn`-only for now; promote to `deny` per-rule after a release of soak.
- Patterns borrowed from `nuonco/example-app-configs` (`policies-demo`, `coder`) and `nuonco/policies`.
