### PR TITLE
feat: use runner init script with management mode for gcp

### DIFF
--- a/byoc-nuon-gcp/runner.toml
+++ b/byoc-nuon-gcp/runner.toml
@@ -1,3 +1,4 @@
-#:schema https://api.nuon.co/v1/general/config-schema?source=runner
+#:schema https://api.nuon.co/v1/general/config-schema?type=runner
 runner_type  = "gcp"
 helm_driver  = "configmap"
+init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/gcp/init-mng-v2.sh"


### PR DESCRIPTION
## Summary

Update the GCP app config to use the new init script version with management mode. We can switch back to the default once this change has been tested and merged.