### PR TITLE
feat(byoc-nuon): central-secret Slack enablement + enable_slack runbook

### DIFF
--- a/byoc-nuon/actions/slack/sync_slack_secrets/sync-slack-secrets.sh
+++ b/byoc-nuon/actions/slack/sync_slack_secrets/sync-slack-secrets.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# sync-slack-secrets
+#
+# Reads the central Slack secret (JSON with client_secret and signing_secret)
+# from infra-shared-prod's AWS Secrets Manager, writes it to the install's
+# ctl-api namespace as ctl-api-slack-{client,signing}-secret, then restarts
+# the api-slack deployment.
+#
+# state_jwt is intentionally left alone — it's auto-generated and
+# kubernetes-synced by the Nuon platform.
+#
+# Required env:
+#   SLACK_SECRETS_ARN  - full ARN of the central secret. Empty => skip (no-op).
+#   NAMESPACE          - k8s namespace for ctl-api (default ctl-api).
+#
+# Cross-account reads do not need explicit assume-role. The install's
+# maintenance role has secretsmanager:GetSecretValue + kms:Decrypt on "*";
+# the central secret's resource policy and the CMK's key policy allow this
+# role by ARN.
+set -euo pipefail
+set -o errtrace
+
+: "${NAMESPACE:=ctl-api}"
+
+if [[ -z "${SLACK_SECRETS_ARN:-}" ]]; then
+  echo "SLACK_SECRETS_ARN is empty; Slack is not enabled for this install. Nothing to do."
+  exit 0
+fi
+
+# Region is encoded in the ARN: arn:aws:secretsmanager:<region>:<acct>:secret:<name>-<suffix>
+SECRETS_REGION=$(echo "$SLACK_SECRETS_ARN" | awk -F: '{print $4}')
+if [[ -z "$SECRETS_REGION" ]]; then
+  echo "could not parse region from SLACK_SECRETS_ARN: $SLACK_SECRETS_ARN" >&2
+  exit 1
+fi
+
+echo "reading central Slack secret"
+echo "  arn:    $SLACK_SECRETS_ARN"
+echo "  region: $SECRETS_REGION"
+
+VALUE=$(aws --region "$SECRETS_REGION" secretsmanager get-secret-value \
+  --secret-id "$SLACK_SECRETS_ARN" \
+  --query SecretString --output text)
+
+CLIENT_SECRET=$(echo "$VALUE" | jq -er '.client_secret')
+SIGNING_SECRET=$(echo "$VALUE" | jq -er '.signing_secret')
+
+if [[ -z "$CLIENT_SECRET" || -z "$SIGNING_SECRET" ]]; then
+  echo "central secret missing client_secret or signing_secret fields" >&2
+  exit 1
+fi
+
+apply_secret() {
+  local name="$1" value="$2"
+  echo "applying secret $NAMESPACE/$name"
+  # --dry-run=client | apply keeps this idempotent without leaking value to argv
+  kubectl create secret generic "$name" \
+    -n "$NAMESPACE" \
+    --from-literal=value="$value" \
+    --dry-run=client -o yaml \
+    | kubectl apply -f -
+}
+
+apply_secret ctl-api-slack-client-secret  "$CLIENT_SECRET"
+apply_secret ctl-api-slack-signing-secret "$SIGNING_SECRET"
+
+# Restart api-slack so it re-reads the secret values.
+# Matches whatever the chart fullname renders to; -l label is more durable
+# than a hard-coded deployment name across chart-version bumps.
+if kubectl -n "$NAMESPACE" get deploy -l app.nuon.co/name=ctl-api-slack -o name | grep -q deploy; then
+  echo "restarting api-slack deployment"
+  kubectl -n "$NAMESPACE" rollout restart deploy -l app.nuon.co/name=ctl-api-slack
+else
+  echo "no api-slack deployment found in $NAMESPACE; secrets applied, restart skipped"
+fi
+
+echo "done"

--- a/byoc-nuon/actions/slack/sync_slack_secrets/sync_slack_secrets.toml
+++ b/byoc-nuon/actions/slack/sync_slack_secrets/sync_slack_secrets.toml
@@ -1,0 +1,19 @@
+# action
+# description: Fetches the Slack client/signing secrets from the central
+# AWS Secrets Manager entry referenced by SLACK_SECRETS_ARN and writes them
+# into the install's ctl-api namespace, then restarts api-slack so it picks
+# up the new values. Skips cleanly when SLACK_SECRETS_ARN is empty.
+name    = "sync_slack_secrets"
+label   = "slack"
+timeout = "2m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "sync"
+inline_contents = "./slack/sync_slack_secrets/sync-slack-secrets.sh"
+
+[steps.env_vars]
+SLACK_SECRETS_ARN = "{{ or .nuon.inputs.inputs.slack_secrets_arn \"\" }}"
+NAMESPACE         = "ctl-api"

--- a/byoc-nuon/inputs/slack/slack_secrets_arn.toml
+++ b/byoc-nuon/inputs/slack/slack_secrets_arn.toml
@@ -1,0 +1,8 @@
+name         = "slack_secrets_arn"
+description  = "ARN of the AWS Secrets Manager secret in the central account that holds this install's Slack app credentials. JSON value with keys client_secret and signing_secret. Leave empty to keep Slack disabled."
+default      = ""
+display_name = "Slack Secrets ARN"
+required     = false
+group        = "slack"
+
+user_configurable = false

--- a/byoc-nuon/runbooks/enable_slack.md
+++ b/byoc-nuon/runbooks/enable_slack.md
@@ -1,0 +1,11 @@
+Pulls the install's Slack Client Secret and Signing Secret from the central AWS Secrets Manager entry referenced by the `slack_secrets_arn` input, writes them into the `ctl-api` namespace, and restarts `api-slack` so it picks them up.
+
+Use this after the central secret is provisioned (in `infra-shared-prod`, with a per-install CMK and resource policy that names this install's `*-maintenance` role) and after `slack_enabled`, `slack_client_id`, and `slack_secrets_arn` are set on the install. Also re-run after rotating the Slack Client Secret or Signing Secret.
+
+`ctl-api-slack-state-jwt-secret` is intentionally untouched — Nuon auto-generates and kubernetes-syncs it.
+
+**Actions**
+
+| Action | Populates |
+|---|---|
+| `sync_slack_secrets` | `ctl-api-slack-client-secret`, `ctl-api-slack-signing-secret`, and rolls `api-slack` |

--- a/byoc-nuon/runbooks/enable_slack.toml
+++ b/byoc-nuon/runbooks/enable_slack.toml
@@ -1,0 +1,8 @@
+name        = "enable_slack"
+description = "Enables api-slack for this install: syncs Slack client/signing secrets from the central AWS Secrets Manager into the install's ctl-api namespace and restarts api-slack."
+readme      = "./runbooks/enable_slack.md"
+
+[[steps]]
+name        = "Sync slack secrets"
+type        = "action"
+action_name = "sync_slack_secrets"

--- a/byoc-nuon/secrets/slack/client_secret.toml
+++ b/byoc-nuon/secrets/slack/client_secret.toml
@@ -1,10 +1,6 @@
 name         = "slack_client_secret"
 display_name = "Slack Client Secret"
-description  = "Client Secret from your Slack app's Basic Information page. Leave default to disable the Slack integration."
+description  = "Client Secret from your Slack app's Basic Information page. Managed out-of-band: the central AWS Secrets Manager entry referenced by slack_secrets_arn is the source of truth, and the sync_slack_secrets action writes the value into k8s."
 default      = "dne" # "empty" value — disables Slack integration
-
-kubernetes_sync             = true
-kubernetes_secret_namespace = "ctl-api"
-kubernetes_secret_name      = "ctl-api-slack-client-secret"
 
 user_configurable = true

--- a/byoc-nuon/secrets/slack/signing_secret.toml
+++ b/byoc-nuon/secrets/slack/signing_secret.toml
@@ -1,10 +1,6 @@
 name         = "slack_signing_secret"
 display_name = "Slack Signing Secret"
-description  = "Signing Secret from your Slack app's Basic Information page. Used to verify signed Slack webhook requests (events, slash commands, interactions). Leave default to disable the Slack integration."
+description  = "Signing Secret from your Slack app's Basic Information page. Used to verify signed Slack webhook requests (events, slash commands, interactions). Managed out-of-band: the central AWS Secrets Manager entry referenced by slack_secrets_arn is the source of truth, and the sync_slack_secrets action writes the value into k8s."
 default      = "dne" # "empty" value — disables Slack integration
-
-kubernetes_sync             = true
-kubernetes_secret_namespace = "ctl-api"
-kubernetes_secret_name      = "ctl-api-slack-signing-secret"
 
 user_configurable = true


### PR DESCRIPTION
New sync_slack_secrets action reads the central infra-shared-prod secret referenced by slack_secrets_arn and writes ctl-api-slack-{client,signing}-secret into the install. Adds enable_slack runbook, drops kubernetes_sync from those two secret tomls. state_jwt_secret stays Nuon-managed.