### PR TITLE
feat: run all readme actions once an hour

### DIFF
--- a/byoc-nuon/README.md
+++ b/byoc-nuon/README.md
@@ -71,10 +71,9 @@ nuon -f ~/.nuon.byoc login
 
 **Outputs**
 
-| Output                                                  | Value      |
-| ------------------------------------------------------- | ---------- | ------------ |
-| {{ range $key, $value := .nuon.install_stack.outputs }} | {{ $key }} | {{ $value }} |
-
+| Output | Value |
+| ------ | ----- |
+{{ range $key, $value := .nuon.install_stack.outputs }}| {{ $key }} | {{ $value }} |
 {{ end }}
 
 </details>
@@ -84,10 +83,9 @@ nuon -f ~/.nuon.byoc login
 
 **Outputs**
 
-| Output                                                                   | Value      |
-| ------------------------------------------------------------------------ | ---------- | ------------ |
-| {{ range $key, $value := dig "outputs" "cluster" (dict) .nuon.sandbox }} | {{ $key }} | {{ $value }} |
-
+| Output | Value |
+| ------ | ----- |
+{{ range $key, $value := dig "outputs" "cluster" (dict) .nuon.sandbox }}| {{ $key }} | {{ $value }} |
 {{ end }}
 
 **Accessing the EKS Cluster**

--- a/byoc-nuon/actions/api_status.toml
+++ b/byoc-nuon/actions/api_status.toml
@@ -6,7 +6,7 @@ timeout = "2m"
 
 [[triggers]]
 type          = "cron"
-cron_schedule = "0 * * * *"
+cron_schedule = "10 * * * *"
 
 [[triggers]]
 type = "manual"

--- a/byoc-nuon/actions/ctl_api_query_workflows_by_type.toml
+++ b/byoc-nuon/actions/ctl_api_query_workflows_by_type.toml
@@ -5,7 +5,7 @@ timeout = "5m"
 
 [[triggers]]
 type          = "cron"
-cron_schedule = "0 * * * *"
+cron_schedule = "5 * * * *"
 
 [[triggers]]
 type = "manual"

--- a/byoc-nuon/actions/ctl_api_query_workflows_by_type.toml
+++ b/byoc-nuon/actions/ctl_api_query_workflows_by_type.toml
@@ -4,6 +4,10 @@ label   = "query"
 timeout = "5m"
 
 [[triggers]]
+type          = "cron"
+cron_schedule = "0 * * * *"
+
+[[triggers]]
 type = "manual"
 
 [[steps]]

--- a/byoc-nuon/actions/dashboard_status.toml
+++ b/byoc-nuon/actions/dashboard_status.toml
@@ -6,7 +6,7 @@ timeout = "2m"
 
 [[triggers]]
 type          = "cron"
-cron_schedule = "0 * * * *"
+cron_schedule = "15 * * * *"
 
 [[triggers]]
 type           = "post-deploy-component"

--- a/byoc-nuon/actions/status_report.toml
+++ b/byoc-nuon/actions/status_report.toml
@@ -3,6 +3,10 @@ name    = "status_report"
 timeout = "5m"
 
 [[triggers]]
+type          = "cron"
+cron_schedule = "0 * * * *"
+
+[[triggers]]
 type = "manual"
 
 [[steps]]


### PR DESCRIPTION
We want to ensure the README is always up to date. Running actions once an hour to start.