### PR TITLE
fix: add pre/post deploy hooks for ctl-api deploy run book

### DIFF
--- a/byoc-nuon/runbooks/deploy_control_plane.toml
+++ b/byoc-nuon/runbooks/deploy_control_plane.toml
@@ -13,13 +13,31 @@ type           = "deploy"
 component_name = "img_nuon_ctl_api"
 
 [[steps]]
+name        = "Initialize the ctl-api DB"
+type        = "action"
+action_name = "ctl_api_init_db"
+
+[[steps]]
+name        = "Initialize ClickHouse"
+type        = "action"
+action_name = "ch_init"
+
+[[steps]]
 name            = "Deploy helm chart"
 type            = "deploy"
 component_name  = "ctl_api"
-deploy_triggers = "true"
+
+[[steps]]
+name        = "ctl-api post-deploy startup"
+type        = "action"
+action_name = "ctl_api_post_deploy_startup"
+
+[[steps]]
+name        = "ctl-api post-deploy"
+type        = "action"
+action_name = "ctl_api_post_deploy"
 
 [[steps]]
 name            = "Deploy dashboard helm chart"
 type            = "deploy"
 component_name  = "dashboard_ui"
-deploy_triggers = "true"


### PR DESCRIPTION
The component deploy actions don't automatically fire on runbooks. We could add this, but after waffling on it, I think it may be better to do it explicitly. 

@fidiego Should we drop the init db actions from this runbook?