### PR TITLE
fix: add the loops api key input back

### DIFF
--- a/byoc-nuon-gcp/inputs/email/loops_api_key.toml
+++ b/byoc-nuon-gcp/inputs/email/loops_api_key.toml
@@ -1,0 +1,7 @@
+name         = "loops_api_key"
+description  = "An API key from your loops account."
+default      = "your-loops-api-key"
+display_name = "Loops API Key"
+group        = "email"
+required     = false
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/email/loops_secret_arn.toml
+++ b/byoc-nuon-gcp/inputs/email/loops_secret_arn.toml
@@ -1,8 +1,0 @@
-name         = "loops_secret_arn"
-description  = "ARN of the AWS Secrets Manager secret in the central account that holds this install's Loops API key. The raw secret string is the API key. Read via web identity federation (see secrets_role_arn). Leave empty to keep Loops disabled."
-default      = ""
-display_name = "Loops Secret ARN"
-required     = false
-group        = "email"
-
-user_configurable = false


### PR DESCRIPTION
## Summary

Forgot to add the old loops api key input back after removing the secret.