### PR TITLE
feat(gcp): add dns_setup runbook

### DIFF
--- a/byoc-nuon-gcp/runbooks/dns_setup.md
+++ b/byoc-nuon-gcp/runbooks/dns_setup.md
@@ -1,0 +1,60 @@
+{{ $inputs := (default dict (index (default dict .nuon.inputs) "inputs")) }}
+{{ $root_domain := (dig "root_domain" "" $inputs) }}
+{{ $public_domain := (dig "outputs" "nuon_dns" "public_domain" "name" $root_domain .nuon.sandbox) }}
+
+When an install is created, a Cloud DNS zone is provisioned for each of its
+domains. Share the nameservers below with the customer so they can add `NS`
+records in their registrar (or parent DNS provider) delegating the domain to
+this install. Until those records are in place, services for the install will
+not resolve.
+
+{{ if (and .nuon.sandbox.populated .nuon.sandbox.outputs) }}
+
+#### Root Domain
+
+Services for this install are served at subdomains of this domain.
+
+Domain:
+
+```
+{{ $public_domain }}
+```
+
+Nameservers (create an `NS` record set on the domain above with these values):
+
+```
+{{ range $ns := dig "nuon_dns" "public_domain" "nameservers" (list) (default dict .nuon.sandbox.outputs) }}{{ $ns }}
+{{ end }}```
+
+{{ else }}
+
+> [!WARNING]
+> Waiting on Sandbox Provision. Once the Sandbox is ready, the root domain records will be visible here.
+
+{{ end }}
+
+{{ $dnsZone := dig "dns_zone" dict (default dict (default dict .nuon.components.management).outputs) }}
+{{ if $dnsZone }}
+
+#### Nuon DNS Delegation Domain
+
+Cloud DNS zones for managed installs are provisioned under this domain.
+
+Domain:
+
+```
+{{ dig "domain" "" $dnsZone }}
+```
+
+Nameservers (create an `NS` record set on the domain above with these values):
+
+```
+{{ range $ns := dig "nameservers" (list) $dnsZone }}{{ $ns }}
+{{ end }}```
+
+{{ else }}
+
+> [!WARNING]
+> Waiting on the management component to deploy. Once it is ready, the delegation domain records will be visible here.
+
+{{ end }}

--- a/byoc-nuon-gcp/runbooks/dns_setup.toml
+++ b/byoc-nuon-gcp/runbooks/dns_setup.toml
@@ -1,0 +1,9 @@
+name        = "dns_setup"
+description = "Show the DNS delegation records (nameservers) to share with the customer so they can delegate their domain to this install."
+readme      = "./runbooks/dns_setup.md"
+labels      = { service = "dns", type = "setup" }
+
+[[steps]]
+name           = "Refresh DNS delegation zone"
+type           = "component_deploy"
+component_name = "management"


### PR DESCRIPTION
We don't actually need to run anything for this runbook, but it makes the nameservers easier to share based on the install's domains:

<img width="1426" height="1288" alt="image" src="https://github.com/user-attachments/assets/af1060c9-c95a-4380-a6b2-829adb01870d" />

