### PR TITLE
feat: read only break glass cross account 

### DIFF
--- a/byoc-nuon/README.md
+++ b/byoc-nuon/README.md
@@ -71,9 +71,10 @@ nuon -f ~/.nuon.byoc login
 
 **Outputs**
 
-| Output | Value |
-| ------ | ----- |
-{{ range $key, $value := .nuon.install_stack.outputs }}| {{ $key }} | {{ $value }} |
+| Output                                                  | Value      |
+| ------------------------------------------------------- | ---------- | ------------ |
+| {{ range $key, $value := .nuon.install_stack.outputs }} | {{ $key }} | {{ $value }} |
+
 {{ end }}
 
 </details>
@@ -83,9 +84,10 @@ nuon -f ~/.nuon.byoc login
 
 **Outputs**
 
-| Output | Value |
-| ------ | ----- |
-{{ range $key, $value := dig "outputs" "cluster" (dict) .nuon.sandbox }}| {{ $key }} | {{ $value }} |
+| Output                                                                   | Value      |
+| ------------------------------------------------------------------------ | ---------- | ------------ |
+| {{ range $key, $value := dig "outputs" "cluster" (dict) .nuon.sandbox }} | {{ $key }} | {{ $value }} |
+
 {{ end }}
 
 **Accessing the EKS Cluster**
@@ -102,6 +104,118 @@ aws --region {{ .nuon.install_stack.outputs.region }} \
 </pre>
 
 </details>
+
+{{ $roRoleArn := dig "custom_nested_stacks" "byoc_nuon_read_only_access" "outputs" "RoleARN" "" .nuon.install_stack.outputs }}
+{{ if $roRoleArn }} {{ $vendorRoleArn := dig "read_only_role_arn" "&lt;your-vendor-role-arn&gt;" $inputs }}
+{{ $clusterName := dig "outputs" "cluster" "name" (printf "n-%s" .nuon.install.id) .nuon.sandbox }}
+{{ $rdsNuon := printf "nuon-%s" .nuon.install.id }} {{ $rdsTemporal := printf "temporal-%s" .nuon.install.id }}
+
+<details>
+<summary><nuon-group gap="2" align="center" justify="start"><strong>BreakGlass-ReadOnly</strong><nuon-status status="active" variant="badge"></nuon-status><nuon-label-badge label="region:{{ $region }}"></nuon-label-badge></nuon-group></summary>
+
+This install has a cross-account read-only break-glass role provisioned. A vendor-owned role can assume it for RDS
+metrics inspection, CloudWatch read access, and (when EKS access is enabled) cluster admin via the EKS access entry.
+
+<!-- prettier-ignore-start -->
+> [!WARNING]
+> SecretsManager is explicitly denied.
+<!-- prettier-ignore-end -->
+
+**Outputs**
+
+| Output  | Value              |
+| ------- | ------------------ |
+| RoleARN | `{{ $roRoleArn }}` |
+
+**Assume the role**
+
+The read-only role trusts the vendor role. Assume the vendor role first, then chain into this install role:
+
+<pre>
+./scripts/install-shell.sh \
+  {{ $vendorRoleArn }} \
+  {{ $roRoleArn }}
+</pre>
+
+All commands below assume you are in that role's session.
+
+**Cluster kubeconfig (EKS admin)**
+
+Generate a kubeconfig for the cluster. This requires `read_only_enable_cluster_access=true` so the EKS access entry
+(AmazonEKSClusterAdminPolicy + AmazonEKSAdminPolicy) exists:
+
+<pre>
+aws --region {{ $region }} eks update-kubeconfig \
+    --name {{ $clusterName }} \
+    --alias {{ $clusterName }}-readonly
+
+kubectl --context {{ $clusterName }}-readonly get nodes
+kubectl --context {{ $clusterName }}-readonly top nodes
+</pre>
+
+**RDS diagnostics**
+
+Two Aurora PostgreSQL clusters back this install:
+
+| Purpose  | Cluster Identifier   |
+| -------- | -------------------- |
+| ctl-api  | `{{ $rdsNuon }}`     |
+| temporal | `{{ $rdsTemporal }}` |
+
+Describe the clusters and their instances, and surface recent failure/maintenance events:
+
+<pre>
+for CLUSTER in {{ $rdsNuon }} {{ $rdsTemporal }}; do
+  echo "=== $CLUSTER ==="
+  aws --region {{ $region }} rds describe-db-clusters \
+      --db-cluster-identifier "$CLUSTER" \
+      --query 'DBClusters[0].{Status:Status,Engine:EngineVersion,Members:DBClusterMembers[].DBInstanceIdentifier,AllocatedStorage:AllocatedStorage}'
+
+  aws --region {{ $region }} rds describe-events \
+      --source-identifier "$CLUSTER" --source-type db-cluster --duration 1440 \
+      --query 'Events[].{Date:Date,Message:Message}'
+done
+</pre>
+
+Pull the key disk/memory/CPU pressure metrics from CloudWatch. `VolumeBytesUsed` is cluster-level (the shared Aurora
+volume); `FreeLocalStorage`, `FreeableMemory`, `CPUUtilization`, and `DatabaseConnections` are per-instance:
+
+<pre>
+# portable: macOS (-v) or GNU (-d) date
+START=$(date -u -v-3H +%FT%TZ 2>/dev/null || date -u -d '3 hours ago' +%FT%TZ)
+END=$(date -u +%FT%TZ)
+
+for CLUSTER in {{ $rdsNuon }} {{ $rdsTemporal }}; do
+  echo "=== $CLUSTER : cluster volume ==="
+  aws --region {{ $region }} cloudwatch get-metric-statistics \
+      --namespace AWS/RDS --metric-name VolumeBytesUsed \
+      --dimensions Name=DBClusterIdentifier,Value="$CLUSTER" \
+      --start-time "$START" --end-time "$END" --period 300 --statistics Maximum \
+      --query 'sort_by(Datapoints,&Timestamp)[-1]'
+
+  for INSTANCE in $(aws --region {{ $region }} rds describe-db-clusters \
+      --db-cluster-identifier "$CLUSTER" \
+      --query 'DBClusters[0].DBClusterMembers[].DBInstanceIdentifier' --output text); do
+    echo "=== $CLUSTER / $INSTANCE : instance pressure ==="
+    for METRIC in FreeLocalStorage FreeableMemory CPUUtilization DatabaseConnections ReadIOPS WriteIOPS; do
+      printf '%-22s ' "$METRIC"
+      aws --region {{ $region }} cloudwatch get-metric-statistics \
+          --namespace AWS/RDS --metric-name "$METRIC" \
+          --dimensions Name=DBInstanceIdentifier,Value="$INSTANCE" \
+          --start-time "$START" --end-time "$END" --period 300 \
+          --statistics Average Minimum Maximum \
+          --query 'sort_by(Datapoints,&Timestamp)[-1].{Avg:Average,Min:Minimum,Max:Maximum}' --output text
+    done
+  done
+done
+</pre>
+
+<nuon-banner theme="info">`FreeLocalStorage` and `FreeableMemory` are reported in bytes. A sustained drop in
+`FreeLocalStorage` toward zero is the clearest disk-pressure signal for an Aurora instance; the shared cluster volume
+(`VolumeBytesUsed`) auto-scales and rarely pressures.</nuon-banner>
+
+</details>
+{{ end }}
 
 {{ with index .nuon.actions.workflows "temporal_status" }}
 {{ $data := dict }}{{ with .outputs }}{{ $data = . }}{{ end }} {{ if false }}

--- a/byoc-nuon/cloudformation/byoc-nuon-read-only-access/README.md
+++ b/byoc-nuon/cloudformation/byoc-nuon-read-only-access/README.md
@@ -1,0 +1,53 @@
+# BYOC Nuon Read-Only Access
+
+<!-- cf-doc md stack.yaml -->
+
+Cross-account read-only access for BYOC Nuon installs. When `InstallReadOnlyRoleArn` is provided, creates a scoped role
+assumable by that ARN with full access to the install's RDS clusters and snapshots, AWS-managed CloudWatch read-only,
+and an explicit deny on SecretsManager. When `InstallReadOnlyEnableClusterAccess` is `"true"` and the EKS cluster exists,
+also creates an AccessEntry granting the role ClusterAdmin and EKSAdmin on the cluster (cluster name is derived as
+`n-{NuonInstallID}` per the byoc-nuon convention). Omit `InstallReadOnlyRoleArn` to disable the whole stack.
+
+## Behavior
+
+- The role is named `{NuonInstallID}-ReadOnlyAccess`.
+- Parameter names match the ctl-api's auto-hoisted install-input parameter names exactly
+  (`Install` + camelCase of the input name). With no explicit `[custom_nested_stacks.parameters]` block in the parent
+  `stack.toml`, ctl-api wires these via `Ref` to the parent stack's hoisted parameters. Console edits to the parent
+  params (`InstallReadOnlyRoleArn`, `InstallReadOnlyEnableClusterAccess`) propagate to the nested stack on the next
+  changeset apply.
+- All resources are gated on `InstallReadOnlyRoleArn` being set. Clearing it on a stack update deletes the role,
+  attached policies, permission boundary, and any EKS access entry. A `WaitConditionHandle` anchors the disabled stack
+  so CloudFormation accepts it with zero managed resources. The `RoleARN` output is unconditional and resolves to an
+  empty string when disabled — the parent stack's PhoneHome custom resource always reads this output and would fail
+  on a conditional one.
+- A permission boundary caps the role to: RDS read everywhere, RDS full access on resources tagged
+  `install.nuon.co/id == {NuonInstallID}`, EKS describe/list and `eks:AccessKubernetesApi` on the install's cluster,
+  CloudWatch + Logs read, and an explicit `Deny secretsmanager:*`.
+- `InstallReadOnlyEnableClusterAccess` can only be flipped to `"true"` after the EKS cluster exists, since the
+  `AWS::EKS::AccessEntry` references it by name. Leave it `"false"` on initial creation. The cluster name is derived
+  inline as `n-${NuonInstallID}` — not a parameter — because the ctl-api custom-nested-stack handler doesn't
+  auto-inject `ClusterName`.
+- When `InstallReadOnlyEnableClusterAccess=true`, an `EKSAccessPolicy` managed policy is created and attached to the
+  role granting `eks:Describe*` and `eks:AccessKubernetesApi` on the install's cluster, plus `eks:List*` on `*`.
+  This lets the assumed role run `aws eks update-kubeconfig --name n-${NuonInstallID} --region <region>` and have
+  kubectl authenticate. Kubernetes-side RBAC is granted via the AccessEntry's `AmazonEKSClusterAdminPolicy` +
+  `AmazonEKSAdminPolicy` associations.
+- All resources are tagged with the standard Nuon trio (`install.nuon.co/id`, `org.nuon.co/id`, `app.nuon.co/id`) plus
+  `role: breakglass`.
+
+## Parameters
+
+| Name                               | Description                                                                                      |  Type  | Default | Allowed Values |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------ | :----: | :-----: | :------------- |
+| InstallReadOnlyRoleArn             | The customer-owned role ARN to grant cross-account access to. Leave empty to disable this stack. | String |         |                |
+| InstallReadOnlyEnableClusterAccess | If `"true"`, create EKS access entries on the cluster. Only enable after the cluster exists.     | String |  false  | "", true, false |
+| NuonAppID                          | The Nuon App ID. Used in tags.                                                                   | String |         |                |
+| NuonInstallID                      | The Nuon Install ID; prefixed to resource names.                                                 | String |         |                |
+| NuonOrgID                          | The Nuon Org ID. Used in tags.                                                                   | String |         |                |
+
+## Outputs
+
+| Name    | Description                                                                | Export |
+| ------- | -------------------------------------------------------------------------- | ------ |
+| RoleARN | The ARN of the read-only role. Empty string when the stack is disabled.    |        |

--- a/byoc-nuon/cloudformation/byoc-nuon-read-only-access/stack.yaml
+++ b/byoc-nuon/cloudformation/byoc-nuon-read-only-access/stack.yaml
@@ -1,0 +1,246 @@
+Description: >-
+  Cross-account read-only access for BYOC Nuon installs. When InstallReadOnlyRoleArn
+  is provided, creates a scoped role assumable by that ARN with full access to the
+  install's RDS clusters and snapshots, AWS-managed CloudWatch read-only, and an
+  explicit deny on SecretsManager. When InstallReadOnlyEnableClusterAccess is true
+  and the EKS cluster exists, also creates an AccessEntry granting the role
+  ClusterAdmin and EKSAdmin on the cluster (cluster name is derived as
+  "n-{NuonInstallID}" per the byoc-nuon convention). Omit InstallReadOnlyRoleArn
+  to disable the whole stack.
+
+  Parameter names match the auto-hoisted install input names exactly
+  ("Install" + camelCase(input name)) so ctl-api wires them via Ref to the
+  parent stack's hoisted parameters instead of baking the resolved values in
+  as literals. That lets console edits to the parent params propagate.
+
+Parameters:
+  InstallReadOnlyRoleArn:
+    Description: The customer-owned role ARN to grant cross-account access to. Leave empty to disable this stack.
+    Type: String
+    Default: ""
+
+  InstallReadOnlyEnableClusterAccess:
+    # "" is accepted because the ctl-api resolves a missing install input to ""
+    # instead of falling back to the input's toml-level default. The
+    # EnableEKSAccess condition treats anything other than "true" as disabled,
+    # so "" behaves the same as "false".
+    Description: If "true", create EKS access entries on the cluster. Only enable after the cluster exists.
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - ""
+      - "true"
+      - "false"
+
+  NuonInstallID:
+    Description: The Nuon Install ID; prefixed to resource names.
+    Type: String
+
+  NuonOrgID:
+    Description: The Nuon Org ID. Used in tags.
+    Type: String
+
+  NuonAppID:
+    Description: The Nuon App ID. Used in tags.
+    Type: String
+
+Conditions:
+  EnableStack: !Not [!Equals [!Ref InstallReadOnlyRoleArn, ""]]
+  EnableEKSAccess: !And
+    - !Condition EnableStack
+    - !Equals [!Ref InstallReadOnlyEnableClusterAccess, "true"]
+
+Resources:
+  # Anchor resource so the stack is valid even when disabled (no other resources created).
+  StackEnabledMarker:
+    Type: AWS::CloudFormation::WaitConditionHandle
+
+  PermissionBoundary:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: EnableStack
+    Properties:
+      ManagedPolicyName: !Sub ${NuonInstallID}-ReadOnlyAccess-boundary
+      Description: !Sub "Permission boundary for ${NuonInstallID}-ReadOnlyAccess breakglass role."
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: RDSDescribeAll
+            Effect: Allow
+            Action:
+              - rds:Describe*
+              - rds:List*
+            Resource: "*"
+          - Sid: RDSFullOnInstallTagged
+            Effect: Allow
+            Action: rds:*
+            Resource:
+              - !Sub arn:aws:rds:*:${AWS::AccountId}:cluster:*
+              - !Sub arn:aws:rds:*:${AWS::AccountId}:cluster-snapshot:*
+              - !Sub arn:aws:rds:*:${AWS::AccountId}:snapshot:*
+              - !Sub arn:aws:rds:*:${AWS::AccountId}:db:*
+            Condition:
+              StringEquals:
+                aws:ResourceTag/install.nuon.co/id: !Ref NuonInstallID
+          - Sid: EKSDescribeList
+            Effect: Allow
+            Action:
+              - eks:Describe*
+              - eks:List*
+            Resource: "*"
+          - Sid: EKSAccessKubernetesApi
+            Effect: Allow
+            Action: eks:AccessKubernetesApi
+            # Cluster name follows the byoc-nuon convention "n-{install_id}". The
+            # ClusterName CFN param can't be passed in from the parent stack today
+            # (ctl-api doesn't auto-inject it into custom nested stacks).
+            Resource: !Sub arn:aws:eks:*:${AWS::AccountId}:cluster/n-${NuonInstallID}
+          - Sid: CloudWatchReadOnly
+            Effect: Allow
+            Action:
+              - cloudwatch:Describe*
+              - cloudwatch:Get*
+              - cloudwatch:List*
+              - logs:Describe*
+              - logs:Get*
+              - logs:List*
+              - logs:FilterLogEvents
+              - logs:StartQuery
+              - logs:StopQuery
+              - logs:TestMetricFilter
+            Resource: "*"
+          - Sid: DenySecretsManager
+            Effect: Deny
+            Action: secretsmanager:*
+            Resource: "*"
+
+  RDSAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: EnableStack
+    Properties:
+      ManagedPolicyName: !Sub ${NuonInstallID}-ReadOnlyAccess-rds
+      Description: !Sub "Grants ${NuonInstallID}-ReadOnlyAccess full RDS access on install-tagged clusters and snapshots."
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: RDSDescribeAll
+            Effect: Allow
+            Action:
+              - rds:Describe*
+              - rds:List*
+            Resource: "*"
+          - Sid: RDSFullOnInstallTagged
+            Effect: Allow
+            Action: rds:*
+            Resource:
+              - !Sub arn:aws:rds:*:${AWS::AccountId}:cluster:*
+              - !Sub arn:aws:rds:*:${AWS::AccountId}:cluster-snapshot:*
+              - !Sub arn:aws:rds:*:${AWS::AccountId}:snapshot:*
+              - !Sub arn:aws:rds:*:${AWS::AccountId}:db:*
+            Condition:
+              StringEquals:
+                aws:ResourceTag/install.nuon.co/id: !Ref NuonInstallID
+
+  DenySecretsManagerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: EnableStack
+    Properties:
+      ManagedPolicyName: !Sub ${NuonInstallID}-ReadOnlyAccess-deny-secrets
+      Description: !Sub "Defense-in-depth deny on secretsmanager:* for ${NuonInstallID}-ReadOnlyAccess."
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenySecretsManager
+            Effect: Deny
+            Action: secretsmanager:*
+            Resource: "*"
+
+  EKSAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: EnableEKSAccess
+    Properties:
+      ManagedPolicyName: !Sub ${NuonInstallID}-ReadOnlyAccess-eks
+      Description: !Sub "EKS describe + kube-API access on cluster n-${NuonInstallID} for ${NuonInstallID}-ReadOnlyAccess."
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: EKSDescribeOnInstallCluster
+            Effect: Allow
+            # Describe* covers DescribeCluster (needed by `aws eks update-kubeconfig`),
+            # DescribeAccessEntry / DescribeAccessPolicy (diagnostics), etc.
+            Action: eks:Describe*
+            Resource: !Sub arn:aws:eks:*:${AWS::AccountId}:cluster/n-${NuonInstallID}
+          - Sid: EKSListAll
+            Effect: Allow
+            # List actions don't support resource-level conditions; they apply to the account.
+            Action: eks:List*
+            Resource: "*"
+          - Sid: EKSAccessKubernetesApi
+            Effect: Allow
+            # IAM-side auth check used by the EKS Authenticator. Kubernetes-side RBAC
+            # is controlled separately by the EKSAccessEntry resource below.
+            Action: eks:AccessKubernetesApi
+            Resource: !Sub arn:aws:eks:*:${AWS::AccountId}:cluster/n-${NuonInstallID}
+
+  ReadOnlyRole:
+    Type: AWS::IAM::Role
+    Condition: EnableStack
+    Properties:
+      RoleName: !Sub ${NuonInstallID}-ReadOnlyAccess
+      Description: !Sub "Cross-account read-only breakglass role for ${NuonInstallID}."
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Ref InstallReadOnlyRoleArn
+            Action: sts:AssumeRole
+      PermissionsBoundary: !Ref PermissionBoundary
+      ManagedPolicyArns:
+        - !Ref RDSAccessPolicy
+        - !Ref DenySecretsManagerPolicy
+        - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+        # EKSAccessPolicy is conditional — only attached when EnableEKSAccess is true,
+        # matching the EKSAccessEntry resource's gating.
+        - !If [EnableEKSAccess, !Ref EKSAccessPolicy, !Ref "AWS::NoValue"]
+      Tags:
+        - Key: Name
+          Value: !Sub ${NuonInstallID}-ReadOnlyAccess
+        - Key: install.nuon.co/id
+          Value: !Ref NuonInstallID
+        - Key: org.nuon.co/id
+          Value: !Ref NuonOrgID
+        - Key: app.nuon.co/id
+          Value: !Ref NuonAppID
+        - Key: role
+          Value: breakglass
+
+  EKSAccessEntry:
+    Type: AWS::EKS::AccessEntry
+    Condition: EnableEKSAccess
+    Properties:
+      ClusterName: !Sub n-${NuonInstallID}
+      PrincipalArn: !GetAtt ReadOnlyRole.Arn
+      Type: STANDARD
+      AccessPolicies:
+        - PolicyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy
+          AccessScope:
+            Type: cluster
+        - PolicyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy
+          AccessScope:
+            Type: cluster
+      Tags:
+        - Key: install.nuon.co/id
+          Value: !Ref NuonInstallID
+        - Key: org.nuon.co/id
+          Value: !Ref NuonOrgID
+        - Key: app.nuon.co/id
+          Value: !Ref NuonAppID
+        - Key: role
+          Value: breakglass
+
+Outputs:
+  # Unconditional so the parent stack's PhoneHomeProps custom resource can always
+  # Fn::GetAtt this output. Returns "" when the stack is disabled.
+  RoleARN:
+    Description: The ARN of the read-only role. Empty string when the stack is disabled.
+    Value: !If [EnableStack, !GetAtt ReadOnlyRole.Arn, ""]

--- a/byoc-nuon/input_groups/read_only.toml
+++ b/byoc-nuon/input_groups/read_only.toml
@@ -1,0 +1,3 @@
+name         = "read-only"
+description  = "Cross-account read-only access for this install. When enabled, a scoped IAM role is created in the install account that a customer-owned role can assume for RDS metrics inspection, CloudWatch read, and optional EKS cluster access. SecretsManager is always denied."
+display_name = "Read-Only Access"

--- a/byoc-nuon/inputs/read-only/enable_cluster_access.toml
+++ b/byoc-nuon/inputs/read-only/enable_cluster_access.toml
@@ -1,0 +1,8 @@
+name              = "read_only_enable_cluster_access"
+description       = "If true, grant the read-only role ClusterAdmin and EKSAdmin on the install's EKS cluster. Only enable after the cluster exists — leave false on initial install."
+default           = "false"
+display_name      = "Enable EKS Cluster Access"
+group             = "read-only"
+type              = "bool"
+required          = false
+user_configurable = true

--- a/byoc-nuon/inputs/read-only/role_arn.toml
+++ b/byoc-nuon/inputs/read-only/role_arn.toml
@@ -1,0 +1,7 @@
+name              = "read_only_role_arn"
+description       = "The customer-owned IAM role ARN that should be granted cross-account read-only access (RDS metrics, CloudWatch, optionally EKS) to this install. Leave empty to disable read-only access."
+default           = ""
+display_name      = "Trusted Role ARN"
+group             = "read-only"
+required          = false
+user_configurable = true

--- a/byoc-nuon/scripts/install-shell.sh
+++ b/byoc-nuon/scripts/install-shell.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS] <VENDOR_ROLE_ARN> <INSTALL_ROLE_ARN>
+
+Drop into a shell with AWS credentials for the install role via the vendor role.
+
+This script first assumes the vendor role, then uses those credentials to
+assume the install role, and spawns a subshell with the final credentials.
+
+Arguments:
+  VENDOR_ROLE_ARN    ARN of the vendor IAM role to assume first
+  INSTALL_ROLE_ARN   ARN of the install IAM role to assume via vendor role
+
+Options:
+  -s, --session      Session name for the assumed roles (default: install-shell)
+  -h, --help         Show this help message and exit
+
+Examples:
+  $(basename "$0") arn:aws:iam::111111111111:role/nuon-vendor-role arn:aws:iam::222222222222:role/nuon-delegated-role
+EOF
+  exit 0
+}
+
+AWS_PAGER=""
+SESSION_NAME="install-shell"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      ;;
+    -s|--session)
+      SESSION_NAME="$2"
+      shift 2
+      ;;
+    *)
+      if [ -z "${VENDOR_ROLE_ARN:-}" ]; then
+        VENDOR_ROLE_ARN="$1"
+      elif [ -z "${INSTALL_ROLE_ARN:-}" ]; then
+        INSTALL_ROLE_ARN="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${VENDOR_ROLE_ARN:-}" ] || [ -z "${INSTALL_ROLE_ARN:-}" ]; then
+  echo >&2 "error: VENDOR_ROLE_ARN and INSTALL_ROLE_ARN are required"
+  echo >&2 ""
+  usage
+fi
+
+set -e
+export AWS_PAGER=""
+
+echo >&2 "assuming vendor role: $VENDOR_ROLE_ARN"
+vendor_resp=$(aws sts assume-role \
+    --role-arn "$VENDOR_ROLE_ARN" \
+    --role-session-name="${SESSION_NAME}-vendor")
+
+export AWS_ACCESS_KEY_ID=$(echo "$vendor_resp" | jq -r .Credentials.AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "$vendor_resp" | jq -r .Credentials.SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo "$vendor_resp" | jq -r .Credentials.SessionToken)
+
+echo >&2 "successfully assumed vendor role"
+aws sts get-caller-identity
+
+echo >&2 "assuming install role: $INSTALL_ROLE_ARN"
+install_resp=$(aws sts assume-role \
+    --role-arn "$INSTALL_ROLE_ARN" \
+    --role-session-name="${SESSION_NAME}")
+
+export AWS_ACCESS_KEY_ID=$(echo "$install_resp" | jq -r .Credentials.AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "$install_resp" | jq -r .Credentials.SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo "$install_resp" | jq -r .Credentials.SessionToken)
+
+echo >&2 "successfully assumed install role"
+aws sts get-caller-identity
+
+echo >&2 "creating subshell"
+echo >&2 " - exit [ctrl-D] to return to original session"
+
+# exec "${SHELL:-sh}"
+exec bash --init-file <(echo 'PS1="[\033[35minstall-role\033[0m] \033[31m$\033[0m "')

--- a/byoc-nuon/stack.toml
+++ b/byoc-nuon/stack.toml
@@ -5,3 +5,14 @@ description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.instal
 # nested stack
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.1.12/vpc/eks/default/stack.yaml"
 runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/runner/asg/stack.yaml"
+
+[[custom_nested_stacks]]
+name         = "byoc_nuon_read_only_access"
+template_url = "./cloudformation/byoc-nuon-read-only-access/stack.yaml"
+index        = 0
+# No [custom_nested_stacks.parameters] block: the nested template's parameter
+# names (InstallReadOnlyRoleArn, InstallReadOnlyEnableClusterAccess) match the
+# auto-hoisted install-input parameter names on the parent stack
+# ("Install" + camelCase(input name)). ctl-api's extractNestedStackParameters
+# auto-Refs them to the parent, so console edits to the parent params propagate
+# to the nested stack on the next changeset apply.


### PR DESCRIPTION
### Description

Introduces a new [custom nested stack](https://docs.nuon.co/guides/custom-nested-stacks) for a customer-toggle-able
delegated role for cross account access with read-only permission to RDS and CloudWatch. 
Additionally, if `InstallReadOnlyEnableClusterAccess` is `true` (`false` by default) an `eks` access-entry is created with `EKSAdmin` and `EKSClusterAdmin` policies .
