### PR TITLE
chore(inputs/oidc): remove an unused input

### DIFF
--- a/byoc-nuon/inputs/oidc/redirect_url.toml
+++ b/byoc-nuon/inputs/oidc/redirect_url.toml
@@ -1,8 +1,0 @@
-name         = "nuon_auth_redirect_url"
-description  = "OIDC Redirect URL - the callback URL for your identity provider."
-default      = "https://auth.{{.nuon.inputs.inputs.root_domain}}/auth"
-display_name = "Auth Redirect URL"
-required     = false
-group        = "oidc"
-
-user_configurable = false


### PR DESCRIPTION
the value for this input is hardcoded in the ctl-api's helm values file
since it's derived from nuon_dns.
