### PR TITLE
Ja/gcp provision fixes

### DIFF
--- a/byoc-nuon-gcp/src/components/cloudsql_network/main.tf
+++ b/byoc-nuon-gcp/src/components/cloudsql_network/main.tf
@@ -1,3 +1,9 @@
+resource "google_project_service" "service_networking" {
+  project            = var.project_id
+  service            = "servicenetworking.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "google_compute_global_address" "private_services" {
   project       = var.project_id
   name          = "cloudsql-${var.install_id}"
@@ -12,4 +18,6 @@ resource "google_service_networking_connection" "private_services" {
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_services.name]
   deletion_policy         = "ABANDON"
+
+  depends_on = [google_project_service.service_networking]
 }

--- a/byoc-nuon-gcp/src/components/cloudsql_nuon/main.tf
+++ b/byoc-nuon-gcp/src/components/cloudsql_nuon/main.tf
@@ -1,3 +1,9 @@
+resource "google_project_service" "sqladmin" {
+  project            = var.project_id
+  service            = "sqladmin.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "google_sql_database_instance" "nuon" {
   project          = var.project_id
   name             = "nuon-${var.install_id}"
@@ -5,6 +11,8 @@ resource "google_sql_database_instance" "nuon" {
   database_version = "POSTGRES_15"
 
   deletion_protection = var.deletion_protection
+
+  depends_on = [google_project_service.sqladmin]
 
   settings {
     tier              = var.tier


### PR DESCRIPTION
## Summary

Assorted fixes for provisioning Nuon BYOC GCP into a fresh GCP project.

- Enable the Service Networking API in the cloudsql_network component
- Enable the SQL Admin API in the cloudsql_nuon component