### PR TITLE
feat: rename "Nuon BYOC" to "Nuon BYOC AWS"

### DIFF
--- a/byoc-nuon/metadata.toml
+++ b/byoc-nuon/metadata.toml
@@ -1,5 +1,5 @@
 version = "v2"
 
 description  = "Nuon - Bring your own cloud"
-display_name = "BYOC Nuon"
+display_name = "BYOC Nuon AWS"
 readme       = "./README.md"


### PR DESCRIPTION
## Summary

Now that we have Nuon BYOC GCP, we should make things more clear.