### PR TITLE
chore(s3-buckets): add a new public prefix "stacks/*"

### DIFF
--- a/byoc-nuon/src/components/s3_buckets/install_templates_bucket.tf
+++ b/byoc-nuon/src/components/s3_buckets/install_templates_bucket.tf
@@ -2,6 +2,7 @@ locals {
   org_id = data.aws_organizations_organization.orgs.id
   public_prefixes = [
     "templates/*",
+    "stacks/*",
   ]
 }
 


### PR DESCRIPTION
### Description

we expose `stacks/*` as a public prefix because we serve custom nested stack templates from this path prefix.

this is specifically required to support [Custom Nested CF Stacks](https://docs.nuon.co/guides/custom-nested-stacks).
