### PR TITLE
fix: bump curl timeout for updating runner versions

### DIFF
--- a/byoc-nuon/actions/ctl_api/ctl_api_post_deploy/update-version.sh
+++ b/byoc-nuon/actions/ctl_api/ctl_api_post_deploy/update-version.sh
@@ -33,7 +33,7 @@ update_runners() {
     url="$admin_api_url/v1/runners/$runner_id/settings"
 
     curl_rc=0
-    http_code=$(curl -s --max-time 10 -X PATCH "$url" \
+    http_code=$(curl -s --max-time 30 -X PATCH "$url" \
       -H "Content-Type: application/json" \
       -d "{\"container_image_tag\": \"$RUNNER_CONTAINER_IMAGE_TAG\", \"binary_version\": \"$RUNNER_CONTAINER_IMAGE_TAG\"}" \
       -w "\n%{http_code}" \


### PR DESCRIPTION
Updating the runner version is intermittently failing.

<img width="296" height="502" alt="image" src="https://github.com/user-attachments/assets/9567607a-726c-4e60-acea-92ceeb94ad09" />
