### PR TITLE
feat: trigger install config file sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,3 +1,5 @@
+name: Sync to Nuon
+
 on:
   push:
     branches: main

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -74,3 +74,18 @@ jobs:
         env:
           NUON_ORG_ID: org4f5hq4tyo44legra6r4nm18
           NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN_org4f5hq4tyo44legra6r4nm18 }}
+
+      - name: Trigger BYOC install configs sync in nuonco/mono
+        if: steps.check_label.outputs.skip != 'true' && success()
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.MONO_REPO_DISPATCH_TOKEN }}
+          repository: nuonco/mono
+          event-type: byoc-sync-completed
+          client-payload: |
+            {
+              "dry_run": true,
+              "source_run_id": "${{ github.run_id }}",
+              "source_sha": "${{ github.sha }}",
+              "source_actor": "${{ github.actor }}"
+            }


### PR DESCRIPTION
## Summary

We maintain our own set of install config files to manage Nuon BYOC installs. These are kept in a separate, private repo, but we want to be able to trigger a dry-run sync for them when we merge changes to the BYOC app configs. This will help us catch compatibility issues early.

This PR updates the github action to trigger a sync after a successful app config sync. We don't want to trigger updates to all installs on every merge, so we pass in the dry-run flag.