### PR TITLE
chore(karpenter): use the ami alias from the input

### DIFF
--- a/byoc-nuon/components/values/karpenter-nodepools.yaml
+++ b/byoc-nuon/components/values/karpenter-nodepools.yaml
@@ -2,6 +2,7 @@ karpenter:
   discovery_key: "{{ .nuon.sandbox.outputs.karpenter.discovery_key }}"
   discovery_value: "{{ .nuon.sandbox.outputs.karpenter.discovery_value }}"
   instance_profile: "{{ .nuon.sandbox.outputs.karpenter.instance_profile.name }}"
+  ami_alias: "{{ .nuon.inputs.inputs.karpenter_ami_alias }}"
 
 cluster_name: "{{ .nuon.sandbox.outputs.cluster.name }}"
 

--- a/byoc-nuon/src/components/karpenter-nodepools/templates/nodeclass.tpl
+++ b/byoc-nuon/src/components/karpenter-nodepools/templates/nodeclass.tpl
@@ -6,7 +6,7 @@ metadata:
   name: "{{ .name }}"
 spec:
   amiSelectorTerms:
-  - alias: "al2023@v20260520"
+  - alias: "{{ $.Values.karpenter.ami_alias }}"
   instanceProfile: "{{ $.Values.karpenter.instance_profile }}"
   securityGroupSelectorTerms:
   - tags:


### PR DESCRIPTION
### Description

The karpenter nodepool AMI Alias should use an input. This way we're certain to get the right value in there. As opposed to relying on the build itself being fresh.
