### PR TITLE
feat(ctl-api): per-deployment resource overrides for ctl-api subdeployments

### DIFF
--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -276,15 +276,28 @@ api:
     port: 8081
     domain: "api.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
     domain_certificate: "{{ .nuon.components.certificate_wildcard_public.outputs.public_domain_certificate_arn }}"
-    resources:
-      requests:
-        cpu: 1000m
-        memory: 2048Mi
     autoscaling:
       minReplicas: 3
       maxReplicas: 10
       targetCPUUtilizationPercentage: 75
       targetMemoryUtilizationPercentage: 75
+    # Unset ctl_api_public_* inputs render as missing fields and inherit
+    # api.resources via the ctl_api.containerResources helper.
+    resources:
+      limits:
+        {{- with .nuon.inputs.inputs.ctl_api_public_cpu_limit }}
+        cpu: {{ . }}
+        {{- end }}
+        {{- with .nuon.inputs.inputs.ctl_api_public_memory_limit }}
+        memory: {{ . }}
+        {{- end }}
+      requests:
+        {{- with .nuon.inputs.inputs.ctl_api_public_cpu_request }}
+        cpu: {{ . }}
+        {{- end }}
+        {{- with .nuon.inputs.inputs.ctl_api_public_memory_request }}
+        memory: {{ . }}
+        {{- end }}
   admin:
     port: 8082
     domain: "admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"

--- a/byoc-nuon/inputs/nuon/ctl_api_public_cpu_limit.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_cpu_limit.toml
@@ -1,0 +1,8 @@
+name         = "ctl_api_public_cpu_limit"
+description  = "Override the CPU limit for the ctl-api-public deployment (e.g. \"500m\", \"1\"). Leave empty to inherit the shared ctl-api default."
+default      = ""
+display_name = "ctl-api-public CPU limit"
+required     = false
+group        = "nuon"
+
+user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_cpu_request.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_cpu_request.toml
@@ -1,0 +1,8 @@
+name         = "ctl_api_public_cpu_request"
+description  = "Override the CPU request for the ctl-api-public deployment (e.g. \"500m\", \"1\"). Leave empty to inherit the shared ctl-api default."
+default      = ""
+display_name = "ctl-api-public CPU request"
+required     = false
+group        = "nuon"
+
+user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_memory_limit.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_memory_limit.toml
@@ -1,0 +1,8 @@
+name         = "ctl_api_public_memory_limit"
+description  = "Override the memory limit for the ctl-api-public deployment (e.g. \"2048Mi\", \"2Gi\"). Leave empty to inherit the shared ctl-api default."
+default      = ""
+display_name = "ctl-api-public memory limit"
+required     = false
+group        = "nuon"
+
+user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_memory_request.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_memory_request.toml
@@ -1,0 +1,8 @@
+name         = "ctl_api_public_memory_request"
+description  = "Override the memory request for the ctl-api-public deployment (e.g. \"2048Mi\", \"2Gi\"). Leave empty to inherit the shared ctl-api default."
+default      = ""
+display_name = "ctl-api-public memory request"
+required     = false
+group        = "nuon"
+
+user_configurable = false

--- a/shared/src/components/ctl_api/templates/api_admin_deployment.tpl
+++ b/shared/src/components/ctl_api/templates/api_admin_deployment.tpl
@@ -72,12 +72,7 @@ spec:
               path: {{ .Values.api.liveness_probe }}
               port: http-internal
           resources:
-            limits:
-              cpu: {{ .Values.api.resources.limits.cpu }}
-              memory: {{ .Values.api.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.api.resources.requests.cpu }}
-              memory: {{ .Values.api.resources.requests.memory }}
+            {{- include "ctl_api.containerResources" (dict "api" .Values.api "name" "admin") | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" . }}

--- a/shared/src/components/ctl_api/templates/api_auth_deployment.tpl
+++ b/shared/src/components/ctl_api/templates/api_auth_deployment.tpl
@@ -73,12 +73,7 @@ spec:
               path: {{ .Values.api.liveness_probe }}
               port: http-internal
           resources:
-            limits:
-              cpu: {{ .Values.api.resources.limits.cpu }}
-              memory: {{ .Values.api.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.api.resources.requests.cpu }}
-              memory: {{ .Values.api.resources.requests.memory }}
+            {{- include "ctl_api.containerResources" (dict "api" .Values.api "name" "auth") | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" . }}

--- a/shared/src/components/ctl_api/templates/api_public_deployment.tpl
+++ b/shared/src/components/ctl_api/templates/api_public_deployment.tpl
@@ -79,12 +79,7 @@ spec:
               path: {{ .Values.api.liveness_probe}}
               port: http
           resources:
-            limits:
-              cpu: {{ .Values.api.resources.limits.cpu }}
-              memory: {{ .Values.api.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.api.resources.requests.cpu }}
-              memory: {{ .Values.api.resources.requests.memory }}
+            {{- include "ctl_api.containerResources" (dict "api" .Values.api "name" "public") | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" . }}

--- a/shared/src/components/ctl_api/templates/api_runner_deployment.tpl
+++ b/shared/src/components/ctl_api/templates/api_runner_deployment.tpl
@@ -79,12 +79,7 @@ spec:
               path: {{ .Values.api.liveness_probe}}
               port: http-runner
           resources:
-            limits:
-              cpu: {{ .Values.api.resources.limits.cpu }}
-              memory: {{ .Values.api.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.api.resources.requests.cpu }}
-              memory: {{ .Values.api.resources.requests.memory }}
+            {{- include "ctl_api.containerResources" (dict "api" .Values.api "name" "runner") | nindent 12 }}
           volumeMounts:
             - name: iid-certs
               mountPath: /etc/nuon/iid-certs

--- a/shared/src/components/ctl_api/templates/api_slack_deployment.tpl
+++ b/shared/src/components/ctl_api/templates/api_slack_deployment.tpl
@@ -80,12 +80,7 @@ spec:
               path: {{ .Values.api.liveness_probe }}
               port: http-internal
           resources:
-            limits:
-              cpu: {{ .Values.api.resources.limits.cpu }}
-              memory: {{ .Values.api.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.api.resources.requests.cpu }}
-              memory: {{ .Values.api.resources.requests.memory }}
+            {{- include "ctl_api.containerResources" (dict "api" .Values.api "name" "slack") | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" . }}

--- a/shared/src/components/ctl_api/templates/deployment_startup.tpl
+++ b/shared/src/components/ctl_api/templates/deployment_startup.tpl
@@ -63,12 +63,7 @@ spec:
             - -f
             - /dev/null
           resources:
-            limits:
-              cpu: {{ .Values.api.resources.limits.cpu }}
-              memory: {{ .Values.api.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.api.resources.requests.cpu }}
-              memory: {{ .Values.api.resources.requests.memory }}
+            {{- include "ctl_api.containerResources" (dict "api" .Values.api "name" "startup") | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" . }}

--- a/shared/src/components/ctl_api/templates/lib/_resources.tpl
+++ b/shared/src/components/ctl_api/templates/lib/_resources.tpl
@@ -1,0 +1,24 @@
+{{- /*
+ctl_api.containerResources renders the container "resources:" body
+(limits/requests) by overlaying .Values.api.<name>.resources on the shared
+.Values.api.resources base. Missing fields in the override silently fall
+back to the base, so callers can tune only what they need.
+
+Usage:
+  resources:
+    {{- include "ctl_api.containerResources" (dict "api" .Values.api "name" "public") | nindent 12 }}
+*/}}
+{{- define "ctl_api.containerResources" -}}
+{{- $base := default (dict) .api.resources -}}
+{{- $override := dig .name "resources" (dict) .api -}}
+{{- $baseLimits := default (dict) $base.limits -}}
+{{- $baseRequests := default (dict) $base.requests -}}
+{{- $overrideLimits := default (dict) $override.limits -}}
+{{- $overrideRequests := default (dict) $override.requests -}}
+limits:
+  cpu: {{ default $baseLimits.cpu $overrideLimits.cpu }}
+  memory: {{ default $baseLimits.memory $overrideLimits.memory }}
+requests:
+  cpu: {{ default $baseRequests.cpu $overrideRequests.cpu }}
+  memory: {{ default $baseRequests.memory $overrideRequests.memory }}
+{{- end }}


### PR DESCRIPTION
## Summary

Each `ctl-api` subdeployment (public, admin, auth, runner, slack, startup) can now have its own CPU and memory requests/limits, overlaid on the shared `api.resources` defaults. Subdeployments with no override keep the existing shared values.

## What you can do after this PR

**Size the public API independently from the rest of `ctl-api`.** Four new BYOC inputs (`ctl_api_public_cpu_request`, `ctl_api_public_cpu_limit`, `ctl_api_public_memory_request`, `ctl_api_public_memory_limit`) flow into `api.public.resources` and are applied only to the public deployment.

## What stays the same

Installs that do not set any of the new inputs render exactly the same as before: all subdeployments inherit `api.resources`. Empty input values are filtered out so they do not collapse the shared defaults to zero.

