### PR TITLE
chore: replace runbook type: deploy with type: component_deploy

### DIFF
--- a/byoc-nuon-gcp/runbooks/deploy_control_plane.toml
+++ b/byoc-nuon-gcp/runbooks/deploy_control_plane.toml
@@ -5,12 +5,12 @@ labels      = { service = "ctl-api", type = "sop" }
 
 [[steps]]
 name           = "ctl-api: Sync image"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "img_nuon_ctl_api"
 
 [[steps]]
 name           = "dashboard-ui: Sync image"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "img_nuon_dashboard_ui"
 
 [[steps]]
@@ -25,7 +25,7 @@ action_name = "ch_init"
 
 [[steps]]
 name            = "ctl-api: Deploy"
-type            = "deploy"
+type            = "component_deploy"
 component_name  = "ctl_api"
 
 [[steps]]
@@ -40,5 +40,5 @@ action_name = "ctl_api_post_deploy"
 
 [[steps]]
 name            = "dashboard-ui: Deploy"
-type            = "deploy"
+type            = "component_deploy"
 component_name  = "dashboard_ui"

--- a/byoc-nuon/runbooks/deploy_control_plane.toml
+++ b/byoc-nuon/runbooks/deploy_control_plane.toml
@@ -5,12 +5,12 @@ labels      = { service = "ctl-api", type = "sop" }
 
 [[steps]]
 name           = "ctl-api: Sync image"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "img_nuon_ctl_api"
 
 [[steps]]
 name           = "dashboard-ui: Sync image"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "img_nuon_dashboard_ui"
 
 [[steps]]
@@ -25,7 +25,7 @@ action_name = "ch_init"
 
 [[steps]]
 name            = "ctl-api: Deploy"
-type            = "deploy"
+type            = "component_deploy"
 component_name  = "ctl_api"
 
 [[steps]]
@@ -40,5 +40,5 @@ action_name = "ctl_api_post_deploy"
 
 [[steps]]
 name            = "dashboard-ui: Deploy"
-type            = "deploy"
+type            = "component_deploy"
 component_name  = "dashboard_ui"


### PR DESCRIPTION
Fixing these deprecation warnings:

```
~/C/b/byoc-nuon-gcp ❯❯❯ nuon apps sync
 syncing directory from /Users/yellott/Code/byoc/byoc-nuon-gcp
 validating configs
 all configs valid
 deprecated: runbook "deploy_control_plane" step "ctl-api: Sync image": type 'deploy' is deprecated, use 'component_deploy' instead
 deprecated: runbook "deploy_control_plane" step "dashboard-ui: Sync image": type 'deploy' is deprecated, use 'component_deploy' instead
 deprecated: runbook "deploy_control_plane" step "ctl-api: Deploy": type 'deploy' is deprecated, use 'component_deploy' instead
 deprecated: runbook "deploy_control_plane" step "dashboard-ui: Deploy": type 'deploy' is deprecated, use 'component_deploy' instead
 ```