### PR TITLE
chore: auto sync byoc-nuon-gcp to byoc org

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -3,6 +3,7 @@ on:
     branches: main
     paths:
       - "byoc-nuon/**"
+      - "byoc-nuon-gcp/**"
   workflow_dispatch:
     inputs:
       NUON_DEBUG:
@@ -64,3 +65,12 @@ jobs:
         env:
           NUON_ORG_ID: orggxqsc8f5zns1jra0oplc0ff
           NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN_orggxqsc8f5zns1jra0oplc0ff }}
+
+      - name: Sync GCP to BYOC(org4f5hq4tyo44legra6r4nm18)
+        if: steps.check_label.outputs.skip != 'true'
+        id: sync_gcp_to_org4f5hq4tyo44legra6r4nm18
+        working-directory: byoc-nuon-gcp
+        run: nuon apps sync .
+        env:
+          NUON_ORG_ID: org4f5hq4tyo44legra6r4nm18
+          NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN_org4f5hq4tyo44legra6r4nm18 }}

--- a/byoc-nuon/actions/kubectl_deployment_resources.toml
+++ b/byoc-nuon/actions/kubectl_deployment_resources.toml
@@ -1,0 +1,17 @@
+# action
+# description: per-deployment resource requests/limits, current top usage per pod,
+# and any OOMKilled containers in a namespace. Output is json.
+# Set NAMESPACE to target a namespace (default ctl-api).
+name    = "kubectl_deployment_resources"
+label   = "kubectl"
+timeout = "1m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "exec"
+inline_contents = "./src/kubectl/deployment-resources.sh"
+
+[steps.env_vars]
+NAMESPACE = "ctl-api"

--- a/byoc-nuon/actions/src/kubectl/deployment-resources.sh
+++ b/byoc-nuon/actions/src/kubectl/deployment-resources.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# emits per-deployment resource requests/limits, current top usage per pod,
+# and any OOMKilled containers as a single json blob to the action output.
+# env:
+#   NAMESPACE - namespace to inspect (default: ctl-api)
+
+set -euo pipefail
+
+: "${NAMESPACE:=ctl-api}"
+
+echo "namespace=${NAMESPACE}"
+
+workdir=$(mktemp -d)
+trap 'rm -rf "${workdir}"' EXIT
+
+kubectl -n "${NAMESPACE}" get deployments -o json > "${workdir}/deployments.json"
+kubectl -n "${NAMESPACE}" get pods -o json > "${workdir}/pods.json"
+
+# kubectl top may fail if metrics-server is unhealthy; fall back to empty usage.
+kubectl -n "${NAMESPACE}" top pods --no-headers 2>/dev/null \
+  | awk 'NF>=3 {printf "{\"name\":\"%s\",\"cpu\":\"%s\",\"memory\":\"%s\"}\n", $1, $2, $3}' \
+  | jq -s '.' > "${workdir}/top.json" || echo '[]' > "${workdir}/top.json"
+
+result=$(jq -c \
+  --slurpfile pods "${workdir}/pods.json" \
+  --slurpfile top "${workdir}/top.json" \
+  '($pods[0]) as $pods
+   | ($top[0]) as $top
+   | {namespace: env.NAMESPACE, deployments: [.items[] as $d
+    | ($d.spec.selector.matchLabels // {}) as $sel
+    | ($pods.items
+        | map(select(
+            (.metadata.labels // {}) as $labels
+            | ($sel | to_entries | all(.value == $labels[.key]))
+          ))
+      ) as $deployment_pods
+    | {
+        deployment: $d.metadata.name,
+        replicas: $d.spec.replicas,
+        ready_replicas: ($d.status.readyReplicas // 0),
+        containers: [$d.spec.template.spec.containers[] | {
+          name: .name,
+          requests: (.resources.requests // {}),
+          limits: (.resources.limits // {})
+        }],
+        pods: [$deployment_pods[] | . as $pod | {
+          name: $pod.metadata.name,
+          phase: $pod.status.phase,
+          restart_count: ([(($pod.status.containerStatuses // [])[]).restartCount] | add // 0),
+          oom_killed: ([
+            ($pod.status.containerStatuses // [])[]
+            | select((.lastState.terminated.reason // "") == "OOMKilled"
+                  or (.state.terminated.reason // "") == "OOMKilled")
+          ] | length > 0),
+          oom_containers: [
+            ($pod.status.containerStatuses // [])[]
+            | select((.lastState.terminated.reason // "") == "OOMKilled"
+                  or (.state.terminated.reason // "") == "OOMKilled")
+            | .name
+          ],
+          usage: ($top | map(select(.name == $pod.metadata.name)) | .[0] // null)
+        }]
+      }
+   ]}' "${workdir}/deployments.json")
+
+echo "${result}" | jq
+echo "${result}" >> "${NUON_ACTIONS_OUTPUT_FILEPATH}"


### PR DESCRIPTION
## What

Adds auto-sync for the `byoc-nuon-gcp` app, which previously was not synced anywhere.

## Changes

- Add `byoc-nuon-gcp/**` to the push path filter so changes to the GCP app trigger the sync workflow.
- Add a `Sync GCP to BYOC(org4f5hq4tyo44legra6r4nm18)` step running `nuon apps sync .` from `byoc-nuon-gcp` into the byoc org, reusing the existing `skip-sync` label gate and the `NUON_API_TOKEN_org4f5hq4tyo44legra6r4nm18` secret.