### PR TITLE
chore: bump amazon linux alias to v20260512

### DIFF
--- a/byoc-nuon/src/components/karpenter-nodepools/templates/nodeclass.tpl
+++ b/byoc-nuon/src/components/karpenter-nodepools/templates/nodeclass.tpl
@@ -6,7 +6,7 @@ metadata:
   name: "{{ .name }}"
 spec:
   amiSelectorTerms:
-  - alias: "al2023@v20260520"
+  - alias: "al2023@v20260512"
   instanceProfile: "{{ $.Values.karpenter.instance_profile }}"
   securityGroupSelectorTerms:
   - tags:


### PR DESCRIPTION
Auto-bump of the Karpenter AL2023 AMI alias to N-1.

- Latest release: `v20260520`
- N-1 (this PR):  `v20260512`
- Previous:       `v20260520`

Source: https://github.com/awslabs/amazon-eks-ami/releases