### PR TITLE
fix(byoc-nuon): remove blank line that hid user_configurable from Nuon parser

### DIFF
--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -282,20 +282,21 @@ api:
       targetCPUUtilizationPercentage: 75
       targetMemoryUtilizationPercentage: 75
     # Unset ctl_api_public_* inputs render as missing fields and inherit
-    # api.resources via the ctl_api.containerResources helper.
+    # api.resources via the ctl_api.containerResources helper. `index` is
+    # used so missing input keys return nil instead of raising.
     resources:
       limits:
-        {{- with .nuon.inputs.inputs.ctl_api_public_cpu_limit }}
+        {{- with index .nuon.inputs.inputs "ctl_api_public_cpu_limit" }}
         cpu: {{ . }}
         {{- end }}
-        {{- with .nuon.inputs.inputs.ctl_api_public_memory_limit }}
+        {{- with index .nuon.inputs.inputs "ctl_api_public_memory_limit" }}
         memory: {{ . }}
         {{- end }}
       requests:
-        {{- with .nuon.inputs.inputs.ctl_api_public_cpu_request }}
+        {{- with index .nuon.inputs.inputs "ctl_api_public_cpu_request" }}
         cpu: {{ . }}
         {{- end }}
-        {{- with .nuon.inputs.inputs.ctl_api_public_memory_request }}
+        {{- with index .nuon.inputs.inputs "ctl_api_public_memory_request" }}
         memory: {{ . }}
         {{- end }}
   admin:

--- a/byoc-nuon/inputs/email/loops_api_key.toml
+++ b/byoc-nuon/inputs/email/loops_api_key.toml
@@ -4,5 +4,4 @@ default      = "your-loops-api-key"
 display_name = "Loops API Key"
 group        = "email"
 required     = false
-
 user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_cpu_limit.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_cpu_limit.toml
@@ -4,5 +4,4 @@ default      = ""
 display_name = "ctl-api-public CPU limit"
 required     = false
 group        = "nuon"
-
 user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_cpu_request.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_cpu_request.toml
@@ -4,5 +4,4 @@ default      = ""
 display_name = "ctl-api-public CPU request"
 required     = false
 group        = "nuon"
-
 user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_memory_limit.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_memory_limit.toml
@@ -4,5 +4,4 @@ default      = ""
 display_name = "ctl-api-public memory limit"
 required     = false
 group        = "nuon"
-
 user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_memory_request.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_memory_request.toml
@@ -4,5 +4,4 @@ default      = ""
 display_name = "ctl-api-public memory request"
 required     = false
 group        = "nuon"
-
 user_configurable = false


### PR DESCRIPTION
**Drop the blank line above `user_configurable` in five input files.** Nuon's TOML parser treats a blank line as a section break, so anything after it gets ignored at the top level. With the blank line in place, the existing `user_configurable = false` lines were silently dropped and the inputs were registered with `source` derived from missing data. 
**Template lookups switch to `index`.** `{{ with index .nuon.inputs.inputs "ctl_api_public_cpu_limit" }}` returns nil silently when the key is absent, so `with` skips the field and the helper falls back to `api.resources`. Without this, installs that omit the inputs raised `map has no entry for key "..."`.


