### PR TITLE
feat: (byoc-nuon) add OPA policies for production guardrails

### DIFF
--- a/byoc-nuon/policies/block-destructive-changes.rego
+++ b/byoc-nuon/policies/block-destructive-changes.rego
@@ -1,0 +1,67 @@
+# Block Destructive Changes Policy (terraform_module)
+#
+# Prevents Terraform plans from deleting or replacing the stateful resources
+# that hold the control plane and customer-install data. Deleting any of these
+# is effectively unrecoverable in production.
+#
+# Checks:
+#   - deny deletion of critical stateful resources   (deny)
+#   - warn on replacement (delete + create)           (warn)
+#
+# Input: Terraform JSON plan (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+# Stateful resources whose loss is catastrophic in production.
+critical_resources := {
+	"aws_db_instance",
+	"aws_rds_cluster",
+	"aws_s3_bucket",
+	"aws_kms_key",
+	"aws_secretsmanager_secret",
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Block outright deletion of any critical resource.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in critical_resources
+	rc.change.actions[_] == "delete"
+	# A pure replace is [delete, create]; a pure delete is just [delete].
+	not is_replace(rc.change.actions)
+	msg := sprintf(
+		"Deletion of critical resource '%s' (type: %s) is not allowed. Remove the destroy from this plan or use a deliberate break-glass procedure.",
+		[rc.address, rc.type],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Replacing a critical resource also destroys its data; warn loudly so an
+# operator must consciously approve it.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in critical_resources
+	is_replace(rc.change.actions)
+	msg := sprintf(
+		"Critical resource '%s' (type: %s) will be REPLACED (destroyed and recreated). Confirm the data is backed up before applying.",
+		[rc.address, rc.type],
+	)
+}
+
+is_replace(actions) if {
+	count(actions) == 2
+	actions[0] == "delete"
+	actions[1] == "create"
+}
+
+is_replace(actions) if {
+	count(actions) == 2
+	actions[0] == "create"
+	actions[1] == "delete"
+}

--- a/byoc-nuon/policies/block-destructive-changes.toml
+++ b/byoc-nuon/policies/block-destructive-changes.toml
@@ -1,0 +1,4 @@
+type       = "terraform_module"
+engine     = "opa"
+contents   = "./block-destructive-changes.rego"
+components = ["*"]

--- a/byoc-nuon/policies/clickhouse-backups-present.rego
+++ b/byoc-nuon/policies/clickhouse-backups-present.rego
@@ -1,0 +1,38 @@
+# ClickHouse Backups Present Policy (terraform_module, component: clickhouse_cluster)
+#
+# The ClickHouse cluster stores control-plane telemetry and is protected by
+# scheduled backups to S3. Shipping the cluster without those backup manifests
+# would leave that data with no recovery path.
+#
+# Checks:
+#   - if the ClickHouse installation is deployed, backup manifests must exist  (warn)
+#
+# Input: Terraform JSON plan (input.plan.resource_changes). The cluster and its
+# backups are applied as kubectl_manifest resources.
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+installation_present if {
+	some rc in input.plan.resource_changes
+	rc.type == "kubectl_manifest"
+	contains(rc.address, "clickhouse_installation")
+}
+
+backup_manifests := [rc |
+	some rc in input.plan.resource_changes
+	rc.type == "kubectl_manifest"
+	contains(lower(rc.address), "backup")
+]
+
+# ──────────────────────────────────────────────────────────────────────────────
+# A deployed ClickHouse cluster must ship its S3 backup manifests.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	installation_present
+	count(backup_manifests) == 0
+	msg := "ClickHouse cluster is being deployed without any backup manifests. The S3 backup CronJobs must be present so telemetry data can be recovered."
+}

--- a/byoc-nuon/policies/clickhouse-backups-present.toml
+++ b/byoc-nuon/policies/clickhouse-backups-present.toml
@@ -1,0 +1,4 @@
+type       = "terraform_module"
+engine     = "opa"
+contents   = "./clickhouse-backups-present.rego"
+components = ["clickhouse_cluster"]

--- a/byoc-nuon/policies/ctl-api-control-plane-integrity.rego
+++ b/byoc-nuon/policies/ctl-api-control-plane-integrity.rego
@@ -1,0 +1,102 @@
+# ctl-api Control-Plane Integrity Policy (helm_chart, component: ctl_api)
+#
+# ctl-api is the Nuon control plane. These checks pin the security and integrity
+# invariants of its rendered manifests so a values change cannot silently weaken
+# the control plane running in the customer's account.
+#
+# Checks (all deny):
+#   - database connection stays hardened: IAM auth + TLS verify-full
+#   - the control plane is never opened to all users
+#   - the admin API stays on the internal domain
+#   - the Nuon support role ARN is not swapped to another account
+#   - the ctl-api ServiceAccount keeps its IRSA role annotation
+#
+# Input: Kubernetes AdmissionReview (input.review.object). ctl-api renders its
+# `env` map into a ConfigMap named "ctl-api" that every Deployment consumes via
+# envFrom, so that ConfigMap is the source of truth for these env values.
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+# Nuon's support role lives in a fixed, Nuon-owned account. The BYOC trust model
+# depends on this ARN: pointing it elsewhere would hand control-plane support
+# access to another account.
+nuon_support_role_arn := "arn:aws:iam::814326426574:role/nuon-internal-support-prod"
+
+support_role_keys := {"ORG_RUNNER_SUPPORT_ROLE_ARN", "RUNNER_DEFAULT_SUPPORT_IAM_ROLE_ARN"}
+
+# The ctl-api env ConfigMap (only defined when reviewing that object).
+ctl_api_config := input.review.object.data if {
+	input.review.kind.kind == "ConfigMap"
+	input.review.object.metadata.name == "ctl-api"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Database connection must use IAM auth and TLS with full verification.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	cfg := ctl_api_config
+	not cfg.DB_USE_IAM == "true"
+	msg := "ctl-api must connect to its database with IAM auth (DB_USE_IAM=\"true\")."
+}
+
+deny contains msg if {
+	cfg := ctl_api_config
+	not cfg.DB_USE_SSL == "true"
+	msg := "ctl-api must connect to its database over TLS (DB_USE_SSL=\"true\")."
+}
+
+deny contains msg if {
+	cfg := ctl_api_config
+	not cfg.DB_SSL_MODE == "verify-full"
+	msg := "ctl-api must verify the database server certificate (DB_SSL_MODE=\"verify-full\")."
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# The control plane must never be opened to all users.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	cfg := ctl_api_config
+	cfg.NUON_AUTH_ALLOW_ALL_USERS == "true"
+	msg := "ctl-api has NUON_AUTH_ALLOW_ALL_USERS=\"true\", which opens the control plane to anyone. This is not allowed."
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# The admin API must stay on the internal domain, never the public one.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	cfg := ctl_api_config
+	url := cfg.ADMIN_API_URL
+	not contains(url, "internal.")
+	msg := sprintf("ctl-api ADMIN_API_URL (%q) must resolve to the internal domain, not a public one.", [url])
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# The Nuon support role ARN must not be swapped to another account.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	cfg := ctl_api_config
+	some key in support_role_keys
+	arn := cfg[key]
+	arn != nuon_support_role_arn
+	msg := sprintf("ctl-api %s (%q) must be the Nuon support role %q.", [key, arn, nuon_support_role_arn])
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# The ctl-api ServiceAccount must carry its IRSA role annotation, or ctl-api
+# cannot assume its AWS role (RDS IAM auth, S3, ECR, ... all fail).
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	input.review.kind.kind == "ServiceAccount"
+	input.review.object.metadata.name == "ctl-api"
+	not has_irsa_role
+	msg := "ctl-api ServiceAccount is missing its eks.amazonaws.com/role-arn annotation; it will not be able to authenticate to AWS."
+}
+
+has_irsa_role if {
+	arn := input.review.object.metadata.annotations["eks.amazonaws.com/role-arn"]
+	arn != ""
+}

--- a/byoc-nuon/policies/ctl-api-control-plane-integrity.toml
+++ b/byoc-nuon/policies/ctl-api-control-plane-integrity.toml
@@ -1,0 +1,4 @@
+type       = "helm_chart"
+engine     = "opa"
+contents   = "./ctl-api-control-plane-integrity.rego"
+components = ["ctl_api"]

--- a/byoc-nuon/policies/eks-endpoint-access.rego
+++ b/byoc-nuon/policies/eks-endpoint-access.rego
@@ -1,0 +1,64 @@
+# EKS Endpoint Access Policy (sandbox)
+#
+# The sandbox provisions the EKS cluster that hosts the entire control plane.
+# A public Kubernetes API endpoint open to 0.0.0.0/0 is a large attack surface
+# for a control plane running in a customer account.
+#
+# Checks:
+#   - EKS API endpoint should not be public / unrestricted   (warn -> deny)
+#
+# Input: Terraform JSON plan from the sandbox run
+#        (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+vpc_configs(rc) := configs if {
+	is_array(rc.change.after.vpc_config)
+	configs := rc.change.after.vpc_config
+}
+
+vpc_configs(rc) := [rc.change.after.vpc_config] if {
+	is_object(rc.change.after.vpc_config)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Warn when the EKS public endpoint is open to the entire internet.
+#
+# Warns so a sandbox that still uses a public endpoint is not blocked. TODO:
+# promote to `deny` once the cluster API is restricted to known CIDRs (or the
+# public endpoint is disabled).
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_eks_cluster"
+	rc.change.actions[_] in ["create", "update"]
+	some cfg in vpc_configs(rc)
+	cfg.endpoint_public_access == true
+	some cidr in cfg.public_access_cidrs
+	cidr == "0.0.0.0/0"
+	msg := sprintf(
+		"EKS cluster '%s' exposes its public API endpoint to 0.0.0.0/0. Restrict public_access_cidrs or disable the public endpoint.",
+		[rc.address],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Also warn when the public endpoint is enabled with no CIDR restriction at all
+# (an empty/absent allowlist defaults to 0.0.0.0/0).
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_eks_cluster"
+	rc.change.actions[_] in ["create", "update"]
+	some cfg in vpc_configs(rc)
+	cfg.endpoint_public_access == true
+	count(object.get(cfg, "public_access_cidrs", [])) == 0
+	msg := sprintf(
+		"EKS cluster '%s' enables the public API endpoint without a public_access_cidrs allowlist (defaults to 0.0.0.0/0). Restrict it to known CIDRs.",
+		[rc.address],
+	)
+}

--- a/byoc-nuon/policies/eks-endpoint-access.toml
+++ b/byoc-nuon/policies/eks-endpoint-access.toml
@@ -1,0 +1,4 @@
+# `sandbox` policies evaluate the sandbox run; the `components` field is ignored.
+type     = "sandbox"
+engine   = "opa"
+contents = "./eks-endpoint-access.rego"

--- a/byoc-nuon/policies/iam-least-privilege.rego
+++ b/byoc-nuon/policies/iam-least-privilege.rego
@@ -1,0 +1,104 @@
+# IAM Least-Privilege Policy (terraform_module)
+#
+# The control plane provisions IAM policies for its service accounts and for the
+# org/runner machinery. Over-broad grants here are a privilege-escalation risk in
+# the customer's account. This nudges those grants toward least privilege.
+#
+# Checks:
+#   - service-wide / full wildcard actions (e.g. "*", "ecr:*", "kms:*")  (warn -> deny)
+#   - write/destructive actions on Resource "*"                           (warn)
+#   - AdministratorAccess attached by a deployed component                (deny)
+#
+# Input: Terraform JSON plan (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+iam_policy_resources := {"aws_iam_policy", "aws_iam_role_policy", "aws_iam_user_policy"}
+
+# Service-wide / full wildcards that grant far more than any single workload needs.
+admin_action_patterns := {"*", "*:*", "iam:*", "s3:*", "ec2:*", "ecr:*", "kms:*", "rds:*", "sts:*"}
+
+# Prefixes of mutating actions we don't want paired with Resource "*".
+write_action_prefixes := {"Create", "Delete", "Put", "Update", "Modify", "Attach", "Detach", "Write", "Terminate"}
+
+# Helpers ─────────────────────────────────────────────────────────────────────
+parse_policy(s) := json.unmarshal(s)
+
+statements(doc) := s if {
+	is_array(doc.Statement)
+	s := doc.Statement
+} else := [doc.Statement] if {
+	is_object(doc.Statement)
+}
+
+to_set(x) := {x} if {
+	is_string(x)
+}
+
+to_set(x) := {v | some v in x} if {
+	is_array(x)
+}
+
+is_write_action(action) if {
+	parts := split(action, ":")
+	count(parts) == 2
+	some prefix in write_action_prefixes
+	startswith(parts[1], prefix)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Flag service-wide / full wildcard actions.
+#
+# Warns so existing broad grants are not blocked while they are scoped down.
+# TODO: promote to `deny` once service-wide wildcard actions are removed.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in iam_policy_resources
+	rc.change.actions[_] in ["create", "update"]
+	some stmt in statements(parse_policy(rc.change.after.policy))
+	stmt.Effect == "Allow"
+	some action in to_set(stmt.Action)
+	action in admin_action_patterns
+	msg := sprintf(
+		"IAM policy '%s' grants wide action '%s'. Scope it to the specific actions the workload requires.",
+		[rc.address, action],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Write/destructive actions on Resource "*". Kept as a warning.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in iam_policy_resources
+	rc.change.actions[_] in ["create", "update"]
+	some stmt in statements(parse_policy(rc.change.after.policy))
+	stmt.Effect == "Allow"
+	some action in to_set(stmt.Action)
+	is_write_action(action)
+	"*" in to_set(stmt.Resource)
+	msg := sprintf(
+		"IAM policy '%s' allows mutating action '%s' on Resource \"*\". Restrict it to specific resource ARNs.",
+		[rc.address, action],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# AdministratorAccess must only ever be granted via the dedicated break-glass
+# role, never attached by a normally-applied Terraform component.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in ["aws_iam_role_policy_attachment", "aws_iam_user_policy_attachment", "aws_iam_policy_attachment"]
+	rc.change.actions[_] in ["create", "update"]
+	endswith(rc.change.after.policy_arn, ":policy/AdministratorAccess")
+	msg := sprintf(
+		"Attachment '%s' grants AdministratorAccess. Admin access must only come from the break-glass role, not a deployed component.",
+		[rc.address],
+	)
+}

--- a/byoc-nuon/policies/iam-least-privilege.toml
+++ b/byoc-nuon/policies/iam-least-privilege.toml
@@ -1,0 +1,4 @@
+type       = "terraform_module"
+engine     = "opa"
+contents   = "./iam-least-privilege.rego"
+components = ["*"]

--- a/byoc-nuon/policies/image-pinned-tags.rego
+++ b/byoc-nuon/policies/image-pinned-tags.rego
@@ -1,0 +1,25 @@
+# Image Pinned Tags Policy (container_image)
+#
+# Every container_image component (ctl-api, dashboard-ui, temporal, clickhouse,
+# ...) must reference an immutable, pinned tag. A mutable "latest" tag means a
+# deploy can silently pull different bits than what was tested.
+#
+# Checks:
+#   - deny "latest" or empty image tags   (deny)
+#
+# Input: container image metadata (input.image, input.tag, input.metadata).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+
+deny contains msg if {
+	input.tag == "latest"
+	msg := sprintf("Image '%s' uses the mutable ':latest' tag. Pin a specific version for reproducible deploys.", [input.image])
+}
+
+deny contains msg if {
+	input.tag == ""
+	msg := sprintf("Image '%s' has no tag. Pin a specific version for reproducible deploys.", [input.image])
+}

--- a/byoc-nuon/policies/image-pinned-tags.toml
+++ b/byoc-nuon/policies/image-pinned-tags.toml
@@ -1,0 +1,4 @@
+type       = "container_image"
+engine     = "opa"
+contents   = "./image-pinned-tags.rego"
+components = ["*"]

--- a/byoc-nuon/policies/image-registry-trust.rego
+++ b/byoc-nuon/policies/image-registry-trust.rego
@@ -1,0 +1,50 @@
+# Image Registry Trust Policy (container_image)
+#
+# The BYOC trust model depends on running only images Nuon publishes or vets.
+# First-party images must come from the Nuon ECR account; third-party images are
+# limited to the specific upstreams this app ships (ClickHouse and Temporal).
+#
+# Checks:
+#   - image must come from a trusted registry / namespace   (warn -> deny)
+#
+# Input: container image metadata (input.image, input.tag, input.metadata).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+# Nuon publishes first-party images (ctl-api, dashboard-ui, ...) from this ECR
+# account.
+nuon_ecr_account := "431927561584"
+
+# Trusted upstream namespaces for the third-party images this app deploys.
+trusted_namespaces := {"altinity/", "clickhouse/", "temporalio/"}
+
+is_trusted if {
+	contains(input.image, sprintf("%s.dkr.ecr", [nuon_ecr_account]))
+}
+
+is_trusted if {
+	some ns in trusted_namespaces
+	startswith(input.image, ns)
+}
+
+is_trusted if {
+	some ns in trusted_namespaces
+	contains(input.image, sprintf("/%s", [ns]))
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Image must come from a trusted source.
+#
+# Warns so a registry-format mismatch cannot block all builds. TODO: promote to
+# `deny` once verified against real container_image evaluation input.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	is_string(input.image)
+	input.image != ""
+	not is_trusted
+	msg := sprintf("Image %q is not from a trusted registry. First-party images must come from the Nuon ECR account %s; third-party images must come from %v.", [input.image, nuon_ecr_account, trusted_namespaces])
+}

--- a/byoc-nuon/policies/image-registry-trust.toml
+++ b/byoc-nuon/policies/image-registry-trust.toml
@@ -1,0 +1,4 @@
+type       = "container_image"
+engine     = "opa"
+contents   = "./image-registry-trust.rego"
+components = ["*"]

--- a/byoc-nuon/policies/network-no-public-ingress.rego
+++ b/byoc-nuon/policies/network-no-public-ingress.rego
@@ -1,0 +1,93 @@
+# Network Exposure Policy (terraform_module)
+#
+# The control plane (databases, admin endpoints) lives inside the install VPC and
+# must never be reachable from the public internet. This blocks security-group
+# rules that open sensitive ports to 0.0.0.0/0.
+#
+# Checks:
+#   - deny public (0.0.0.0/0 or ::/0) ingress on sensitive ports   (deny)
+#   - warn public ingress on any other port                         (warn)
+#
+# Input: Terraform JSON plan (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+# Ports that must never be exposed to the public internet.
+sensitive_ports := {22, 23, 3389, 5432, 3306, 1433, 6379, 27017, 9000, 2379, 9440}
+
+open_cidrs := {"0.0.0.0/0", "::/0"}
+
+# Normalize ingress rules from both the inline `ingress` block (aws_security_group)
+# and the standalone aws_security_group_rule / aws_vpc_security_group_ingress_rule.
+ingress_rules(rc) := rules if {
+	rc.type == "aws_security_group"
+	rules := {r | some r in rc.change.after.ingress}
+}
+
+ingress_rules(rc) := rules if {
+	rc.type in ["aws_security_group_rule", "aws_vpc_security_group_ingress_rule"]
+	rc.change.after.type == "ingress"
+	rules := {rc.change.after}
+}
+
+ingress_rules(rc) := rules if {
+	rc.type == "aws_vpc_security_group_ingress_rule"
+	not rc.change.after.type
+	rules := {rc.change.after}
+}
+
+rule_cidrs(rule) := cidrs if {
+	cidrs := {c | some c in rule.cidr_blocks}
+}
+
+rule_cidrs(rule) := cidrs if {
+	not rule.cidr_blocks
+	cidrs := {rule.cidr_ipv4}
+}
+
+port_in_range(port, rule) if {
+	rule.from_port <= port
+	port <= rule.to_port
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Deny public ingress on sensitive ports.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.change.actions[_] in ["create", "update"]
+	some rule in ingress_rules(rc)
+	some cidr in rule_cidrs(rule)
+	cidr in open_cidrs
+	some port in sensitive_ports
+	port_in_range(port, rule)
+	msg := sprintf(
+		"Security group '%s' allows public ingress from %s on sensitive port %d. Restrict access to the VPC or specific CIDRs.",
+		[rc.address, cidr, port],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Warn on any other public ingress.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.change.actions[_] in ["create", "update"]
+	some rule in ingress_rules(rc)
+	some cidr in rule_cidrs(rule)
+	cidr in open_cidrs
+	not any_sensitive_port(rule)
+	msg := sprintf(
+		"Security group '%s' allows public ingress from %s on ports %d-%d. Confirm this endpoint is intended to be internet-facing.",
+		[rc.address, cidr, rule.from_port, rule.to_port],
+	)
+}
+
+any_sensitive_port(rule) if {
+	some port in sensitive_ports
+	port_in_range(port, rule)
+}

--- a/byoc-nuon/policies/network-no-public-ingress.toml
+++ b/byoc-nuon/policies/network-no-public-ingress.toml
@@ -1,0 +1,4 @@
+type       = "terraform_module"
+engine     = "opa"
+contents   = "./network-no-public-ingress.rego"
+components = ["*"]

--- a/byoc-nuon/policies/no-cluster-roles.rego
+++ b/byoc-nuon/policies/no-cluster-roles.rego
@@ -1,0 +1,23 @@
+# No Cluster-Wide RBAC Policy (helm_chart, components: ctl_api, dashboard_ui)
+#
+# The control-plane API and dashboard should only ever hold namespaced RBAC
+# (Role / RoleBinding). Cluster-scoped RBAC (ClusterRole / ClusterRoleBinding)
+# grants permissions across the whole cluster and widens the blast radius if the
+# workload is compromised.
+#
+# Checks:
+#   - deny ClusterRole and ClusterRoleBinding objects   (deny)
+#
+# Input: Kubernetes AdmissionReview (input.review.object). ClusterRoles are
+# cluster-scoped, so this is scoped by component rather than by namespace.
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+deny contains msg if {
+	input.review.kind.kind in {"ClusterRole", "ClusterRoleBinding"}
+	msg := sprintf("%s '%s' is not allowed: this component must use namespaced RBAC (Role/RoleBinding), not cluster-wide RBAC.", [input.review.kind.kind, input.review.object.metadata.name])
+}

--- a/byoc-nuon/policies/no-cluster-roles.toml
+++ b/byoc-nuon/policies/no-cluster-roles.toml
@@ -1,0 +1,4 @@
+type       = "helm_chart"
+engine     = "opa"
+contents   = "./no-cluster-roles.rego"
+components = ["ctl_api", "dashboard_ui"]

--- a/byoc-nuon/policies/no-loadbalancer-services.rego
+++ b/byoc-nuon/policies/no-loadbalancer-services.rego
@@ -1,0 +1,38 @@
+# No LoadBalancer Services Policy (helm_chart)
+#
+# Control-plane traffic is meant to enter through the managed Ingress / ALB. A
+# raw type: LoadBalancer Service silently provisions a public cloud load
+# balancer, which can expose an internal service to the internet.
+#
+# Checks:
+#   - deny Service type LoadBalancer   (deny)
+#   - warn Service type NodePort        (warn)
+#
+# Input: Kubernetes AdmissionReview (input.review.object).
+#
+# If a workload genuinely needs a public load balancer, allowlist it here or
+# relax this rule to `warn`.
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+deny contains msg if {
+	input.review.kind.kind == "Service"
+	input.review.object.spec.type == "LoadBalancer"
+	msg := sprintf(
+		"Service '%s' is type LoadBalancer, which provisions a public cloud load balancer. Expose it through the managed Ingress instead.",
+		[input.review.object.metadata.name],
+	)
+}
+
+warn contains msg if {
+	input.review.kind.kind == "Service"
+	input.review.object.spec.type == "NodePort"
+	msg := sprintf(
+		"Service '%s' is type NodePort. Prefer an Ingress for control-plane endpoints.",
+		[input.review.object.metadata.name],
+	)
+}

--- a/byoc-nuon/policies/no-loadbalancer-services.toml
+++ b/byoc-nuon/policies/no-loadbalancer-services.toml
@@ -1,0 +1,4 @@
+type       = "helm_chart"
+engine     = "opa"
+contents   = "./no-loadbalancer-services.rego"
+components = ["*"]

--- a/byoc-nuon/policies/pod-security.rego
+++ b/byoc-nuon/policies/pod-security.rego
@@ -1,0 +1,83 @@
+# Pod Security Policy (helm_chart)
+#
+# Baseline workload hardening for everything the control plane runs on the
+# cluster: no privileged escalation to the node, and workloads should not run as
+# root.
+#
+# Checks:
+#   - deny privileged containers / host namespace sharing   (deny)
+#   - containers should run as non-root                       (warn -> deny)
+#
+# Input: Kubernetes AdmissionReview (input.review.object).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+pod_spec_resources := {"Pod", "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "ReplicaSet"}
+
+get_pod_spec(obj) := obj.spec if {
+	input.review.kind.kind == "Pod"
+}
+
+get_pod_spec(obj) := obj.spec.template.spec if {
+	input.review.kind.kind in {"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job"}
+}
+
+get_pod_spec(obj) := obj.spec.jobTemplate.spec.template.spec if {
+	input.review.kind.kind == "CronJob"
+}
+
+all_containers(pod_spec) := array.concat(
+	object.get(pod_spec, "containers", []),
+	object.get(pod_spec, "initContainers", []),
+)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Privileged containers can take over the node - never allow them.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	input.review.kind.kind in pod_spec_resources
+	pod_spec := get_pod_spec(input.review.object)
+	some container in all_containers(pod_spec)
+	container.securityContext.privileged == true
+	msg := sprintf(
+		"%s '%s' container '%s' runs in privileged mode. Privileged containers are not allowed on the control-plane cluster.",
+		[input.review.kind.kind, input.review.object.metadata.name, container.name],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Host namespace sharing is an escape hatch onto the node.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	input.review.kind.kind in pod_spec_resources
+	pod_spec := get_pod_spec(input.review.object)
+	some field in ["hostNetwork", "hostPID", "hostIPC"]
+	pod_spec[field] == true
+	msg := sprintf(
+		"%s '%s' sets %s=true. Sharing host namespaces is not allowed on the control-plane cluster.",
+		[input.review.kind.kind, input.review.object.metadata.name, field],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Workloads should run as non-root.
+#
+# Warns so workloads without an explicit non-root setting are not blocked.
+# TODO: promote to `deny` once all charts set securityContext.runAsNonRoot=true
+# at the pod or container level.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	input.review.kind.kind in pod_spec_resources
+	pod_spec := get_pod_spec(input.review.object)
+	some container in all_containers(pod_spec)
+	not container.securityContext.runAsNonRoot
+	not pod_spec.securityContext.runAsNonRoot
+	msg := sprintf(
+		"%s '%s' container '%s' may run as root. Set securityContext.runAsNonRoot=true at the pod or container level.",
+		[input.review.kind.kind, input.review.object.metadata.name, container.name],
+	)
+}

--- a/byoc-nuon/policies/pod-security.toml
+++ b/byoc-nuon/policies/pod-security.toml
@@ -1,0 +1,4 @@
+type       = "helm_chart"
+engine     = "opa"
+contents   = "./pod-security.rego"
+components = ["*"]

--- a/byoc-nuon/policies/rds-data-protection.rego
+++ b/byoc-nuon/policies/rds-data-protection.rego
@@ -1,0 +1,102 @@
+# RDS Data Protection Policy (terraform_module)
+#
+# Guards the two control-plane Postgres clusters (ctl-api + Temporal) against
+# the most catastrophic production failure modes: losing or exposing the
+# database that backs the entire Nuon install.
+#
+# Checks:
+#   - deletion_protection must be enabled       (warn -> deny)
+#   - rds.force_ssl must be "1" (require TLS)    (warn -> deny)
+#   - backup_retention_period must be >= 7 days  (warn)
+#   - skip_final_snapshot must be false          (deny)
+#   - storage_encrypted must be true             (deny)
+#
+# Input: Terraform JSON plan (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+min_backup_retention_days := 7
+
+# ──────────────────────────────────────────────────────────────────────────────
+# RDS deletion protection.
+#
+# Warns so installs that have not yet enabled deletion protection are not
+# blocked. TODO: promote to `deny` once every RDS component sets
+# deletion_protection = true.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_db_instance"
+	rc.change.actions[_] in ["create", "update"]
+	rc.change.after.deletion_protection == false
+	msg := sprintf(
+		"RDS instance '%s' has deletion_protection disabled. The control-plane database must be protected from accidental deletion.",
+		[rc.address],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Enforce TLS for database connections via the rds.force_ssl parameter.
+#
+# Warns during the TLS rollout. TODO: promote to `deny` once every RDS parameter
+# group sets rds.force_ssl = "1".
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_db_parameter_group"
+	rc.change.actions[_] in ["create", "update"]
+	some p in rc.change.after.parameter
+	p.name == "rds.force_ssl"
+	p.value == "0"
+	msg := sprintf(
+		"RDS parameter group '%s' sets rds.force_ssl=0, allowing unencrypted database connections. Set it to \"1\" to require TLS.",
+		[rc.address],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Backup retention window. Kept as a warning so the threshold stays tunable.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_db_instance"
+	rc.change.actions[_] in ["create", "update"]
+	retention := rc.change.after.backup_retention_period
+	retention < min_backup_retention_days
+	msg := sprintf(
+		"RDS instance '%s' has backup_retention_period=%d (< %d days). Increase retention to survive accidental data loss.",
+		[rc.address, retention, min_backup_retention_days],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Never skip the final snapshot - it is the last line of defense on delete.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_db_instance"
+	rc.change.actions[_] in ["create", "update"]
+	rc.change.after.skip_final_snapshot == true
+	msg := sprintf(
+		"RDS instance '%s' has skip_final_snapshot=true. A final snapshot must be taken so the database can be recovered after deletion.",
+		[rc.address],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Storage must be encrypted at rest.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_db_instance"
+	rc.change.actions[_] in ["create", "update"]
+	rc.change.after.storage_encrypted == false
+	msg := sprintf(
+		"RDS instance '%s' has storage_encrypted=false. Control-plane databases must be encrypted at rest.",
+		[rc.address],
+	)
+}

--- a/byoc-nuon/policies/rds-data-protection.toml
+++ b/byoc-nuon/policies/rds-data-protection.toml
@@ -1,0 +1,4 @@
+type       = "terraform_module"
+engine     = "opa"
+contents   = "./rds-data-protection.rego"
+components = ["rds_cluster_nuon", "rds_cluster_temporal"]

--- a/byoc-nuon/policies/s3-data-protection.rego
+++ b/byoc-nuon/policies/s3-data-protection.rego
@@ -19,6 +19,20 @@ import future.keywords.in
 
 public_acls := {"public-read", "public-read-write", "authenticated-read"}
 
+# Buckets that are intentionally public: the install-templates bucket serves
+# CloudFormation QuickLink templates that the customer's AWS account fetches over
+# public HTTPS, so its public-access block is deliberately open (access is scoped
+# by a bucket policy to specific public prefixes).
+intentionally_public_buckets := {"install_template"}
+
+# Buckets that hold immutable backup objects and do not require versioning.
+unversioned_ok_buckets := {"clickhouse_bucket"}
+
+bucket_exempt(address, names) if {
+	some name in names
+	contains(address, name)
+}
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Bucket versioning must remain Enabled (protects against overwrite/delete).
 # ──────────────────────────────────────────────────────────────────────────────
@@ -26,6 +40,7 @@ deny contains msg if {
 	some rc in input.plan.resource_changes
 	rc.type == "aws_s3_bucket_versioning"
 	rc.change.actions[_] in ["create", "update"]
+	not bucket_exempt(rc.address, unversioned_ok_buckets)
 	some cfg in rc.change.after.versioning_configuration
 	cfg.status != "Enabled"
 	msg := sprintf(
@@ -57,12 +72,14 @@ public_access_blocks := [rc |
 ]
 
 # ──────────────────────────────────────────────────────────────────────────────
-# A public-access block that disables any protection defeats its purpose.
+# A public-access block that disables any protection defeats its purpose, unless
+# the bucket is intentionally public.
 # ──────────────────────────────────────────────────────────────────────────────
 deny contains msg if {
 	some rc in input.plan.resource_changes
 	rc.type == "aws_s3_bucket_public_access_block"
 	rc.change.actions[_] in ["create", "update"]
+	not bucket_exempt(rc.address, intentionally_public_buckets)
 	after := rc.change.after
 	some field in ["block_public_acls", "block_public_policy", "ignore_public_acls", "restrict_public_buckets"]
 	after[field] == false

--- a/byoc-nuon/policies/s3-data-protection.rego
+++ b/byoc-nuon/policies/s3-data-protection.rego
@@ -1,0 +1,87 @@
+# S3 Data Protection Policy (terraform_module)
+#
+# The S3 buckets in this app hold blob storage and ClickHouse backups. They must
+# never be publicly reachable and must retain object versions for recovery.
+#
+# Checks:
+#   - bucket versioning must stay Enabled        (deny)
+#   - buckets must have a public-access block     (warn -> deny)
+#   - public-access block flags must all be true  (deny)
+#   - public bucket ACLs are not allowed          (deny)
+#
+# Input: Terraform JSON plan (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+public_acls := {"public-read", "public-read-write", "authenticated-read"}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Bucket versioning must remain Enabled (protects against overwrite/delete).
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_s3_bucket_versioning"
+	rc.change.actions[_] in ["create", "update"]
+	some cfg in rc.change.after.versioning_configuration
+	cfg.status != "Enabled"
+	msg := sprintf(
+		"S3 versioning '%s' sets status=%q. Versioning must stay Enabled so objects can be recovered.",
+		[rc.address, cfg.status],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Every bucket should be covered by an aws_s3_bucket_public_access_block.
+#
+# Warns so buckets without a block are not yet blocked. TODO: promote to `deny`
+# once every bucket ships a public-access block, so a missing one fails the plan.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_s3_bucket"
+	rc.change.actions[_] in ["create", "update"]
+	count(public_access_blocks) == 0
+	msg := sprintf(
+		"S3 bucket '%s' is provisioned without any aws_s3_bucket_public_access_block in the plan. Add one (all four flags true) to guarantee the bucket cannot be made public.",
+		[rc.address],
+	)
+}
+
+public_access_blocks := [rc |
+	some rc in input.plan.resource_changes
+	rc.type == "aws_s3_bucket_public_access_block"
+]
+
+# ──────────────────────────────────────────────────────────────────────────────
+# A public-access block that disables any protection defeats its purpose.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_s3_bucket_public_access_block"
+	rc.change.actions[_] in ["create", "update"]
+	after := rc.change.after
+	some field in ["block_public_acls", "block_public_policy", "ignore_public_acls", "restrict_public_buckets"]
+	after[field] == false
+	msg := sprintf(
+		"S3 public-access block '%s' has %s=false. All four public-access protections must be true.",
+		[rc.address, field],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Never set a public bucket ACL.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in ["aws_s3_bucket_acl", "aws_s3_bucket"]
+	rc.change.actions[_] in ["create", "update"]
+	rc.change.after.acl in public_acls
+	msg := sprintf(
+		"S3 resource '%s' sets a public ACL (%q). Buckets must remain private.",
+		[rc.address, rc.change.after.acl],
+	)
+}

--- a/byoc-nuon/policies/s3-data-protection.toml
+++ b/byoc-nuon/policies/s3-data-protection.toml
@@ -1,0 +1,4 @@
+type       = "terraform_module"
+engine     = "opa"
+contents   = "./s3-data-protection.rego"
+components = ["s3_buckets"]


### PR DESCRIPTION
Add deny/warn policies under byoc-nuon/policies to catch serious production mistakes before build/deploy. Failing-now checks are warn with a TODO to promote to deny.

Component-scoped (Nuon-specific):
- ctl-api-control-plane-integrity (helm_chart, ctl_api): DB IAM+TLS verify-full, no allow-all-users, internal-only admin API, pinned Nuon support role ARN, ServiceAccount IRSA annotation
- rds-data-protection (terraform_module, rds_cluster_*): deletion protection, force_ssl, backups, final snapshot, encryption at rest
- s3-data-protection (terraform_module, s3_buckets): versioning, public-access block, no public ACLs
- clickhouse-backups-present (terraform_module, clickhouse_cluster)
- image-registry-trust (container_image): Nuon ECR + vetted upstreams

Broad safety nets (*):
- block-destructive-changes, network-no-public-ingress, iam-least-privilege (terraform_module)
- no-loadbalancer-services, pod-security (helm_chart)
- image-pinned-tags (container_image)
- eks-endpoint-access (sandbox)