### PR TITLE
chore: bump amazon linux alias to v20260610

### DIFF
--- a/byoc-nuon/inputs/karpenter/karpenter_ami_alias.toml
+++ b/byoc-nuon/inputs/karpenter/karpenter_ami_alias.toml
@@ -1,6 +1,6 @@
 name         = "karpenter_ami_alias"
 description  = "The AWS AMI Alias for the Karpenter EC2 Nodeclasses. Set globally."
-default      = "al2023@v20260520"
+default      = "al2023@v20260610"
 display_name = "Runner Image URL"
 group        = "karpenter"
 required     = true


### PR DESCRIPTION
Auto-bump of the Karpenter AL2023 AMI alias to N-1.

- Latest release: `v20260618`
- N-1 (this PR):  `v20260610`
- Previous:       `v20260520`

Source: https://github.com/awslabs/amazon-eks-ami/releases