### PR TITLE
fix: query workflow steps with workflow ID

### DIFF
--- a/byoc-nuon/actions/ctl_api/ctl_api_query_workflow_steps/query-workflow-steps.sh
+++ b/byoc-nuon/actions/ctl_api/ctl_api_query_workflow_steps/query-workflow-steps.sh
@@ -30,7 +30,7 @@ if [[ -n "$workflow_id" ]] && ! [[ "$workflow_id" =~ ^[a-zA-Z0-9_-]+$ ]]; then
 fi
 
 if [[ -n "$workflow_id" ]]; then
-  workflow_filter="AND w.id = '$workflow_id'"
+  workflow_filter="AND id = '$workflow_id'"
 else
   workflow_filter=""
 fi


### PR DESCRIPTION
# Summary

The query workflow steps action works without a WORKFLOW_ID, but fails when one is provided. This fixes the error.