### PR TITLE
chore: pin the ctl-api and dashboard-ui charts to a new version

### DIFF
--- a/byoc-nuon/components/92-helm-ctl_api.toml
+++ b/byoc-nuon/components/92-helm-ctl_api.toml
@@ -9,7 +9,7 @@ dependencies   = ["rds_cluster_nuon", "karpenter_nodepools", "clickhouse_cluster
 [public_repo]
 repo      = "nuonco/charts"
 directory = "charts/ctl-api"
-branch    = "ctl-api-v0.3.1"
+branch    = "ctl-api-v0.3.2"
 
 [[values_file]]
 contents = "./values/ctl-api.yaml"

--- a/byoc-nuon/components/93-helm-dashboard_ui.toml
+++ b/byoc-nuon/components/93-helm-dashboard_ui.toml
@@ -10,7 +10,7 @@ dependencies = ["ctl_api"]
 [public_repo]
 repo      = "nuonco/charts"
 directory = "charts/dashboard-ui"
-branch    = "main"
+branch    = "dashboard-ui-v0.1.1"
 
 [[values_file]]
 contents = "./values/dashboard-ui.yaml"


### PR DESCRIPTION
### Description

Update to versions that remove an orphaned resource.
