### PR TITLE
chore(inputs): configure some customer facing inputs

### DIFF
--- a/byoc-nuon/inputs/github/github_app_client.toml
+++ b/byoc-nuon/inputs/github/github_app_client.toml
@@ -1,8 +1,8 @@
 name         = "github_app_client_id"
 description  = "The github app client id."
-default      = ""
+default      = "please-provide-a-value"
 display_name = "GitHub App Client ID"
 group        = "github"
 required     = true
 
-user_configurable = false
+user_configurable = true

--- a/byoc-nuon/inputs/github/github_app_id.toml
+++ b/byoc-nuon/inputs/github/github_app_id.toml
@@ -1,8 +1,8 @@
 name         = "github_app_id"
 description  = "The github app id."
-default      = ""
+default      = "please-provide-a-value"
 display_name = "GitHub App ID"
 group        = "github"
 required     = true
 
-user_configurable = false
+user_configurable = true

--- a/byoc-nuon/inputs/github/github_app_name.toml
+++ b/byoc-nuon/inputs/github/github_app_name.toml
@@ -1,8 +1,8 @@
 name         = "github_app_name"
 description  = "The name of the GitHub app to use for VCS connections."
-default      = ""
+default      = "please-provide-a-value"
 display_name = "GitHub App Name"
 group        = "github"
 required     = true
 
-user_configurable = false
+user_configurable = true

--- a/byoc-nuon/inputs/oidc/allow_all_users.toml
+++ b/byoc-nuon/inputs/oidc/allow_all_users.toml
@@ -1,9 +1,9 @@
 name         = "nuon_auth_allow_all_users"
 description  = "If this is set to true, any user with an email in one of the allowed_domains will be able to register."
-default      = ""
+default      = "please-provide-a-value"
 display_name = "Allow All Users"
 required     = true
 group        = "oidc"
 type         = "bool"
 
-user_configurable = false
+user_configurable = true

--- a/byoc-nuon/inputs/oidc/allowed_domains.toml
+++ b/byoc-nuon/inputs/oidc/allowed_domains.toml
@@ -1,9 +1,9 @@
 name         = "nuon_auth_allowed_domains"
 description  = "A comma delimited lists of domains from which user are allowed to register. Usually your org's email domain."
-default      = ""
+default      = "please-provide-a-value"
 display_name = "Allowed Domains"
 required     = true
 group        = "oidc"
 type         = "string"
 
-user_configurable = false
+user_configurable = true

--- a/byoc-nuon/inputs/oidc/client_id.toml
+++ b/byoc-nuon/inputs/oidc/client_id.toml
@@ -1,8 +1,8 @@
 name         = "nuon_auth_client_id"
 description  = "OIDC Client ID from your identity provider."
-default      = ""
+default      = "please-provide-a-value"
 display_name = "Auth Client ID"
 required     = false
 group        = "oidc"
 
-user_configurable = false
+user_configurable = true

--- a/byoc-nuon/inputs/oidc/issuer_url.toml
+++ b/byoc-nuon/inputs/oidc/issuer_url.toml
@@ -1,8 +1,8 @@
 name         = "nuon_auth_issuer_url"
 description  = "OIDC Issuer URL. Not required for Google OAuth - leave empty. Required for generic OIDC providers."
-default      = ""
+default      = "please-provide-a-value"
 display_name = "Auth Issuer URL"
 required     = false
 group        = "oidc"
 
-user_configurable = false
+user_configurable = true

--- a/byoc-nuon/inputs/oidc/provider_type.toml
+++ b/byoc-nuon/inputs/oidc/provider_type.toml
@@ -1,8 +1,8 @@
 name         = "nuon_auth_provider_type"
 description  = "Identity provider type. Currently only 'google' is supported."
-default      = ""
+default      = "please-provide-a-value"
 display_name = "Auth Provider Type"
 required     = false
 group        = "oidc"
 
-user_configurable = false
+user_configurable = true


### PR DESCRIPTION
we provide a placeholder value which is necessary because we have
existing installs and we are unable to migrate these as required w/out a
default value in that case.
