### PR TITLE
fix(gcp): route-based healthchecks with compact json output

### DIFF
--- a/byoc-nuon-gcp/actions/ctl_api/api_status/healthcheck.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/api_status/healthcheck.sh
@@ -4,16 +4,22 @@ set -e
 set -o pipefail
 set -u
 
-echo >&2 "checking httproute ${ROUTE_NAME} in ${ROUTE_NAMESPACE}..."
+route_name="${ROUTE_NAME:-${INGRESS_NAME:-}}"
+route_namespace="${ROUTE_NAMESPACE:-${INGRESS_NAMESPACE:-}}"
 
-route_json=$(kubectl get --namespace "$ROUTE_NAMESPACE" httproute "$ROUTE_NAME" -o json)
+if [ -z "$route_name" ] || [ -z "$route_namespace" ]; then
+  echo >&2 "route name/namespace not set (ROUTE_NAME/ROUTE_NAMESPACE)"
+  exit 1
+fi
+
+echo >&2 "checking httproute ${route_name} in ${route_namespace}..."
+
+route_json=$(kubectl get --namespace "$route_namespace" httproute "$route_name" -o json)
 
 hostname=$(echo "$route_json" | jq -r '.spec.hostnames[0] // "unknown"')
 gateway=$(echo "$route_json" | jq -r '.spec.parentRefs[0].name // "unknown"')
 gateway_namespace=$(echo "$route_json" | jq -r '.spec.parentRefs[0].namespace // .metadata.namespace')
 
-# A route is serving traffic when its parent gateway reports both Accepted and
-# ResolvedRefs = True. Empty conditions (not yet reconciled) count as unhealthy.
 accepted=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="Accepted") | .status] | (length > 0) and (all(. == "True"))')
 resolved=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="ResolvedRefs") | .status] | (length > 0) and (all(. == "True"))')
 
@@ -25,12 +31,12 @@ fi
 
 gateway_address=$(kubectl get --namespace "$gateway_namespace" gateway "$gateway" -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "unknown")
 
-outputs=$(jq --null-input \
+jq -cn \
   --arg hn "$hostname" \
   --arg gw "$gateway" \
   --arg addr "$gateway_address" \
   --arg accepted "$accepted" \
   --arg resolved "$resolved" \
   --arg indicatorVar "$indicator" \
-  '{"indicator": $indicatorVar, "hostname": $hn, "gateway": $gw, "gateway_address": $addr, "accepted": $accepted, "resolved_refs": $resolved}')
-echo "$outputs" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  '{indicator: $indicatorVar, hostname: $hn, gateway: $gw, gateway_address: $addr, accepted: $accepted, resolved_refs: $resolved}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/ctl_api_post_deploy.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/ctl_api_post_deploy.toml
@@ -40,25 +40,25 @@ inline_contents = "./ctl_api/ctl_api_post_deploy/get-migrations.sh"
 ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
 
 [[steps]]
-name            = "public-ingress-healthcheck"
+name            = "public-route-healthcheck"
 inline_contents = "./ctl_api/ctl_api_post_deploy/healthcheck.sh"
 
 [steps.env_vars]
-INGRESS_NAME      = "ctl-api-public"
-INGRESS_NAMESPACE = "ctl-api"
+ROUTE_NAME      = "ctl-api-public"
+ROUTE_NAMESPACE = "ctl-api"
 
 [[steps]]
-name            = "runner-ingress-healthcheck"
+name            = "runner-route-healthcheck"
 inline_contents = "./ctl_api/ctl_api_post_deploy/healthcheck.sh"
 
 [steps.env_vars]
-INGRESS_NAME      = "ctl-api-runner"
-INGRESS_NAMESPACE = "ctl-api"
+ROUTE_NAME      = "ctl-api-runner"
+ROUTE_NAMESPACE = "ctl-api"
 
 [[steps]]
-name            = "admin-ingress-healthcheck"
+name            = "admin-route-healthcheck"
 inline_contents = "./ctl_api/ctl_api_post_deploy/healthcheck.sh"
 
 [steps.env_vars]
-INGRESS_NAME      = "ctl-api-admin"
-INGRESS_NAMESPACE = "ctl-api"
+ROUTE_NAME      = "ctl-api-admin"
+ROUTE_NAMESPACE = "ctl-api"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/healthcheck.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/healthcheck.sh
@@ -4,22 +4,33 @@ set -e
 set -o pipefail
 set -u
 
-echo >&2 "checking ingress..."
+echo >&2 "checking httproute ${ROUTE_NAME} in ${ROUTE_NAMESPACE}..."
 
-ingress_json=`kubectl get --namespace $INGRESS_NAMESPACE ingress $INGRESS_NAME -o json | jq -c`
-status=`echo $ingress_json |jq -c '.status'`
-certificate_map=`echo $ingress_json |jq -r '.metadata.annotations."networking.gke.io/certmap"'`
-hostname=`echo $ingress_json |jq -r '.metadata.annotations."external-dns.alpha.kubernetes.io/hostname"'`
+route_json=$(kubectl get --namespace "$ROUTE_NAMESPACE" httproute "$ROUTE_NAME" -o json)
 
-# determine status
-lb_ingress_count=`echo $status | jq '.loadBalancer.ingress | length'`
-if [ "$lb_ingress_count" == "0" ];
-  then
-    indicator="🔴"
-  else
-    indicator="🟢"
+hostname=$(echo "$route_json" | jq -r '.spec.hostnames[0] // "unknown"')
+gateway=$(echo "$route_json" | jq -r '.spec.parentRefs[0].name // "unknown"')
+gateway_namespace=$(echo "$route_json" | jq -r '.spec.parentRefs[0].namespace // .metadata.namespace')
+
+# A route is serving traffic when its parent gateway reports both Accepted and
+# ResolvedRefs = True. Empty conditions (not yet reconciled) count as unhealthy.
+accepted=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="Accepted") | .status] | (length > 0) and (all(. == "True"))')
+resolved=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="ResolvedRefs") | .status] | (length > 0) and (all(. == "True"))')
+
+if [ "$accepted" = "true" ] && [ "$resolved" = "true" ]; then
+  indicator="🟢"
+else
+  indicator="🔴"
 fi
 
-# compose the output
-outputs=`jq --null-input --arg cert "$certificate_map" --arg hn "$hostname" --arg indicatorVar "$indicator" --argjson statusVar "$status" '{"status": $statusVar, "indicator": $indicatorVar, "certificate_map": $cert, "hostname": $hn}'`
-echo $outputs >> $NUON_ACTIONS_OUTPUT_FILEPATH
+gateway_address=$(kubectl get --namespace "$gateway_namespace" gateway "$gateway" -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "unknown")
+
+outputs=$(jq --null-input \
+  --arg hn "$hostname" \
+  --arg gw "$gateway" \
+  --arg addr "$gateway_address" \
+  --arg accepted "$accepted" \
+  --arg resolved "$resolved" \
+  --arg indicatorVar "$indicator" \
+  '{"indicator": $indicatorVar, "hostname": $hn, "gateway": $gw, "gateway_address": $addr, "accepted": $accepted, "resolved_refs": $resolved}')
+echo "$outputs" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/healthcheck.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/healthcheck.sh
@@ -4,16 +4,22 @@ set -e
 set -o pipefail
 set -u
 
-echo >&2 "checking httproute ${ROUTE_NAME} in ${ROUTE_NAMESPACE}..."
+route_name="${ROUTE_NAME:-${INGRESS_NAME:-}}"
+route_namespace="${ROUTE_NAMESPACE:-${INGRESS_NAMESPACE:-}}"
 
-route_json=$(kubectl get --namespace "$ROUTE_NAMESPACE" httproute "$ROUTE_NAME" -o json)
+if [ -z "$route_name" ] || [ -z "$route_namespace" ]; then
+  echo >&2 "route name/namespace not set (ROUTE_NAME/ROUTE_NAMESPACE)"
+  exit 1
+fi
+
+echo >&2 "checking httproute ${route_name} in ${route_namespace}..."
+
+route_json=$(kubectl get --namespace "$route_namespace" httproute "$route_name" -o json)
 
 hostname=$(echo "$route_json" | jq -r '.spec.hostnames[0] // "unknown"')
 gateway=$(echo "$route_json" | jq -r '.spec.parentRefs[0].name // "unknown"')
 gateway_namespace=$(echo "$route_json" | jq -r '.spec.parentRefs[0].namespace // .metadata.namespace')
 
-# A route is serving traffic when its parent gateway reports both Accepted and
-# ResolvedRefs = True. Empty conditions (not yet reconciled) count as unhealthy.
 accepted=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="Accepted") | .status] | (length > 0) and (all(. == "True"))')
 resolved=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="ResolvedRefs") | .status] | (length > 0) and (all(. == "True"))')
 
@@ -25,12 +31,12 @@ fi
 
 gateway_address=$(kubectl get --namespace "$gateway_namespace" gateway "$gateway" -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "unknown")
 
-outputs=$(jq --null-input \
+jq -cn \
   --arg hn "$hostname" \
   --arg gw "$gateway" \
   --arg addr "$gateway_address" \
   --arg accepted "$accepted" \
   --arg resolved "$resolved" \
   --arg indicatorVar "$indicator" \
-  '{"indicator": $indicatorVar, "hostname": $hn, "gateway": $gw, "gateway_address": $addr, "accepted": $accepted, "resolved_refs": $resolved}')
-echo "$outputs" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  '{indicator: $indicatorVar, hostname: $hn, gateway: $gw, gateway_address: $addr, accepted: $accepted, resolved_refs: $resolved}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/ctl_api/dashboard_status/healthcheck.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/dashboard_status/healthcheck.sh
@@ -4,16 +4,22 @@ set -e
 set -o pipefail
 set -u
 
-echo >&2 "checking httproute ${ROUTE_NAME} in ${ROUTE_NAMESPACE}..."
+route_name="${ROUTE_NAME:-${INGRESS_NAME:-}}"
+route_namespace="${ROUTE_NAMESPACE:-${INGRESS_NAMESPACE:-}}"
 
-route_json=$(kubectl get --namespace "$ROUTE_NAMESPACE" httproute "$ROUTE_NAME" -o json)
+if [ -z "$route_name" ] || [ -z "$route_namespace" ]; then
+  echo >&2 "route name/namespace not set (ROUTE_NAME/ROUTE_NAMESPACE)"
+  exit 1
+fi
+
+echo >&2 "checking httproute ${route_name} in ${route_namespace}..."
+
+route_json=$(kubectl get --namespace "$route_namespace" httproute "$route_name" -o json)
 
 hostname=$(echo "$route_json" | jq -r '.spec.hostnames[0] // "unknown"')
 gateway=$(echo "$route_json" | jq -r '.spec.parentRefs[0].name // "unknown"')
 gateway_namespace=$(echo "$route_json" | jq -r '.spec.parentRefs[0].namespace // .metadata.namespace')
 
-# A route is serving traffic when its parent gateway reports both Accepted and
-# ResolvedRefs = True. Empty conditions (not yet reconciled) count as unhealthy.
 accepted=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="Accepted") | .status] | (length > 0) and (all(. == "True"))')
 resolved=$(echo "$route_json" | jq -r '[.status.parents[]?.conditions[]? | select(.type=="ResolvedRefs") | .status] | (length > 0) and (all(. == "True"))')
 
@@ -25,12 +31,12 @@ fi
 
 gateway_address=$(kubectl get --namespace "$gateway_namespace" gateway "$gateway" -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "unknown")
 
-outputs=$(jq --null-input \
+jq -cn \
   --arg hn "$hostname" \
   --arg gw "$gateway" \
   --arg addr "$gateway_address" \
   --arg accepted "$accepted" \
   --arg resolved "$resolved" \
   --arg indicatorVar "$indicator" \
-  '{"indicator": $indicatorVar, "hostname": $hn, "gateway": $gw, "gateway_address": $addr, "accepted": $accepted, "resolved_refs": $resolved}')
-echo "$outputs" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  '{indicator: $indicatorVar, hostname: $hn, gateway: $gw, gateway_address: $addr, accepted: $accepted, resolved_refs: $resolved}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"


### PR DESCRIPTION
Two fixes for the GCP ctl-api/dashboard status actions (Gateway API, no Ingress objects):

1. ctl_api_post_deploy still used `kubectl get ingress` (missed in #766) — now queries the HTTPRoute like the others.
2. All three route healthchecks (dashboard_status, api_status, ctl_api_post_deploy) emitted pretty-printed multi-line JSON via a quoted echo, which the runner's line-by-line output parser rejected ("unexpected end of JSON input"). Now emit compact single-line JSON with `jq -cn`.

Scripts also accept ROUTE_NAME/ROUTE_NAMESPACE or the legacy INGRESS_NAME/INGRESS_NAMESPACE, so script/toml version skew during sync can't leave a step with an unset var. Validated against a live install (external + internal gateway routes).