### PR TITLE
fix: remove old branch

### DIFF
--- a/byoc-nuon-gcp/components/92-helm-ctl_api.toml
+++ b/byoc-nuon-gcp/components/92-helm-ctl_api.toml
@@ -11,7 +11,7 @@ repo      = "nuonco/charts"
 directory = "charts/ctl-api"
 # TEMP: testing the GCP slack HTTPRoute fix before merge — revert to a tagged
 # release (e.g. ctl-api-v0.3.4) once merged.
-branch    = "ja/fix-slack-ingress"
+branch    = "main"
 
 [[values_file]]
 contents = "./values/ctl-api.yaml"


### PR DESCRIPTION
## Summary

Forgot to switch the ctl-api component back to main after testing changes to the helm chart.