### PR TITLE
feat: add timestamps to readme so we can how fresh the data is

### DIFF
--- a/byoc-nuon/README.md
+++ b/byoc-nuon/README.md
@@ -18,7 +18,7 @@
 {{ $apiSteps := dig "steps" (dict) $api }} {{ $dashSteps := dig "steps" (dict) $dash }}
 
 <details>
-<summary><nuon-group gap="2" align="center" justify="start"><strong>API</strong>{{ range $step := list "alb-healthcheck-ctl-api-public" "alb-healthcheck-ctl-api-admin" "alb-healthcheck-ctl-api-runner" }}{{ $indicator := dig $step "indicator" "" $apiSteps }}{{ if eq $indicator "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $indicator "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}{{ end }}<nuon-label-badge label="version:{{ dig "ctl_api_version" "unknown" $api }}"></nuon-label-badge><nuon-label-badge label="git:{{ dig "ctl_api_git_ref" "unknown" $api }}"></nuon-label-badge><a href="https://api.{{ $public_domain }}/docs/index.html">Open ↗</a></nuon-group></summary>
+<summary><nuon-group gap="2" align="center" justify="start"><strong>API</strong>{{ range $step := list "alb-healthcheck-ctl-api-public" "alb-healthcheck-ctl-api-admin" "alb-healthcheck-ctl-api-runner" }}{{ $indicator := dig $step "indicator" "" $apiSteps }}{{ if eq $indicator "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $indicator "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}{{ end }}<nuon-label-badge label="version:{{ dig "ctl_api_version" "unknown" $api }}"></nuon-label-badge><nuon-label-badge label="git:{{ dig "ctl_api_git_ref" "unknown" $api }}"></nuon-label-badge><a href="https://api.{{ $public_domain }}/docs/index.html">Open ↗</a>{{ with dig "updated_at" "" $api }}<span style="margin-left:auto;"><nuon-label-badge label="last updated:{{ (toDate "2006-01-02T15:04:05Z" .) | date "Jan 2 15:04 UTC" }}"></nuon-label-badge></span>{{ end }}</nuon-group></summary>
 
 **Links**
 
@@ -54,7 +54,7 @@ nuon -f ~/.nuon.byoc login
 </details>
 
 <details>
-<summary><nuon-group gap="2" align="center" justify="start"><strong>Dashboard</strong>{{ $indicator := dig "alb-healthcheck-dashboard-ui" "indicator" "" $dashSteps }}{{ if eq $indicator "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $indicator "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}<nuon-label-badge label="version:{{ dig "dashboard_ui_version" "unknown" $dash }}"></nuon-label-badge><nuon-label-badge label="git:{{ dig "dashboard_ui_git_ref" "unknown" $dash }}"></nuon-label-badge><a href="https://app.{{ $public_domain }}">Open ↗</a></nuon-group></summary>
+<summary><nuon-group gap="2" align="center" justify="start"><strong>Dashboard</strong>{{ $indicator := dig "alb-healthcheck-dashboard-ui" "indicator" "" $dashSteps }}{{ if eq $indicator "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $indicator "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}<nuon-label-badge label="version:{{ dig "dashboard_ui_version" "unknown" $dash }}"></nuon-label-badge><nuon-label-badge label="git:{{ dig "dashboard_ui_git_ref" "unknown" $dash }}"></nuon-label-badge><a href="https://app.{{ $public_domain }}">Open ↗</a>{{ with dig "updated_at" "" $dash }}<span style="margin-left:auto;"><nuon-label-badge label="last updated:{{ (toDate "2006-01-02T15:04:05Z" .) | date "Jan 2 15:04 UTC" }}"></nuon-label-badge></span>{{ end }}</nuon-group></summary>
 
 **Links**
 
@@ -137,8 +137,9 @@ aws --region {{ .nuon.install_stack.outputs.region }} \
 {{ end }}
 {{ end }}
 
+{{ $statusOutputs := dict }}{{ with (index (default dict .nuon.actions.workflows) "status_report") }}{{ with .outputs }}{{ $statusOutputs = . }}{{ end }}{{ end }}
 <details>
-<summary><strong>Status</strong></summary>
+<summary><nuon-group gap="2" align="center" justify="start"><strong>Status</strong>{{ with dig "updated_at" "" $statusOutputs }}<span style="margin-left:auto;"><nuon-label-badge label="last updated:{{ (toDate "2006-01-02T15:04:05Z" .) | date "Jan 2 15:04 UTC" }}"></nuon-label-badge></span>{{ end }}</nuon-group></summary>
 
 {{ with (index (default dict .nuon.actions.workflows) "status_report") }}
 {{ $steps := dict }}{{ with .outputs }}{{ with .steps }}{{ $steps = . }}{{ end }}{{ end }}
@@ -371,8 +372,9 @@ section.</nuon-banner>
 
 </details>
 
+{{ $wfOutputs := dict }}{{ with (index (default dict .nuon.actions.workflows) "ctl_api_query_workflows_by_type") }}{{ with .outputs }}{{ $wfOutputs = . }}{{ end }}{{ end }}
 <details>
-<summary><strong>Workflows</strong></summary>
+<summary><nuon-group gap="2" align="center" justify="start"><strong>Workflows</strong>{{ with dig "updated_at" "" $wfOutputs }}<span style="margin-left:auto;"><nuon-label-badge label="last updated:{{ (toDate "2006-01-02T15:04:05Z" .) | date "Jan 2 15:04 UTC" }}"></nuon-label-badge></span>{{ end }}</nuon-group></summary>
 
 {{ with (index (default dict .nuon.actions.workflows) "ctl_api_query_workflows_by_type") }}
 {{ $wfData := dict }}{{ with .outputs }}{{ $wfData = . }}{{ end }} {{ $wfRows := dig "workflows" (list) $wfData }}

--- a/byoc-nuon/actions/ctl_api/api_status/api_status.toml
+++ b/byoc-nuon/actions/ctl_api/api_status/api_status.toml
@@ -41,3 +41,7 @@ inline_contents = "./ctl_api/api_status/healthcheck.sh"
 [steps.env_vars]
 INGRESS_NAME      = "ctl-api-runner"
 INGRESS_NAMESPACE = "ctl-api"
+
+[[steps]]
+name            = "timestamp"
+inline_contents = "./ctl_api/api_status/timestamp.sh"

--- a/byoc-nuon/actions/ctl_api/api_status/timestamp.sh
+++ b/byoc-nuon/actions/ctl_api/api_status/timestamp.sh
@@ -1,0 +1,1 @@
+../../../../shared/actions/src/timestamp.sh

--- a/byoc-nuon/actions/ctl_api/ctl_api_query_workflows_by_type/ctl_api_query_workflows_by_type.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_query_workflows_by_type/ctl_api_query_workflows_by_type.toml
@@ -22,3 +22,7 @@ DB_ADDR        = "{{ .nuon.components.rds_cluster_nuon.outputs.address }}"
 DB_PORT        = "5432"
 REGION         = "{{ .nuon.install_stack.outputs.region }}"
 LIMIT          = "25"
+
+[[steps]]
+name            = "timestamp"
+inline_contents = "./ctl_api/ctl_api_query_workflows_by_type/timestamp.sh"

--- a/byoc-nuon/actions/ctl_api/ctl_api_query_workflows_by_type/timestamp.sh
+++ b/byoc-nuon/actions/ctl_api/ctl_api_query_workflows_by_type/timestamp.sh
@@ -1,0 +1,1 @@
+../../../../shared/actions/src/timestamp.sh

--- a/byoc-nuon/actions/ctl_api/dashboard_status/dashboard_status.toml
+++ b/byoc-nuon/actions/ctl_api/dashboard_status/dashboard_status.toml
@@ -30,3 +30,7 @@ inline_contents = "./ctl_api/dashboard_status/healthcheck.sh"
 [steps.env_vars]
 INGRESS_NAME      = "dashboard-ui"
 INGRESS_NAMESPACE = "dashboard-ui"
+
+[[steps]]
+name            = "timestamp"
+inline_contents = "./ctl_api/dashboard_status/timestamp.sh"

--- a/byoc-nuon/actions/ctl_api/dashboard_status/timestamp.sh
+++ b/byoc-nuon/actions/ctl_api/dashboard_status/timestamp.sh
@@ -1,0 +1,1 @@
+../../../../shared/actions/src/timestamp.sh

--- a/shared/actions/src/timestamp.sh
+++ b/shared/actions/src/timestamp.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Emits `{updated_at: <ISO8601 UTC>}` to the action outputs. Used by
+# README-populating actions so each section can render the time its
+# data was last refreshed.
+
+set -euo pipefail
+
+jq -nc --arg ts "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" '{updated_at: $ts}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"


### PR DESCRIPTION
## Problem

It should be easier to see when the data in the readme was last updated.

## Solution

This PR saves a timestamp at the end of each status action used for the README, and displays them in each section.