### PR TITLE
chore(nodepools): set `expireAfter=0` on clickhouse installation pool

### DIFF
--- a/byoc-nuon/components/values/karpenter-nodepools.yaml
+++ b/byoc-nuon/components/values/karpenter-nodepools.yaml
@@ -50,7 +50,7 @@ nodepools:
     limits:
       cpu: 14
       memory: "1000Gi"
-    expireAfter: "2160h"
+    expireAfter: "Never"
     disruption:
       budgets:
         - nodes: "0"


### PR DESCRIPTION
we already have a disruption budget of zero so this change isn't
disruptive, it's simply correct.
