### PR TITLE
fix: go back to input for loops api key

### DIFF
--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -91,6 +91,7 @@ env:
   BLOB_STORAGE_REGION: "{{ .nuon.install_stack.outputs.region }}"
 
   SEGMENT_WRITE_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  LOOPS_API_KEY: "{{ .nuon.inputs.inputs.loops_api_key }}"
 
   # GCP management
   MANAGEMENT_GAR_REPOSITORY_URL: "{{ .nuon.components.management.outputs.gar.repository_url }}"
@@ -138,11 +139,6 @@ envSecrets:
     optional: true
     valueFrom:
       name: ctl-api-slack-state-jwt-secret
-      key: value
-  - name: "LOOPS_API_KEY"
-    optional: true
-    valueFrom:
-      name: ctl-api-loops-api-key
       key: value
 
 image:

--- a/byoc-nuon-gcp/secrets/email/loops_api_key.toml
+++ b/byoc-nuon-gcp/secrets/email/loops_api_key.toml
@@ -1,6 +1,0 @@
-name         = "loops_api_key"
-display_name = "Loops API Key"
-description  = "API key for your Loops account. Managed out-of-band: the central AWS Secrets Manager entry referenced by loops_secret_arn is the source of truth, and the sync_loops_secret action writes the value into k8s."
-default      = "dne" # "empty" value — disables Loops integration
-
-user_configurable = true


### PR DESCRIPTION
## Summary

The helm chart fails to deploy when providing this as a secret. Until that's fixed, we'll stick with providing it as an input.