### PR TITLE
fix: schedule the ctl-api slack pod on GCP installs

### DIFF
--- a/shared/src/components/ctl_api/templates/api_slack_deployment.tpl
+++ b/shared/src/components/ctl_api/templates/api_slack_deployment.tpl
@@ -28,16 +28,14 @@ spec:
       automountServiceAccountToken: true
 
       # start: NodePool Selection
+      {{- with .Values.api.nodeSelector }}
       nodeSelector:
-        pool.nuon.co: "public"
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.tolerations }}
       tolerations:
-        - key: "pool.nuon.co"
-          operator: "Equal"
-          value: "public"
-          effect: "NoSchedule"
-        - key: "pool.nuon.co/public" # this taint is being renamed and deprecated
-          operator: "Exists"
-          effect: "NoSchedule"
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       # end: NodePool Selection
 
       # start: Topology Spread Constraints


### PR DESCRIPTION
The ctl-api slack listener now schedules on any install, including GCP. It picks its node pool from the same install-level setting the other ctl-api services use, instead of demanding a hardcoded "public" pool.

## What you can do after this PR

**The slack pod runs on GCP installs.** GCP clusters only have a "main" node pool, so the slack pod sat unschedulable (Pending) forever while every other ctl-api service ran fine. It now lands on the same pool as the rest of ctl-api.

**Node pool selection comes from values.** The slack deployment reads its node selector and tolerations from the install values, matching the public, admin, runner, and auth deployments.

## What stays the same

AWS installs that set a public node pool in their values keep pinning the slack pod there. Behavior on those installs is unchanged.
