### PR TITLE
fix(gcp): healthcheck httproutes instead of ingress

### DIFF
--- a/byoc-nuon-gcp/actions/ctl_api/api_status/api_status.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/api_status/api_status.toml
@@ -1,6 +1,6 @@
 # action
-# description: fetches ctl-api version and runs ingress healthchecks for the
-# public, admin (private), and runner ingresses.
+# description: fetches ctl-api version and runs route healthchecks for the
+# public, admin (private), and runner HTTPRoutes.
 name    = "api_status"
 labels  = { service = "ctl-api", type = "debug" }
 timeout = "2m"
@@ -20,28 +20,28 @@ inline_contents = "./ctl_api/api_status/version.sh"
 API_URL = "https://api.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
 
 [[steps]]
-name            = "ingress-healthcheck-ctl-api-public"
+name            = "route-healthcheck-ctl-api-public"
 inline_contents = "./ctl_api/api_status/healthcheck.sh"
 
 [steps.env_vars]
-INGRESS_NAME      = "ctl-api-public"
-INGRESS_NAMESPACE = "ctl-api"
+ROUTE_NAME      = "ctl-api-public"
+ROUTE_NAMESPACE = "ctl-api"
 
 [[steps]]
-name            = "ingress-healthcheck-ctl-api-admin"
+name            = "route-healthcheck-ctl-api-admin"
 inline_contents = "./ctl_api/api_status/healthcheck.sh"
 
 [steps.env_vars]
-INGRESS_NAME      = "ctl-api-admin"
-INGRESS_NAMESPACE = "ctl-api"
+ROUTE_NAME      = "ctl-api-admin"
+ROUTE_NAMESPACE = "ctl-api"
 
 [[steps]]
-name            = "ingress-healthcheck-ctl-api-runner"
+name            = "route-healthcheck-ctl-api-runner"
 inline_contents = "./ctl_api/api_status/healthcheck.sh"
 
 [steps.env_vars]
-INGRESS_NAME      = "ctl-api-runner"
-INGRESS_NAMESPACE = "ctl-api"
+ROUTE_NAME      = "ctl-api-runner"
+ROUTE_NAMESPACE = "ctl-api"
 
 [[steps]]
 name            = "timestamp"

--- a/byoc-nuon-gcp/actions/ctl_api/api_status/healthcheck.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/api_status/healthcheck.sh
@@ -4,22 +4,33 @@ set -e
 set -o pipefail
 set -u
 
-echo >&2 "checking ingress..."
+echo >&2 "checking httproute ${ROUTE_NAME} in ${ROUTE_NAMESPACE}..."
 
-ingress_json=`kubectl get --namespace $INGRESS_NAMESPACE ingress $INGRESS_NAME -o json | jq -c`
-status=`echo $ingress_json |jq -c '.status'`
-certificate_map=`echo $ingress_json |jq -r '.metadata.annotations."networking.gke.io/certmap"'`
-hostname=`echo $ingress_json |jq -r '.metadata.annotations."external-dns.alpha.kubernetes.io/hostname"'`
+route_json=$(kubectl get --namespace "$ROUTE_NAMESPACE" httproute "$ROUTE_NAME" -o json)
 
-# determine status
-lb_ingress_count=`echo $status | jq '.loadBalancer.ingress | length'`
-if [ "$lb_ingress_count" == "0" ];
-  then
-    indicator="🔴"
-  else
-    indicator="🟢"
+hostname=$(echo "$route_json" | jq -r '.spec.hostnames[0] // "unknown"')
+gateway=$(echo "$route_json" | jq -r '.spec.parentRefs[0].name // "unknown"')
+gateway_namespace=$(echo "$route_json" | jq -r '.spec.parentRefs[0].namespace // .metadata.namespace')
+
+# A route is serving traffic when its parent gateway reports both Accepted and
+# ResolvedRefs = True. Empty conditions (not yet reconciled) count as unhealthy.
+accepted=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="Accepted") | .status] | (length > 0) and (all(. == "True"))')
+resolved=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="ResolvedRefs") | .status] | (length > 0) and (all(. == "True"))')
+
+if [ "$accepted" = "true" ] && [ "$resolved" = "true" ]; then
+  indicator="🟢"
+else
+  indicator="🔴"
 fi
 
-# compose the output
-outputs=`jq --null-input --arg cert "$certificate_map" --arg hn "$hostname" --arg indicatorVar "$indicator" --argjson statusVar "$status" '{"status": $statusVar, "indicator": $indicatorVar, "certificate_map": $cert, "hostname": $hn}'`
-echo $outputs >> $NUON_ACTIONS_OUTPUT_FILEPATH
+gateway_address=$(kubectl get --namespace "$gateway_namespace" gateway "$gateway" -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "unknown")
+
+outputs=$(jq --null-input \
+  --arg hn "$hostname" \
+  --arg gw "$gateway" \
+  --arg addr "$gateway_address" \
+  --arg accepted "$accepted" \
+  --arg resolved "$resolved" \
+  --arg indicatorVar "$indicator" \
+  '{"indicator": $indicatorVar, "hostname": $hn, "gateway": $gw, "gateway_address": $addr, "accepted": $accepted, "resolved_refs": $resolved}')
+echo "$outputs" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/ctl_api/dashboard_status/dashboard_status.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/dashboard_status/dashboard_status.toml
@@ -1,6 +1,6 @@
 # action
-# description: fetches dashboard-ui version and runs the ingress healthcheck for
-# the dashboard ingress.
+# description: fetches dashboard-ui version and runs the route healthcheck for
+# the dashboard HTTPRoute.
 name    = "dashboard_status"
 labels  = { service = "ctl-api", type = "debug" }
 timeout = "2m"
@@ -25,12 +25,12 @@ inline_contents = "./ctl_api/dashboard_status/version.sh"
 APP_URL = "https://app.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
 
 [[steps]]
-name            = "ingress-healthcheck-dashboard-ui"
+name            = "route-healthcheck-dashboard-ui"
 inline_contents = "./ctl_api/dashboard_status/healthcheck.sh"
 
 [steps.env_vars]
-INGRESS_NAME      = "dashboard-ui"
-INGRESS_NAMESPACE = "dashboard-ui"
+ROUTE_NAME      = "dashboard-ui"
+ROUTE_NAMESPACE = "dashboard-ui"
 
 [[steps]]
 name            = "timestamp"

--- a/byoc-nuon-gcp/actions/ctl_api/dashboard_status/healthcheck.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/dashboard_status/healthcheck.sh
@@ -4,22 +4,33 @@ set -e
 set -o pipefail
 set -u
 
-echo >&2 "checking ingress..."
+echo >&2 "checking httproute ${ROUTE_NAME} in ${ROUTE_NAMESPACE}..."
 
-ingress_json=`kubectl get --namespace $INGRESS_NAMESPACE ingress $INGRESS_NAME -o json | jq -c`
-status=`echo $ingress_json |jq -c '.status'`
-certificate_map=`echo $ingress_json |jq -r '.metadata.annotations."networking.gke.io/certmap"'`
-hostname=`echo $ingress_json |jq -r '.metadata.annotations."external-dns.alpha.kubernetes.io/hostname"'`
+route_json=$(kubectl get --namespace "$ROUTE_NAMESPACE" httproute "$ROUTE_NAME" -o json)
 
-# determine status
-lb_ingress_count=`echo $status | jq '.loadBalancer.ingress | length'`
-if [ "$lb_ingress_count" == "0" ];
-  then
-    indicator="🔴"
-  else
-    indicator="🟢"
+hostname=$(echo "$route_json" | jq -r '.spec.hostnames[0] // "unknown"')
+gateway=$(echo "$route_json" | jq -r '.spec.parentRefs[0].name // "unknown"')
+gateway_namespace=$(echo "$route_json" | jq -r '.spec.parentRefs[0].namespace // .metadata.namespace')
+
+# A route is serving traffic when its parent gateway reports both Accepted and
+# ResolvedRefs = True. Empty conditions (not yet reconciled) count as unhealthy.
+accepted=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="Accepted") | .status] | (length > 0) and (all(. == "True"))')
+resolved=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="ResolvedRefs") | .status] | (length > 0) and (all(. == "True"))')
+
+if [ "$accepted" = "true" ] && [ "$resolved" = "true" ]; then
+  indicator="🟢"
+else
+  indicator="🔴"
 fi
 
-# compose the output
-outputs=`jq --null-input --arg cert "$certificate_map" --arg hn "$hostname" --arg indicatorVar "$indicator" --argjson statusVar "$status" '{"status": $statusVar, "indicator": $indicatorVar, "certificate_map": $cert, "hostname": $hn}'`
-echo $outputs >> $NUON_ACTIONS_OUTPUT_FILEPATH
+gateway_address=$(kubectl get --namespace "$gateway_namespace" gateway "$gateway" -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "unknown")
+
+outputs=$(jq --null-input \
+  --arg hn "$hostname" \
+  --arg gw "$gateway" \
+  --arg addr "$gateway_address" \
+  --arg accepted "$accepted" \
+  --arg resolved "$resolved" \
+  --arg indicatorVar "$indicator" \
+  '{"indicator": $indicatorVar, "hostname": $hn, "gateway": $gw, "gateway_address": $addr, "accepted": $accepted, "resolved_refs": $resolved}')
+echo "$outputs" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"


### PR DESCRIPTION
The dashboard_status and api_status actions checked `kubectl get ingress`, but the GCP install routes via Gateway API (HTTPRoute + Gateway) and has no Ingress objects, so the healthcheck step errored every run.

Both healthchecks now query the HTTPRoute and derive health from the parent gateway's Accepted + ResolvedRefs conditions, reporting hostname, gateway, and its LB address. Env vars (ROUTE_NAME/ROUTE_NAMESPACE) and step names renamed accordingly. Validated against external and internal gateway routes on a live install.