### PR TITLE
feat: make loops api key a vendor-provided secret

### DIFF
--- a/byoc-nuon-gcp/actions/email/sync_loops_secret/sync-loops-secret.sh
+++ b/byoc-nuon-gcp/actions/email/sync_loops_secret/sync-loops-secret.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# sync-loops-secret (GCP)
+#
+# Reads the central Loops secret (the raw API key string) from the central AWS
+# Secrets Manager (byoc-infra-prod), writes it to the install's ctl-api
+# namespace as ctl-api-loops-api-key, then restarts ctl-api so it picks up the
+# new value.
+#
+# Unlike the AWS install (whose maintenance IAM role is granted on the secret
+# directly), a GCP install has no AWS identity. Instead it federates: the
+# runner mints a Google-signed OIDC token for its GCP identity (the
+# <install_id>-maintenance service account, via the GCE/GKE metadata server)
+# and exchanges it for temporary AWS credentials via
+# sts:AssumeRoleWithWebIdentity against the per-install IAM role whose trust
+# policy is bound to that GCP service account. That role is what the central
+# secret's resource policy and CMK key policy grant.
+#
+# Required env:
+#   LOOPS_SECRET_ARN  - full ARN of the central secret. Empty => skip (no-op).
+#   SECRETS_ROLE_ARN  - AWS IAM role to assume via web identity.
+#   SECRETS_AUDIENCE  - OIDC audience the role's trust policy expects.
+#   NAMESPACE         - k8s namespace for ctl-api (default ctl-api).
+#   INSTALL_ID        - used for the STS role session name.
+set -euo pipefail
+set -o errtrace
+
+: "${NAMESPACE:=ctl-api}"
+: "${SECRETS_AUDIENCE:=sts.amazonaws.com}"
+
+if [[ -z "${LOOPS_SECRET_ARN:-}" ]]; then
+  echo "LOOPS_SECRET_ARN is empty; Loops is not enabled for this install. Nothing to do."
+  exit 0
+fi
+
+if [[ -z "${SECRETS_ROLE_ARN:-}" ]]; then
+  echo "SECRETS_ROLE_ARN is empty; cannot federate into AWS to read the secret." >&2
+  exit 1
+fi
+
+# Region is encoded in the ARN: arn:aws:secretsmanager:<region>:<acct>:secret:<name>-<suffix>
+SECRETS_REGION=$(echo "$LOOPS_SECRET_ARN" | awk -F: '{print $4}')
+if [[ -z "$SECRETS_REGION" ]]; then
+  echo "could not parse region from LOOPS_SECRET_ARN: $LOOPS_SECRET_ARN" >&2
+  exit 1
+fi
+
+# 1. Mint a Google-signed OIDC identity token for this runner's GCP identity.
+#    Same metadata endpoint the runner uses internally (pkg/gcp identity.go).
+echo "minting GCP identity token (audience: $SECRETS_AUDIENCE)"
+WEB_IDENTITY_TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${SECRETS_AUDIENCE}&format=full")
+if [[ -z "$WEB_IDENTITY_TOKEN" ]]; then
+  echo "failed to mint GCP identity token from the metadata server" >&2
+  exit 1
+fi
+
+# 2. Exchange it for temporary AWS credentials (no pre-existing AWS creds needed).
+echo "assuming AWS role via web identity"
+echo "  role:   $SECRETS_ROLE_ARN"
+echo "  region: $SECRETS_REGION"
+CREDS=$(aws --region "$SECRETS_REGION" sts assume-role-with-web-identity \
+  --role-arn "$SECRETS_ROLE_ARN" \
+  --role-session-name "loops-sync-${INSTALL_ID:-nuon}" \
+  --web-identity-token "$WEB_IDENTITY_TOKEN" \
+  --query 'Credentials' --output json)
+
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -er '.AccessKeyId')
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -er '.SecretAccessKey')
+export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -er '.SessionToken')
+
+# 3. Read the central secret with the temporary credentials. The secret string
+#    is the raw Loops API key (no JSON wrapper).
+echo "reading central Loops secret"
+echo "  arn: $LOOPS_SECRET_ARN"
+API_KEY=$(aws --region "$SECRETS_REGION" secretsmanager get-secret-value \
+  --secret-id "$LOOPS_SECRET_ARN" \
+  --query SecretString --output text)
+
+if [[ -z "$API_KEY" || "$API_KEY" == "None" ]]; then
+  echo "central Loops secret is empty" >&2
+  exit 1
+fi
+
+apply_secret() {
+  local name="$1" value="$2"
+  echo "applying secret $NAMESPACE/$name"
+  # --dry-run=client | apply keeps this idempotent without leaking value to argv
+  kubectl create secret generic "$name" \
+    -n "$NAMESPACE" \
+    --from-literal=value="$value" \
+    --dry-run=client -o yaml \
+    | kubectl apply -f -
+}
+
+apply_secret ctl-api-loops-api-key "$API_KEY"
+
+# Restart ctl-api so it re-reads the secret value.
+# -l label is more durable than a hard-coded deployment name across chart bumps.
+if kubectl -n "$NAMESPACE" get deploy -l app.nuon.co/name=ctl-api -o name | grep -q deploy; then
+  echo "restarting ctl-api deployment"
+  kubectl -n "$NAMESPACE" rollout restart deploy -l app.nuon.co/name=ctl-api
+else
+  echo "no ctl-api deployment found in $NAMESPACE; secret applied, restart skipped"
+fi
+
+echo "done"

--- a/byoc-nuon-gcp/actions/email/sync_loops_secret/sync_loops_secret.toml
+++ b/byoc-nuon-gcp/actions/email/sync_loops_secret/sync_loops_secret.toml
@@ -1,0 +1,24 @@
+# action
+# description: Fetches the Loops API key from the central AWS Secrets Manager
+# entry referenced by LOOPS_SECRET_ARN — federating this GCP install's identity
+# into AWS via web identity (SECRETS_ROLE_ARN) — and writes it into the
+# install's ctl-api namespace, then restarts ctl-api so it picks up the new
+# value. Skips cleanly when LOOPS_SECRET_ARN is empty.
+name    = "sync_loops_secret"
+labels  = { service = "email", type = "sop" }
+label   = "email"
+timeout = "2m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "sync"
+inline_contents = "./email/sync_loops_secret/sync-loops-secret.sh"
+
+[steps.env_vars]
+LOOPS_SECRET_ARN  = "{{ or .nuon.inputs.inputs.loops_secret_arn \"\" }}"
+SECRETS_ROLE_ARN  = "{{ or .nuon.inputs.inputs.secrets_role_arn \"\" }}"
+SECRETS_AUDIENCE  = "sts.amazonaws.com"
+NAMESPACE         = "ctl-api"
+INSTALL_ID        = "{{ .nuon.install.id }}"

--- a/byoc-nuon-gcp/actions/slack/sync_slack_secrets/sync_slack_secrets.toml
+++ b/byoc-nuon-gcp/actions/slack/sync_slack_secrets/sync_slack_secrets.toml
@@ -18,7 +18,7 @@ inline_contents = "./slack/sync_slack_secrets/sync-slack-secrets.sh"
 
 [steps.env_vars]
 SLACK_SECRETS_ARN      = "{{ or .nuon.inputs.inputs.slack_secrets_arn \"\" }}"
-SLACK_SECRETS_ROLE_ARN = "{{ or .nuon.inputs.inputs.slack_secrets_role_arn \"\" }}"
-SLACK_SECRETS_AUDIENCE = "{{ or .nuon.inputs.inputs.slack_secrets_audience \"sts.amazonaws.com\" }}"
+SLACK_SECRETS_ROLE_ARN = "{{ or .nuon.inputs.inputs.secrets_role_arn \"\" }}"
+SLACK_SECRETS_AUDIENCE = "sts.amazonaws.com"
 NAMESPACE              = "ctl-api"
 INSTALL_ID             = "{{ .nuon.install.id }}"

--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -91,7 +91,6 @@ env:
   BLOB_STORAGE_REGION: "{{ .nuon.install_stack.outputs.region }}"
 
   SEGMENT_WRITE_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  LOOPS_API_KEY: "{{ .nuon.inputs.inputs.loops_api_key }}"
 
   # GCP management
   MANAGEMENT_GAR_REPOSITORY_URL: "{{ .nuon.components.management.outputs.gar.repository_url }}"
@@ -139,6 +138,11 @@ envSecrets:
     optional: true
     valueFrom:
       name: ctl-api-slack-state-jwt-secret
+      key: value
+  - name: "LOOPS_API_KEY"
+    optional: true
+    valueFrom:
+      name: ctl-api-loops-api-key
       key: value
 
 image:

--- a/byoc-nuon-gcp/docs/aws-gcp-identity-federation.md
+++ b/byoc-nuon-gcp/docs/aws-gcp-identity-federation.md
@@ -172,8 +172,8 @@ sequenceDiagram
 2. In `mono/infra/byoc-secrets`, add the install to `var.gcp_installs` with that
    id, and apply. This creates/updates the OIDC provider's `client_id_list`, the
    `…-secret-reader` role, and the secret grants.
-3. Set the install inputs `slack_secrets_arn` and `slack_secrets_role_arn` (from
-   the workspace outputs `slack_secret_arns` / `slack_secret_role_arns`).
+3. Set the install inputs `slack_secrets_arn` and `secrets_role_arn` (from
+   the workspace outputs `slack_secret_arns` / `secret_reader_role_arns`).
 4. Run the `slack_setup` runbook.
 
 See [`runbooks/slack_setup.md`](../runbooks/slack_setup.md) for the full

--- a/byoc-nuon-gcp/input_groups/secrets.toml
+++ b/byoc-nuon-gcp/input_groups/secrets.toml
@@ -1,0 +1,3 @@
+name         = "secrets"
+description  = "Federation settings this install uses to read its credentials from the central, vendor-owned AWS Secrets Manager store. Shared by all integrations that source secrets from that store."
+display_name = "Central secrets"

--- a/byoc-nuon-gcp/inputs/email/loops_api_key.toml
+++ b/byoc-nuon-gcp/inputs/email/loops_api_key.toml
@@ -1,7 +1,0 @@
-name         = "loops_api_key"
-description  = "An API key from your loops account."
-default      = "your-loops-api-key"
-display_name = "Loops API Key"
-group        = "email"
-required     = false
-user_configurable = false

--- a/byoc-nuon-gcp/inputs/email/loops_secret_arn.toml
+++ b/byoc-nuon-gcp/inputs/email/loops_secret_arn.toml
@@ -1,0 +1,8 @@
+name         = "loops_secret_arn"
+description  = "ARN of the AWS Secrets Manager secret in the central account that holds this install's Loops API key. The raw secret string is the API key. Read via web identity federation (see secrets_role_arn). Leave empty to keep Loops disabled."
+default      = ""
+display_name = "Loops Secret ARN"
+required     = false
+group        = "email"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/secrets/secrets_role_arn.toml
+++ b/byoc-nuon-gcp/inputs/secrets/secrets_role_arn.toml
@@ -1,0 +1,8 @@
+name         = "secrets_role_arn"
+description  = "ARN of the AWS IAM role this GCP install assumes (via sts:AssumeRoleWithWebIdentity) to read its secrets from the central AWS Secrets Manager store. The role's trust policy is bound to this install's maintenance GCP service account, and the role is granted read on this install's secrets + CMK. Leave empty to keep central-secret sync disabled."
+default      = ""
+display_name = "Central Secrets Role ARN"
+required     = false
+group        = "secrets"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/slack/slack_secrets_arn.toml
+++ b/byoc-nuon-gcp/inputs/slack/slack_secrets_arn.toml
@@ -1,5 +1,5 @@
 name         = "slack_secrets_arn"
-description  = "ARN of the AWS Secrets Manager secret in the central account that holds this install's Slack app credentials. JSON value with keys client_secret and signing_secret. Read via web identity federation (see slack_secrets_role_arn). Leave empty to keep Slack disabled."
+description  = "ARN of the AWS Secrets Manager secret in the central account that holds this install's Slack app credentials. JSON value with keys client_secret and signing_secret. Read via web identity federation (see secrets_role_arn). Leave empty to keep Slack disabled."
 default      = ""
 display_name = "Slack Secrets ARN"
 required     = false

--- a/byoc-nuon-gcp/inputs/slack/slack_secrets_audience.toml
+++ b/byoc-nuon-gcp/inputs/slack/slack_secrets_audience.toml
@@ -1,8 +1,0 @@
-name         = "slack_secrets_audience"
-description  = "OIDC audience embedded in the Google-signed identity token used to assume slack_secrets_role_arn. Must match the audience condition in the AWS role's trust policy. Defaults to sts.amazonaws.com."
-default      = "sts.amazonaws.com"
-display_name = "Slack Secrets Audience"
-required     = false
-group        = "slack"
-
-user_configurable = false

--- a/byoc-nuon-gcp/inputs/slack/slack_secrets_role_arn.toml
+++ b/byoc-nuon-gcp/inputs/slack/slack_secrets_role_arn.toml
@@ -1,8 +1,0 @@
-name         = "slack_secrets_role_arn"
-description  = "ARN of the AWS IAM role this GCP install assumes (via sts:AssumeRoleWithWebIdentity) to read the central Slack secret. The role's trust policy is bound to this install's maintenance GCP service account, and the role is granted access to the secret + CMK. Leave empty to keep Slack disabled."
-default      = ""
-display_name = "Slack Secrets Role ARN"
-required     = false
-group        = "slack"
-
-user_configurable = false

--- a/byoc-nuon-gcp/runbooks/loops_setup.md
+++ b/byoc-nuon-gcp/runbooks/loops_setup.md
@@ -1,0 +1,88 @@
+{{ $loopsSynced := false }}{{ with index (default dict .nuon.actions.workflows) "sync_loops_secret" }}{{ if eq .status "finished" }}{{ $loopsSynced = true }}{{ end }}{{ end }}
+
+# Loops setup — {{ if $loopsSynced }}✅ Completed{{ else }}⏳ Pending{{ end }}
+
+<nuon-banner theme="warn">Run this only after the install has finished provisioning. It assumes the ctl-api is
+healthy.</nuon-banner>
+
+Manual steps required to wire the Loops API key into this install **after it has been provisioned**.
+
+<nuon-group gap="2" align="center" justify="start">{{ if $loopsSynced }}<nuon-status status="active" variant="badge"></nuon-status><nuon-label-badge label="status:synced"></nuon-label-badge>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status><nuon-label-badge label="status:not yet run"></nuon-label-badge>{{ end }}{{ with index (default dict .nuon.actions.workflows) "sync_loops_secret" }}{{ with dig "updated_at" "" . }}<span style="margin-left:auto;font-size:0.85em;">Last
+synced <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}{{ end }}</nuon-group>
+
+Process for delivering the Loops API key to `ctl-api`. The key is sourced from a central, vendor-owned secret store,
+then pulled into the install's `ctl-api` namespace as the `ctl-api-loops-api-key` secret and mounted as the
+`LOOPS_API_KEY` env var.
+
+The flow spans two places:
+
+- **[nuonco/mono/infra/byoc-secrets](https://github.com/nuonco/mono/tree/main/infra/byoc-secrets)** — the central AWS
+  Secrets Manager entry (in the `byoc-infra-prod` account) at `nuon/byoc-nuon/{{ .nuon.install.id }}/loops` that holds
+  this install's Loops API key. The same central store serves every install regardless of cloud.
+- **this install** — the `loops_secret_arn` input and this runbook's `sync_loops_secret` step that pulls the secret
+  into the install's `ctl-api` namespace.
+
+<nuon-banner theme="info">The secret value never lives in Terraform state. Terraform only creates the empty secret container and the grants; the value is written out-of-band.</nuon-banner>
+
+### Prerequisites
+
+- The install is provisioned and the control plane is healthy.
+- The install's federated secret-reader role (`{{ .nuon.install.id }}-secret-reader`) exists and its ARN is set on the
+  `secrets_role_arn` input. This role is provisioned by `byoc-secrets` when the install is enrolled.
+- You have credentials for the `byoc-infra-prod` AWS account.
+- You can open PRs against `nuonco/mono`.
+
+### 1. Provision the central secret
+
+In `nuonco/mono`, the `infra/byoc-secrets` workspace creates a per-install Loops secret container. Every install already
+in `var.installs` / `var.gcp_installs` gets a `nuon/byoc-nuon/<install_id>/loops` container — no per-install Terraform
+edit is needed beyond having this install enrolled.
+
+Once applied, note the **secret ARN** for this install from the `loops_secret_arns` output.
+
+### 2. Populate the secret value
+
+The Loops secret value is the **raw API key string** (no JSON wrapper). From a host with `byoc-infra-prod` credentials
+run:
+
+```bash
+AWS_PROFILE=byoc-infra-prod.NuonPowerUser AWS_REGION=us-west-2 \
+aws secretsmanager put-secret-value \
+  --secret-id "nuon/byoc-nuon/{{ .nuon.install.id }}/loops" \
+  --secret-string "<loops api key>"
+```
+
+### 3. Set the install input
+
+Set the install's `loops_secret_arn` input (in the `email` input group) to the ARN from the `loops_secret_arns` output
+in step 1. Leave it empty to keep Loops disabled.
+
+```toml
+# input.group: email
+[[inputs]]
+loops_secret_arn = '<arn from loops_secret_arns output>'
+```
+
+`sync_loops_secret` uses the `secrets_role_arn` input to federate into AWS.
+
+### 4. Run the `Loops: Sync loops secret` step {{ if $loopsSynced }}✅ (completed){{ end }}
+
+{{ if $loopsSynced }}<nuon-banner theme="success"> This step has at least one successful run. Re-run it only to pick up a
+rotated key. </nuon-banner>{{ else }}<nuon-banner theme="info"> Not run yet. Run this runbook to complete this step.
+</nuon-banner>{{ end }}
+
+After the install sync applies, run this runbook. Its `Loops: Sync loops secret` step runs the `sync_loops_secret`
+action, which:
+
+- mints a Google-signed OIDC token for the `{{ .nuon.install.id }}-maintenance` service account and assumes
+  `secrets_role_arn` via `sts:AssumeRoleWithWebIdentity`, then reads the central secret referenced by
+  `loops_secret_arn`,
+- writes `ctl-api-loops-api-key` into the install's `ctl-api` namespace,
+- restarts `ctl-api` so it picks up the value.
+
+If `loops_secret_arn` is empty, the action is a no-op and Loops stays disabled.
+
+### Rotating the Loops API key
+
+Re-run **step 2** with the new value, then re-run this runbook's `Loops: Sync loops secret` step. No Terraform change is
+required.

--- a/byoc-nuon-gcp/runbooks/loops_setup.toml
+++ b/byoc-nuon-gcp/runbooks/loops_setup.toml
@@ -1,0 +1,9 @@
+name        = "loops_setup"
+description = "Set up the Loops integration for this install: provision and populate the central secret, set the loops_secret_arn input, then sync the API key into the ctl-api namespace."
+readme      = "./runbooks/loops_setup.md"
+labels      = { service = "email", type = "setup" }
+
+[[steps]]
+name        = "Loops: Sync loops secret"
+type        = "action"
+action_name = "sync_loops_secret"

--- a/byoc-nuon-gcp/runbooks/slack_setup.md
+++ b/byoc-nuon-gcp/runbooks/slack_setup.md
@@ -124,7 +124,7 @@ gcloud iam service-accounts describe \
 Once merged, Terraform Cloud creates the empty Slack secret container at `nuon/byoc-nuon/{{ .nuon.install.id }}/slack`,
 creates a per-install `{{ .nuon.install.id }}-secret-reader` IAM role trusting that GCP service account (via the built-in
 `accounts.google.com` provider), and grants the role `secretsmanager:GetSecretValue` + `kms:Decrypt` on the secret and
-CMK. Note the **secret ARN** and the **role ARN** from the `slack_secret_arns` / `slack_secret_role_arns` outputs.
+CMK. Note the **secret ARN** and the **role ARN** from the `slack_secret_arns` / `secret_reader_role_arns` outputs.
 
 ### 3. Populate the secret value
 
@@ -148,13 +148,14 @@ Set the install's Slack inputs in the install config file. The relevant inputs:
 
 | Input                      | Value                                                       |
 | -------------------------- | ----------------------------------------------------------- |
-| `slack_enabled`            | `true`                                                      |
-| `slack_client_id`          | the Slack app's Client ID from step 1                       |
-| `slack_secrets_arn`        | the ARN from the `slack_secret_arns` output in step 2       |
-| `slack_secrets_role_arn`   | the ARN from the `slack_secret_role_arns` output in step 2  |
+| `slack_enabled`     | `true`                                                            |
+| `slack_client_id`   | the Slack app's Client ID from step 1                             |
+| `slack_secrets_arn` | the ARN from the `slack_secret_arns` output in step 2             |
+| `secrets_role_arn`  | the ARN from the `secret_reader_role_arns` output in step 2       |
 
-Set these in the install config file. `slack_enabled` lives in the `nuon` input group; the rest live in the `slack`
-input group. Fill in the Client ID from step 1 and the ARNs from step 2:
+Set these in the install config file. `slack_enabled` lives in the `nuon` input group; `slack_client_id` and
+`slack_secrets_arn` live in the `slack` input group; `secrets_role_arn` lives in the `secrets` input group (it is the
+shared central-secrets federation role, not Slack-specific). Fill in the Client ID from step 1 and the ARNs from step 2:
 
 ```toml
 # input.group: nuon
@@ -163,16 +164,16 @@ slack_enabled = 'true'
 
 # input.group: slack
 [[inputs]]
-slack_client_id        = '<slack client id>'
-slack_secrets_arn      = '<arn from slack_secret_arns output>'
-slack_secrets_role_arn = '<arn from slack_secret_role_arns output>'
+slack_client_id   = '<slack client id>'
+slack_secrets_arn = '<arn from slack_secret_arns output>'
+
+# input.group: secrets
+[[inputs]]
+secrets_role_arn = '<arn from secret_reader_role_arns output>'
 ```
 
 The OAuth redirect URL is **not** an input — ctl-api derives it as
 `https://slack.<root_domain>/slack/oauth/callback`, which matches the URL registered in the Slack app manifest (step 1).
-
-`slack_secrets_audience` defaults to `sts.amazonaws.com` and only needs setting if the federated role's trust policy
-expects a different audience.
 
 ### 5. Run the `Slack: Sync slack secrets` step {{ if $slackSynced }}✅ (completed){{ end }}
 
@@ -184,7 +185,7 @@ After the install sync applies, run this runbook. Its `Slack: Sync slack secrets
 action, which:
 
 - mints a Google-signed OIDC token for the `{{ .nuon.install.id }}-maintenance` service account and assumes
-  `slack_secrets_role_arn` via `sts:AssumeRoleWithWebIdentity`, then reads the central secret referenced by
+  `secrets_role_arn` via `sts:AssumeRoleWithWebIdentity`, then reads the central secret referenced by
   `slack_secrets_arn`,
 - writes `ctl-api-slack-client-secret` and `ctl-api-slack-signing-secret` into the install's `ctl-api` namespace,
 - restarts `api-slack` so it picks up the values.

--- a/byoc-nuon-gcp/secrets/email/loops_api_key.toml
+++ b/byoc-nuon-gcp/secrets/email/loops_api_key.toml
@@ -1,0 +1,6 @@
+name         = "loops_api_key"
+display_name = "Loops API Key"
+description  = "API key for your Loops account. Managed out-of-band: the central AWS Secrets Manager entry referenced by loops_secret_arn is the source of truth, and the sync_loops_secret action writes the value into k8s."
+default      = "dne" # "empty" value — disables Loops integration
+
+user_configurable = true


### PR DESCRIPTION
## Summary

We want to move the loops api key from being an input to a vendor-provided secret. This PR adds an action, runbook, and input and secret config changes to support this.