### PR TITLE
chore: wire slack envSecrets and bump ctl-api chart to v0.3.1

### DIFF
--- a/byoc-nuon/components/92-helm-ctl_api.toml
+++ b/byoc-nuon/components/92-helm-ctl_api.toml
@@ -9,7 +9,7 @@ dependencies   = ["rds_cluster_nuon", "karpenter_nodepools", "clickhouse_cluster
 [public_repo]
 repo      = "nuonco/charts"
 directory = "charts/ctl-api"
-branch    = "ctl-api-v0.3.0"
+branch    = "ctl-api-v0.3.1"
 
 [[values_file]]
 contents = "./values/ctl-api.yaml"

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -131,6 +131,21 @@ envSecrets:
     valueFrom:
       name: clickhouse-cluster-pw
       key: value
+  - name: "SLACK_CLIENT_SECRET"
+    optional: true
+    valueFrom:
+      name: ctl-api-slack-client-secret
+      key: value
+  - name: "SLACK_SIGNING_SECRET"
+    optional: true
+    valueFrom:
+      name: ctl-api-slack-signing-secret
+      key: value
+  - name: "SLACK_STATE_JWT_SECRET"
+    optional: true
+    valueFrom:
+      name: ctl-api-slack-state-jwt-secret
+      key: value
 
 image:
   repository: "{{ .nuon.components.img_nuon_ctl_api.outputs.image.repository }}"


### PR DESCRIPTION
Wires SLACK_CLIENT_SECRET/SIGNING_SECRET/STATE_JWT_SECRET into AWS ctl-api envSecrets and bumps the chart pin to ctl-api-v0.3.1 (nuonco/charts#14, optional secret refs).