### PR TITLE
chore: ctl-api: pin chart and remove worker limits

### DIFF
--- a/byoc-nuon/components/92-helm-ctl_api.toml
+++ b/byoc-nuon/components/92-helm-ctl_api.toml
@@ -9,7 +9,7 @@ dependencies   = ["rds_cluster_nuon", "karpenter_nodepools", "clickhouse_cluster
 [public_repo]
 repo      = "nuonco/charts"
 directory = "charts/ctl-api"
-branch    = "main"
+branch    = "ctl-api-v0.2.1"
 
 [[values_file]]
 contents = "./values/ctl-api.yaml"

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -165,12 +165,9 @@ worker:
       maxReplicas: 2
       command: ["/bin/service", "worker", "--namespace=apps"]
       resources:
-        limits:
+        requests:
           cpu: 2000m
           memory: 4Gi
-        requests:
-          cpu: 1750m
-          memory: 3Gi
       extraEnv:
         - name: TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_EXECUTION_SIZE
           value: "10000"
@@ -187,9 +184,6 @@ worker:
       maxReplicas: 2
       command: ["/bin/service", "worker", "--namespace=components"]
       resources:
-        limits:
-          cpu: 1000m
-          memory: 1Gi
         requests:
           cpu: 1000m
           memory: 1Gi
@@ -198,12 +192,9 @@ worker:
       maxReplicas: 4
       command: ["/bin/service", "worker", "--namespace=installs"]
       resources:
-        limits:
+        requests:
           cpu: 2000m
           memory: 4Gi
-        requests:
-          cpu: 1750m
-          memory: 3Gi
       extraEnv:
         - name: TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_EXECUTION_SIZE
           value: "10000"
@@ -233,9 +224,6 @@ worker:
       maxReplicas: 4
       command: ["/bin/service", "worker", "--namespace=runners"]
       resources:
-        limits:
-          cpu: 2000m
-          memory: 4Gi
         requests:
           cpu: 2000m
           memory: 4Gi


### PR DESCRIPTION
- **chore(ctl-api): pin chart to v0.2.1**
- **chore(ctl-api): remove resource limits from the ctl-api workers**
