### PR TITLE
chore: remove some inputs

### DIFF
--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -300,24 +300,10 @@ api:
       maxReplicas: 10
       targetCPUUtilizationPercentage: 75
       targetMemoryUtilizationPercentage: 75
-    # Unset ctl_api_public_* inputs render as missing fields and inherit
-    # api.resources via the ctl_api.containerResources helper. `index` is
-    # used so missing input keys return nil instead of raising.
     resources:
-      limits:
-        {{- with index .nuon.inputs.inputs "ctl_api_public_cpu_limit" }}
-        cpu: {{ . }}
-        {{- end }}
-        {{- with index .nuon.inputs.inputs "ctl_api_public_memory_limit" }}
-        memory: {{ . }}
-        {{- end }}
       requests:
-        {{- with index .nuon.inputs.inputs "ctl_api_public_cpu_request" }}
-        cpu: {{ . }}
-        {{- end }}
-        {{- with index .nuon.inputs.inputs "ctl_api_public_memory_request" }}
-        memory: {{ . }}
-        {{- end }}
+        cpu: 1000m
+        memory: 2Gi
   admin:
     port: 8082
     domain: "admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"

--- a/byoc-nuon/inputs/nuon/ctl_api_public_cpu_limit.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_cpu_limit.toml
@@ -1,7 +1,0 @@
-name         = "ctl_api_public_cpu_limit"
-description  = "Override the CPU limit for the ctl-api-public deployment (e.g. \"500m\", \"1\"). Leave empty to inherit the shared ctl-api default."
-default      = ""
-display_name = "ctl-api-public CPU limit"
-required     = false
-group        = "nuon"
-user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_cpu_request.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_cpu_request.toml
@@ -1,7 +1,0 @@
-name         = "ctl_api_public_cpu_request"
-description  = "Override the CPU request for the ctl-api-public deployment (e.g. \"500m\", \"1\"). Leave empty to inherit the shared ctl-api default."
-default      = ""
-display_name = "ctl-api-public CPU request"
-required     = false
-group        = "nuon"
-user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_memory_limit.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_memory_limit.toml
@@ -1,7 +1,0 @@
-name         = "ctl_api_public_memory_limit"
-description  = "Override the memory limit for the ctl-api-public deployment (e.g. \"2048Mi\", \"2Gi\"). Leave empty to inherit the shared ctl-api default."
-default      = ""
-display_name = "ctl-api-public memory limit"
-required     = false
-group        = "nuon"
-user_configurable = false

--- a/byoc-nuon/inputs/nuon/ctl_api_public_memory_request.toml
+++ b/byoc-nuon/inputs/nuon/ctl_api_public_memory_request.toml
@@ -1,7 +1,0 @@
-name         = "ctl_api_public_memory_request"
-description  = "Override the memory request for the ctl-api-public deployment (e.g. \"2048Mi\", \"2Gi\"). Leave empty to inherit the shared ctl-api default."
-default      = ""
-display_name = "ctl-api-public memory request"
-required     = false
-group        = "nuon"
-user_configurable = false


### PR DESCRIPTION
ctl-api public api resources can be set to pre-determined values
