### PR TITLE
fix: PVCs and other operational cleanup for clickhouse on GCP

### DIFF
--- a/byoc-nuon-gcp/actions/clickhouse/ch_verify_backups/ch_verify_backups.sh
+++ b/byoc-nuon-gcp/actions/clickhouse/ch_verify_backups/ch_verify_backups.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+# Verifies the ClickHouse GCS backup pipeline:
+#   1. the HMAC credential secret exists
+#   2. the backup CronJob(s) exist
+#   3. a manually-triggered backup run completes (logs should show BACKUP_CREATED)
+#   4. backup objects are present in the GCS bucket
+#
+# Required env:
+#   BUCKET_NAME   the ClickHouse backup bucket (gcs_buckets.outputs.clickhouse_bucket.name)
+# Optional env:
+#   BACKUP_TABLE  the table to verify (default "ctl_api.otel_log_records")
+#
+# Emits (to $NUON_ACTIONS_OUTPUT_FILEPATH): indicator, backup_job, table, cronjob,
+#   objects_found, updated_at
+
+NS=clickhouse
+BUCKET="$BUCKET_NAME"
+TABLE="${BACKUP_TABLE:-ctl_api.otel_log_records}"
+# cron name mirrors backups.tf: replace "_"->"-" then strip leading "ctl-api."
+CRON="ch-gcs-backup-$(echo "$TABLE" | sed 's/_/-/g; s/ctl-api\.//')"
+
+echo "### HMAC credential secret"
+secret_ok="true"
+kubectl -n "$NS" get secret clickhouse-backup-hmac || secret_ok="false"
+
+echo
+echo "### Backup CronJobs"
+kubectl -n "$NS" get cronjob
+
+echo
+echo "### Triggering a backup run from cronjob/$CRON"
+job="backup-verify-$(date +%s)"
+kubectl -n "$NS" create job "$job" --from=cronjob/"$CRON"
+
+set +e
+kubectl -n "$NS" wait --for=condition=complete "job/$job" --timeout=300s
+rc=$?
+set -e
+
+echo
+echo "### Job logs (expect BACKUP_CREATED)"
+kubectl -n "$NS" logs -l "job-name=$job" --tail=40 || true
+kubectl -n "$NS" delete job "$job" || true
+
+echo
+echo "### Objects in gs://$BUCKET/backups/$TABLE/"
+objects_found=$(gcloud storage ls "gs://$BUCKET/backups/$TABLE/" 2>/dev/null | grep -c . || true)
+gcloud storage ls "gs://$BUCKET/backups/$TABLE/" || true
+
+if [ "$rc" = "0" ]; then
+  backup_job="completed"
+else
+  backup_job="did-not-complete"
+fi
+echo "backup job: $backup_job  objects_found: $objects_found"
+
+# 🟢 when the secret exists, the run completed, and objects are present
+indicator="🔴"
+if [ "$secret_ok" = "true" ] && [ "$rc" = "0" ] && [ "$objects_found" -gt 0 ]; then
+  indicator="🟢"
+fi
+
+jq -n -c \
+  --arg ind "$indicator" \
+  --arg s "$backup_job" \
+  --arg t "$TABLE" \
+  --arg c "$CRON" \
+  --argjson of "$objects_found" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{indicator: $ind, backup_job: $s, table: $t, cronjob: $c, objects_found: $of, updated_at: $ts}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/clickhouse/ch_verify_backups/ch_verify_backups.toml
+++ b/byoc-nuon-gcp/actions/clickhouse/ch_verify_backups/ch_verify_backups.toml
@@ -1,0 +1,19 @@
+# action
+# description: verifies the ClickHouse GCS backup pipeline — HMAC secret + cronjob exist,
+# a triggered run completes, and backup objects are present in the bucket.
+name    = "ch_verify_backups"
+labels  = { service = "clickhouse", type = "debug" }
+label   = "gcp"
+timeout = "8m"
+role    = "{{.nuon.install.id}}-provision"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "verify_backups"
+inline_contents = "./clickhouse/ch_verify_backups/ch_verify_backups.sh"
+
+[steps.env_vars]
+BUCKET_NAME  = "{{ .nuon.components.gcs_buckets.outputs.clickhouse_bucket.name }}"
+BACKUP_TABLE = "ctl_api.otel_log_records"

--- a/byoc-nuon-gcp/actions/clickhouse/ch_verify_pod_spread/ch_verify_pod_spread.sh
+++ b/byoc-nuon-gcp/actions/clickhouse/ch_verify_pod_spread/ch_verify_pod_spread.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+# Verifies the ClickHouse pod anti-affinity is in effect:
+#   - the 2 server replicas must be on distinct nodes
+#   - the 3 keeper replicas must be on distinct nodes (ideally distinct zones, to keep
+#     raft quorum safe from a single zonal outage)
+#
+# Emits (to $NUON_ACTIONS_OUTPUT_FILEPATH): indicator, server_nodes, keeper_nodes,
+#   keeper_distinct_zones, server_distinct_nodes_ok, keeper_distinct_nodes_ok, updated_at
+
+NS=clickhouse
+SERVER_SEL="clickhouse.altinity.com/chi=clickhouse-installation"
+KEEPER_SEL="clickhouse-keeper.altinity.com/chk=clickhouse-keeper"
+
+echo "### Server replicas"
+kubectl -n "$NS" get pods -l "$SERVER_SEL" \
+  -o custom-columns='POD:.metadata.name,NODE:.spec.nodeName,ZONE:.metadata.labels.topology\.kubernetes\.io/zone'
+
+echo
+echo "### Keeper replicas"
+kubectl -n "$NS" get pods -l "$KEEPER_SEL" \
+  -o custom-columns='POD:.metadata.name,NODE:.spec.nodeName,ZONE:.metadata.labels.topology\.kubernetes\.io/zone'
+
+server_total=$(kubectl -n "$NS" get pods -l "$SERVER_SEL" -o jsonpath='{.items[*].spec.nodeName}' | tr ' ' '\n' | grep -c . || true)
+server_distinct=$(kubectl -n "$NS" get pods -l "$SERVER_SEL" -o jsonpath='{.items[*].spec.nodeName}' | tr ' ' '\n' | sort -u | grep -c . || true)
+keeper_total=$(kubectl -n "$NS" get pods -l "$KEEPER_SEL" -o jsonpath='{.items[*].spec.nodeName}' | tr ' ' '\n' | grep -c . || true)
+keeper_distinct=$(kubectl -n "$NS" get pods -l "$KEEPER_SEL" -o jsonpath='{.items[*].spec.nodeName}' | tr ' ' '\n' | sort -u | grep -c . || true)
+keeper_zones=$(kubectl -n "$NS" get pods -l "$KEEPER_SEL" -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}{end}' | sort -u | grep -c . || true)
+
+server_ok=false
+[ "$server_total" -gt 0 ] && [ "$server_total" = "$server_distinct" ] && server_ok=true
+keeper_ok=false
+[ "$keeper_total" -gt 0 ] && [ "$keeper_total" = "$keeper_distinct" ] && keeper_ok=true
+
+indicator="🔴"
+if [ "$server_ok" = "true" ] && [ "$keeper_ok" = "true" ]; then indicator="🟢"; fi
+
+echo
+echo "server: $server_distinct/$server_total distinct nodes (ok=$server_ok)"
+echo "keeper: $keeper_distinct/$keeper_total distinct nodes, $keeper_zones distinct zones (ok=$keeper_ok)"
+
+jq -n -c \
+  --arg ind "$indicator" \
+  --argjson so "$server_ok" \
+  --argjson ko "$keeper_ok" \
+  --arg sn "$server_distinct/$server_total" \
+  --arg kn "$keeper_distinct/$keeper_total" \
+  --argjson kz "$keeper_zones" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{indicator: $ind, server_distinct_nodes_ok: $so, keeper_distinct_nodes_ok: $ko, server_nodes: $sn, keeper_nodes: $kn, keeper_distinct_zones: $kz, updated_at: $ts}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/clickhouse/ch_verify_pod_spread/ch_verify_pod_spread.toml
+++ b/byoc-nuon-gcp/actions/clickhouse/ch_verify_pod_spread/ch_verify_pod_spread.toml
@@ -1,0 +1,13 @@
+# action
+# description: verifies ClickHouse pod anti-affinity — server and keeper replicas are
+# spread across distinct nodes (and reports distinct keeper zones).
+name    = "ch_verify_pod_spread"
+labels  = { service = "clickhouse", type = "debug" }
+timeout = "2m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "verify_pod_spread"
+inline_contents = "./clickhouse/ch_verify_pod_spread/ch_verify_pod_spread.sh"

--- a/byoc-nuon-gcp/actions/clickhouse/ch_verify_storage/ch_verify_storage.sh
+++ b/byoc-nuon-gcp/actions/clickhouse/ch_verify_storage/ch_verify_storage.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+# Verifies ClickHouse persistent storage:
+#   1. lists PVCs and flags any that are not Bound
+#   2. confirms the data dir is backed by a real disk (not an ephemeral overlay)
+#   3. (optional, disruptive) writes a row, restarts the StatefulSet, and confirms the
+#      row survived — the durability proof. Gated behind RUN_RESTART_TEST=true.
+#
+# Optional env:
+#   RUN_RESTART_TEST  "true" to run the disruptive write/restart/read test (default "false")
+#
+# Emits (to $NUON_ACTIONS_OUTPUT_FILEPATH): indicator, pvcs_bound, pvcs_total,
+#   unbound_pvcs, data_mount, restart_test, updated_at
+
+NS=clickhouse
+
+echo "### PVCs (expect one per server replica, Bound, 20Gi, storageclass ssd)"
+kubectl -n "$NS" get pvc
+
+pvcs_total=$(kubectl -n "$NS" get pvc -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -c . || true)
+pvcs_bound=$(kubectl -n "$NS" get pvc -o jsonpath='{range .items[*]}{.status.phase}{"\n"}{end}' | grep -c '^Bound$' || true)
+unbound=$(kubectl -n "$NS" get pvc \
+  -o jsonpath='{range .items[*]}{.metadata.name}={.status.phase}{"\n"}{end}' \
+  | grep -v '=Bound' || true)
+if [ -n "$unbound" ]; then
+  echo "WARNING: unbound PVCs:"
+  echo "$unbound"
+fi
+
+echo
+echo "### Data dir mount (should be a real PV device, not overlay/tmpfs)"
+pod=$(kubectl -n "$NS" get pods -l clickhouse.altinity.com/chi=clickhouse-installation \
+  -o jsonpath='{.items[0].metadata.name}')
+echo "using pod: $pod"
+kubectl -n "$NS" exec "$pod" -- df -h /var/lib/clickhouse
+data_mount=$(kubectl -n "$NS" exec "$pod" -- df -P /var/lib/clickhouse | tail -1 | awk '{print $1}')
+
+restart_test="skipped"
+if [ "${RUN_RESTART_TEST:-false}" = "true" ]; then
+  echo
+  echo "### Durability test (write -> rollout restart StatefulSet -> read back)"
+  sts="chi-clickhouse-installation-simple-0-0"
+  testpod="chi-clickhouse-installation-simple-0-0-0"
+  kubectl -n "$NS" exec "$testpod" -- clickhouse client -q \
+    "CREATE TABLE IF NOT EXISTS default.persist_check (id UInt32) ENGINE=MergeTree ORDER BY id"
+  kubectl -n "$NS" exec "$testpod" -- clickhouse client -q \
+    "INSERT INTO default.persist_check VALUES (42)"
+  kubectl -n "$NS" rollout restart statefulset "$sts"
+  kubectl -n "$NS" rollout status statefulset "$sts" --timeout=180s
+  count=$(kubectl -n "$NS" exec "$testpod" -- clickhouse client -q \
+    "SELECT count() FROM default.persist_check")
+  kubectl -n "$NS" exec "$testpod" -- clickhouse client -q \
+    "DROP TABLE default.persist_check"
+  if [ "$count" = "1" ]; then
+    restart_test="passed"
+  else
+    restart_test="failed (count=$count)"
+  fi
+  echo "durability restart test: $restart_test"
+fi
+
+# 🟢 when every PVC is Bound and the restart test (if run) passed; 🔴 otherwise
+indicator="🟢"
+if [ -n "$unbound" ]; then indicator="🔴"; fi
+case "$restart_test" in failed*) indicator="🔴" ;; esac
+
+jq -n -c \
+  --arg ind "$indicator" \
+  --arg pb "$pvcs_bound" \
+  --arg pt "$pvcs_total" \
+  --arg dm "$data_mount" \
+  --arg rt "$restart_test" \
+  --arg ub "$unbound" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{indicator: $ind, pvcs_bound: ($pb|tonumber), pvcs_total: ($pt|tonumber), data_mount: $dm, restart_test: $rt, unbound_pvcs: ($ub | split("\n") | map(select(length > 0))), updated_at: $ts}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/clickhouse/ch_verify_storage/ch_verify_storage.toml
+++ b/byoc-nuon-gcp/actions/clickhouse/ch_verify_storage/ch_verify_storage.toml
@@ -1,0 +1,17 @@
+# action
+# description: verifies ClickHouse persistent storage — PVCs bound, data dir on a real
+# disk, and (optionally) that data survives a StatefulSet restart.
+name    = "ch_verify_storage"
+labels  = { service = "clickhouse", type = "debug" }
+timeout = "6m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "verify_storage"
+inline_contents = "./clickhouse/ch_verify_storage/ch_verify_storage.sh"
+
+[steps.env_vars]
+# set to "true" to run the disruptive write -> restart -> read durability test
+RUN_RESTART_TEST = "false"

--- a/byoc-nuon-gcp/components/90-tf-clickhouse_cluster.toml
+++ b/byoc-nuon-gcp/components/90-tf-clickhouse_cluster.toml
@@ -3,7 +3,7 @@ name              = "clickhouse_cluster"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 
-dependencies = ["crd_clickhouse_operator"]
+dependencies = ["crd_clickhouse_operator", "gcs_buckets"]
 
 [public_repo]
 repo      = "nuonco/byoc"
@@ -11,8 +11,9 @@ directory = "byoc-nuon-gcp/src/components/clickhouse_cluster"
 branch    = "main"
 
 [vars]
-install_id = "{{ .nuon.install.id }}"
-project_id = "{{ .nuon.install_stack.outputs.project_id }}"
+install_id             = "{{ .nuon.install.id }}"
+project_id             = "{{ .nuon.install_stack.outputs.project_id }}"
+clickhouse_bucket_name = "{{ .nuon.components.gcs_buckets.outputs.clickhouse_bucket.name }}"
 region     = "{{ .nuon.install_stack.outputs.region }}"
 zone       = "{{ .nuon.install.sandbox.outputs.nuon_dns.internal_domain.name }}"
 

--- a/byoc-nuon-gcp/runbooks/verify_clickhouse.md
+++ b/byoc-nuon-gcp/runbooks/verify_clickhouse.md
@@ -1,0 +1,97 @@
+Verifies the ClickHouse cluster's durability and resilience: persistent volumes are bound and actually
+retain data across pod/StatefulSet recreation, the server and keeper pods are spread across distinct
+nodes, and scheduled GCS backups are running. Use this after deploying ClickHouse changes, or when
+diagnosing data-loss / availability concerns.
+
+Each check below runs as an action against the install — no direct cluster or GCP access is required.
+Run a step to refresh its result; the latest output is rendered inline.
+
+> **Background:** ClickHouse on GCP previously ran with no `volumeClaimTemplates`, so its data lived on
+> ephemeral pod storage and was lost on any reschedule — surfacing as a "no healthy upstream" error on
+> the auth service (which depends on ClickHouse). Persistent volumes and pod anti-affinity were added to
+> fix this. This runbook confirms both are in effect.
+
+{{ $storage := dict }}{{ $storageID := "" }}{{ with index .nuon.actions.workflows "ch_verify_storage" }}{{ with .outputs }}{{ $storage = . }}{{ end }}{{ $storageID = dig "id" "" . }}{{ end }}
+{{ $spread := dict }}{{ $spreadID := "" }}{{ with index .nuon.actions.workflows "ch_verify_pod_spread" }}{{ with .outputs }}{{ $spread = . }}{{ end }}{{ $spreadID = dig "id" "" . }}{{ end }}
+{{ $backups := dict }}{{ $backupsID := "" }}{{ with index .nuon.actions.workflows "ch_verify_backups" }}{{ with .outputs }}{{ $backups = . }}{{ end }}{{ $backupsID = dig "id" "" . }}{{ end }}
+
+---
+
+**1. Persistent storage**
+
+Lists the PVCs (expect one per server replica, `Bound`, `20Gi`, storageclass `ssd`) and confirms the
+data dir is backed by a real disk rather than an ephemeral overlay. To also prove data survives a
+StatefulSet recreation, re-run the action with `RUN_RESTART_TEST=true` — note this restarts the
+`chi-clickhouse-installation-simple-0-0` StatefulSet and is disruptive.
+
+<nuon-group gap="2" align="center" justify="start">{{ $ind := dig "indicator" "" $storage }}{{ if eq $ind "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $ind "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}<nuon-label-badge
+label="pvcs:{{ dig "pvcs_bound" "?" $storage }}/{{ dig "pvcs_total" "?" $storage }} bound"></nuon-label-badge><nuon-label-badge
+label="restart-test:{{ dig "restart_test" "not run" $storage }}"></nuon-label-badge>{{ with dig "updated_at" "" $storage }}<span style="margin-left:auto;font-size:0.85em;">Last run by
+<a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/actions/{{ $storageID }}">ch_verify_storage</a>
+<nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</nuon-group>
+
+| Check | Result |
+| ----- | ------ |
+| PVCs bound | {{ dig "pvcs_bound" "?" $storage }} / {{ dig "pvcs_total" "?" $storage }} |
+| Data dir device | {{ dig "data_mount" "unknown" $storage }} |
+| Unbound PVCs | {{ $ub := dig "unbound_pvcs" (list) $storage }}{{ if $ub }}{{ range $ub }}`{{ . }}` {{ end }}{{ else }}none{{ end }} |
+| Durability restart test | {{ dig "restart_test" "not run" $storage }} |
+
+> **Note — first cutover is destructive:** the very first deploy that adds `volumeClaimTemplates` to an
+> install still running on ephemeral storage forces the operator to recreate the StatefulSet, and the
+> old ephemeral data is lost in that one transition. Treat the initial volumes rollout on any existing
+> install as a reset of ClickHouse data. After that, data persists.
+
+<nuon-action-card name="ch_verify_storage"></nuon-action-card>
+
+---
+
+**2. Pod spread (anti-affinity)**
+
+Confirms the 2 server replicas are on distinct nodes and the 3 keeper replicas are on distinct nodes
+(and reports how many distinct zones the keeper quorum spans — ideally 3, so a single zonal outage
+cannot break raft quorum).
+
+<nuon-group gap="2" align="center" justify="start">{{ $ind := dig "indicator" "" $spread }}{{ if eq $ind "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $ind "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}<nuon-label-badge
+label="server:{{ dig "server_nodes" "?" $spread }} nodes"></nuon-label-badge><nuon-label-badge
+label="keeper:{{ dig "keeper_nodes" "?" $spread }} nodes / {{ dig "keeper_distinct_zones" "?" $spread }} zones"></nuon-label-badge>{{ with dig "updated_at" "" $spread }}<span style="margin-left:auto;font-size:0.85em;">Last run by
+<a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/actions/{{ $spreadID }}">ch_verify_pod_spread</a>
+<nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</nuon-group>
+
+| Check | Result |
+| ----- | ------ |
+| Server replicas on distinct nodes | {{ dig "server_nodes" "?" $spread }} {{ if dig "server_distinct_nodes_ok" false $spread }}✅{{ else }}❌{{ end }} |
+| Keeper replicas on distinct nodes | {{ dig "keeper_nodes" "?" $spread }} {{ if dig "keeper_distinct_nodes_ok" false $spread }}✅{{ else }}❌{{ end }} |
+| Keeper distinct zones | {{ dig "keeper_distinct_zones" "?" $spread }} |
+
+<nuon-action-card name="ch_verify_pod_spread"></nuon-action-card>
+
+---
+
+**3. GCS backups**
+
+Confirms the HMAC credential secret and backup CronJob(s) exist, triggers a backup run and waits for it
+to complete (logs should show `BACKUP_CREATED`), and lists the resulting objects in the backup bucket.
+
+<nuon-group gap="2" align="center" justify="start">{{ $ind := dig "indicator" "" $backups }}{{ if eq $ind "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $ind "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}<nuon-label-badge
+label="job:{{ dig "backup_job" "not run" $backups }}"></nuon-label-badge><nuon-label-badge
+label="objects:{{ dig "objects_found" "?" $backups }}"></nuon-label-badge>{{ with dig "updated_at" "" $backups }}<span style="margin-left:auto;font-size:0.85em;">Last run by
+<a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/actions/{{ $backupsID }}">ch_verify_backups</a>
+<nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</nuon-group>
+
+| Check | Result |
+| ----- | ------ |
+| Backup job | {{ dig "backup_job" "not run" $backups }} |
+| Table | {{ dig "table" "-" $backups }} |
+| CronJob | {{ dig "cronjob" "-" $backups }} |
+| Objects in bucket | {{ dig "objects_found" "?" $backups }} |
+
+<nuon-action-card name="ch_verify_backups"></nuon-action-card>
+
+---
+
+**4. Replica status**
+
+An at-a-glance view of ClickHouse replica health (flags any read-only replicas).
+
+<nuon-action-card name="ch_cluster_replicas"></nuon-action-card>

--- a/byoc-nuon-gcp/runbooks/verify_clickhouse.toml
+++ b/byoc-nuon-gcp/runbooks/verify_clickhouse.toml
@@ -1,0 +1,24 @@
+name        = "verify_clickhouse"
+description = "Verify ClickHouse durability & resilience — volumes persist across recreation, pods are spread across nodes, and GCS backups run."
+readme      = "./runbooks/verify_clickhouse.md"
+labels      = { service = "clickhouse", type = "debug" }
+
+[[steps]]
+name        = "Verify storage"
+type        = "action"
+action_name = "ch_verify_storage"
+
+[[steps]]
+name        = "Verify pod spread"
+type        = "action"
+action_name = "ch_verify_pod_spread"
+
+[[steps]]
+name        = "Verify backups"
+type        = "action"
+action_name = "ch_verify_backups"
+
+[[steps]]
+name        = "Replica status"
+type        = "action"
+action_name = "ch_cluster_replicas"

--- a/byoc-nuon-gcp/src/components/clickhouse_cluster/backup.sh
+++ b/byoc-nuon-gcp/src/components/clickhouse_cluster/backup.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# usage bash /usr/local/bin/backup.sh otel_log_records
+#
+# Backs up a ClickHouse table to GCS over the S3-compatible (interoperability) API.
+# Unlike the AWS install, GCS has no environment-credential flow, so we pass the
+# HMAC access/secret key inline to the S3() function via $S3_ACCESS_KEY / $S3_SECRET_KEY.
+
+set -e
+set -o pipefail
+set -u
+
+TABLE=$1
+TIMESTAMP=`date -Iseconds -u | sed 's/-//g; s/://g; s/T//g; s/+//g'`
+LOCATION="$BUCKET_URL/backups/"$TABLE
+INITIAL_BACKUP="$LOCATION/initial"
+CURRENT_BACKUP="$LOCATION/$TIMESTAMP"
+
+echo
+echo "[clickhouse backups to gcs] Preparing to create a backup:"
+echo
+echo "    table = "$TABLE
+echo "   backup = "$TIMESTAMP
+echo " location = "$LOCATION
+echo "  initial = "$INITIAL_BACKUP
+echo "  current = "$CURRENT_BACKUP
+echo
+
+
+set +e
+# 1. check for an existing initial backup. if it does not exist, create it.
+
+# NOTE(fd): we are allowing this to fail w/out breaking the script.
+#  - if it fails because the initial backup exists, that's fine
+#  - if it fails for other reasons, the backup command will fail
+#    and we can rely on catching that error
+
+# the query checks for entries w/ a base backup. these can only exist if the base backup exists. so if the count is > 0, we have
+# an initial backup. it is a bit indirect but it works well.
+HAS_INITIAL_QUERY="SELECT count(*) FROM system.backups WHERE status = 'BACKUP_CREATED' AND position(base_backup_name, '$INITIAL_BACKUP') != 0;"
+HAS_INITIAL=`clickhouse client --host $CLICKHOUSE_URL --user $CLICKHOUSE_USERNAME --password $CLICKHOUSE_PASSWORD -q "$HAS_INITIAL_QUERY"`
+
+# if it does not exit, create it
+if [ "$HAS_INITIAL" == "0" ]; then
+  CREATE_INITIAL_BACKUP_CMD="BACKUP TABLE $TABLE TO S3('$INITIAL_BACKUP', '$S3_ACCESS_KEY', '$S3_SECRET_KEY');"
+  echo
+  echo "[clickhouse backups to gcs] Creating initial backup"
+  echo
+  RESPONSE=`clickhouse client --host $CLICKHOUSE_URL --user $CLICKHOUSE_USERNAME --password $CLICKHOUSE_PASSWORD -q "$CREATE_INITIAL_BACKUP_CMD"`
+  if [[ $RESPONSE == *"BACKUP_FAILED"* ]]; then
+      echo
+      echo "[clickhouse backups to gcs] failed create the initial backup"
+      echo
+      echo $RESPONSE >&2
+      echo
+      echo "[clickhouse backups to gcs] we will continue anyway"
+      echo
+  fi
+fi
+set -e
+
+# 2. create the backup w/ the initital backup as its base
+
+COMMAND="BACKUP TABLE $TABLE TO S3('$CURRENT_BACKUP', '$S3_ACCESS_KEY', '$S3_SECRET_KEY') SETTINGS base_backup = S3('$INITIAL_BACKUP', '$S3_ACCESS_KEY', '$S3_SECRET_KEY');"
+
+echo
+echo '[clickhouse backups to gcs] creating current backup'
+echo
+
+RESPONSE=`clickhouse client --host $CLICKHOUSE_URL --user $CLICKHOUSE_USERNAME --password $CLICKHOUSE_PASSWORD -q "$COMMAND"`
+if [[ $RESPONSE == *"BACKUP_FAILED"* ]]; then
+    echo
+    echo "[clickhouse backups to gcs] failed to create the current backup"
+    echo
+    echo $RESPONSE
+    exit 1
+fi

--- a/byoc-nuon-gcp/src/components/clickhouse_cluster/backups.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_cluster/backups.tf
@@ -1,0 +1,176 @@
+// clickhouse GCS backup crons
+// docs: https://clickhouse.com/docs/en/operations/backup#configuring-backuprestore-to-use-an-s3-endpoint
+//
+// NOTE: GCS does not support the S3 environment-credential flow that the AWS install relies on
+// (IRSA + use_environment_credentials). Instead we authenticate to the bucket over the GCS
+// interoperability (S3-compatible XML) API using an HMAC key, passed inline to the BACKUP command.
+
+// dedicated service account whose HMAC key the backup jobs use to reach the bucket.
+resource "google_service_account" "clickhouse_backup" {
+  project      = var.project_id
+  account_id   = "ch-backup-${substr(var.install_id, 0, 12)}"
+  display_name = "clickhouse backups for ${var.install_id}"
+}
+
+// grant the backup SA read/write on the clickhouse backup bucket only.
+resource "google_storage_bucket_iam_member" "clickhouse_backup" {
+  bucket = var.clickhouse_bucket_name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.clickhouse_backup.email}"
+}
+
+// HMAC key used by ClickHouse's S3 client to talk to GCS.
+resource "google_storage_hmac_key" "clickhouse_backup" {
+  project               = var.project_id
+  service_account_email = google_service_account.clickhouse_backup.email
+}
+
+// sync the HMAC credentials into the clickhouse namespace as a k8s secret.
+resource "kubectl_manifest" "clickhouse_backup_hmac_secret" {
+  yaml_body = yamlencode({
+    "apiVersion" = "v1"
+    "kind"       = "Secret"
+    "metadata" = {
+      "name"      = "clickhouse-backup-hmac"
+      "namespace" = "clickhouse"
+      "managed"   = "terraform"
+    }
+    "type" = "Opaque"
+    "stringData" = {
+      "access_key" = google_storage_hmac_key.clickhouse_backup.access_id
+      "secret_key" = google_storage_hmac_key.clickhouse_backup.secret
+    }
+  })
+  depends_on = [
+    kubectl_manifest.clickhouse_installation
+  ]
+}
+
+resource "kubectl_manifest" "clickhouse_backup_script" {
+  yaml_body = yamlencode({
+    "apiVersion" = "v1"
+    "kind"       = "ConfigMap"
+    "metadata" = {
+      "name"      = "clickhouse-backup-to-gcs-script"
+      "namespace" = "clickhouse"
+      "managed"   = "terraform"
+    }
+    "data" = {
+      "backup.sh" = file("${path.module}/backup.sh")
+    }
+  })
+  depends_on = [
+    kubectl_manifest.clickhouse_installation
+  ]
+}
+
+// we make a cron for each of the tables in locals.backups.tables
+// TODO(fd): running n crons where n = len(locals.backups.tables) is likely to tax the db as we grow.
+// consider making this a job and triggering it via ctl-api or some other process w/ insight
+// into the state of these tables so the system can choose when to back itself up. this would mean we
+// would backup more often during on-hours and less during off-hours, presumably saving resources.
+resource "kubectl_manifest" "clickhouse_backup_crons" {
+  for_each = toset(local.backups.tables)
+
+  yaml_body = yamlencode({
+    "apiVersion" = "batch/v1"
+    "kind"       = "CronJob"
+    "metadata" = {
+      "name"      = "ch-gcs-backup-${replace(replace(each.key, "_", "-"), "ctl-api.", "")}"
+      "namespace" = "clickhouse"
+      "annotations" = {
+        "nuon.clickhouse.io/table" = replace(replace(each.key, "_", "-"), "ctl-api.", "")
+      }
+    }
+    "spec" = {
+      "jobTemplate" = {
+        "spec" = {
+          "template" = {
+            "spec" = {
+              "containers" = [
+                {
+                  "command" = [
+                    "bash",
+                    "/usr/local/bin/backup.sh",
+                    each.key,
+                  ]
+                  "env" = [
+                    {
+                      "name"  = "BUCKET_URL"
+                      "value" = "https://storage.googleapis.com/${var.clickhouse_bucket_name}"
+                    },
+                    {
+                      // this is the service url
+                      "name"  = "CLICKHOUSE_URL"
+                      "value" = "clickhouse.clickhouse.svc.cluster.local"
+                    },
+                    {
+                      "name"  = "CLICKHOUSE_USERNAME"
+                      "value" = "clickhouse"
+                    },
+                    {
+                      "name" = "CLICKHOUSE_PASSWORD"
+                      "valueFrom" = {
+                        "secretKeyRef" = {
+                          "name" = "clickhouse-cluster-pw"
+                          "key"  = "value"
+                        }
+                      }
+                    },
+                    {
+                      "name" = "S3_ACCESS_KEY"
+                      "valueFrom" = {
+                        "secretKeyRef" = {
+                          "name" = "clickhouse-backup-hmac"
+                          "key"  = "access_key"
+                        }
+                      }
+                    },
+                    {
+                      "name" = "S3_SECRET_KEY"
+                      "valueFrom" = {
+                        "secretKeyRef" = {
+                          "name" = "clickhouse-backup-hmac"
+                          "key"  = "secret_key"
+                        }
+                      }
+                    },
+                  ]
+                  "image"           = "${var.cluster_image_repository}:${var.cluster_image_tag}"
+                  "imagePullPolicy" = "IfNotPresent"
+                  "name"            = "ch-gcs-backup-${replace(replace(each.key, "_", "-"), "ctl-api.", "")}"
+                  "volumeMounts" = [
+                    {
+                      "name"      = "config-volume"
+                      "mountPath" = "/usr/local/bin/backup.sh"
+                      "subPath" : "backup.sh"
+                    },
+                  ]
+                },
+              ]
+              "restartPolicy"      = "OnFailure"
+              "serviceAccountName" = "default"
+              "volumes" = [
+                {
+                  "configMap" = {
+                    "name" = "clickhouse-backup-to-gcs-script"
+                  }
+                  "name" = "config-volume"
+                },
+              ]
+            }
+          }
+        }
+      }
+      "schedule"                   = "*/30 * * * *"
+      "successfulJobsHistoryLimit" = 0
+      "failedJobsHistoryLimit"     = 0
+    }
+  })
+
+  depends_on = [
+    kubectl_manifest.clickhouse_installation,
+    kubectl_manifest.clickhouse_backup_hmac_secret,
+    kubectl_manifest.clickhouse_backup_script,
+  ]
+}

--- a/byoc-nuon-gcp/src/components/clickhouse_cluster/keeper.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_cluster/keeper.tf
@@ -62,6 +62,40 @@ resource "kubectl_manifest" "clickhouse_keeper_installation" {
                 "fsGroup"   = 101
                 "runAsUser" = 101
               }
+              # spread the 3 keeper replicas onto distinct nodes so a single node failure
+              # cannot take out the raft quorum. the regional pool has >=1 node per zone
+              # (3 zones), so DoNotSchedule/minDomains=3 is satisfiable and naturally
+              # spreads the quorum across zones. label is applied automatically by the CRD.
+              # NOTE: no nodeSelector/tolerations on GCP (single autoscaling pool, no taints).
+              "topologySpreadConstraints" = [
+                # hard: the 3 keeper replicas must land on distinct nodes.
+                {
+                  "maxSkew"           = 1
+                  "topologyKey"       = "kubernetes.io/hostname"
+                  "whenUnsatisfiable" = "DoNotSchedule"
+                  "minDomains"        = 3
+                  "labelSelector" = {
+                    "matchLabels" = {
+                      # verified against live pods; the AWS install's "app=clickhouse-keeper"
+                      # label does not exist on this keeper CRD version.
+                      "clickhouse-keeper.altinity.com/chk" = "clickhouse-keeper"
+                    }
+                  }
+                },
+                # soft: strongly prefer one replica per zone so a single zonal outage
+                # cannot take out raft quorum (observed pre-fix: 2 of 3 keepers in one zone).
+                # soft (not DoNotSchedule) so a capacity-constrained zone can't strand a replica.
+                {
+                  "maxSkew"           = 1
+                  "topologyKey"       = "topology.kubernetes.io/zone"
+                  "whenUnsatisfiable" = "ScheduleAnyway"
+                  "labelSelector" = {
+                    "matchLabels" = {
+                      "clickhouse-keeper.altinity.com/chk" = "clickhouse-keeper"
+                    }
+                  }
+                }
+              ]
               "containers" = [
                 {
                   "image"           = "${var.keeper_image_repository}:${var.keeper_image_tag}"

--- a/byoc-nuon-gcp/src/components/clickhouse_cluster/main.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_cluster/main.tf
@@ -18,7 +18,8 @@ resource "kubectl_manifest" "clickhouse_installation" {
     spec = {
       defaults = {
         templates = {
-          podTemplate = "default"
+          podTemplate             = "default"
+          dataVolumeClaimTemplate = "data-volume-template"
         }
       }
       configuration = {
@@ -51,8 +52,8 @@ resource "kubectl_manifest" "clickhouse_installation" {
           ]
         }
         settings = {
-          "logger/level"   = "warning"
-          "logger/console" = true
+          "logger/level"                    = "warning"
+          "logger/console"                  = true
           "prometheus/endpoint"             = "/metrics"
           "prometheus/port"                 = 9363
           "prometheus/metrics"              = true
@@ -94,8 +95,28 @@ resource "kubectl_manifest" "clickhouse_installation" {
                 {
                   name  = "clickhouse"
                   image = "${var.cluster_image_repository}:${var.cluster_image_tag}"
+                  volumeMounts = [
+                    {
+                      name      = "data-volume-template"
+                      mountPath = "/var/lib/clickhouse"
+                    }
+                  ]
                 }
               ]
+            }
+          }
+        ]
+        volumeClaimTemplates = [
+          {
+            name = "data-volume-template"
+            spec = {
+              storageClassName = "ssd"
+              accessModes      = ["ReadWriteOnce"]
+              resources = {
+                requests = {
+                  storage = "20Gi"
+                }
+              }
             }
           }
         ]

--- a/byoc-nuon-gcp/src/components/clickhouse_cluster/main.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_cluster/main.tf
@@ -91,6 +91,36 @@ resource "kubectl_manifest" "clickhouse_installation" {
           {
             name = "default"
             spec = {
+              # never co-locate the two replicas on the same node, and best-effort
+              # spread them across zones. the label is applied automatically by the CRD.
+              # NOTE: unlike the AWS install there is no dedicated tainted node pool on GCP
+              # (single autoscaling regional pool "main"), so we set no nodeSelector/tolerations.
+              affinity = {
+                podAntiAffinity = {
+                  requiredDuringSchedulingIgnoredDuringExecution = [
+                    {
+                      labelSelector = {
+                        matchLabels = {
+                          "clickhouse.altinity.com/chi" = "clickhouse-installation"
+                        }
+                      }
+                      topologyKey = "kubernetes.io/hostname"
+                    }
+                  ]
+                }
+              }
+              topologySpreadConstraints = [
+                {
+                  maxSkew           = 1
+                  topologyKey       = "topology.kubernetes.io/zone"
+                  whenUnsatisfiable = "ScheduleAnyway"
+                  labelSelector = {
+                    matchLabels = {
+                      "clickhouse.altinity.com/chi" = "clickhouse-installation"
+                    }
+                  }
+                }
+              ]
               containers = [
                 {
                   name  = "clickhouse"

--- a/byoc-nuon-gcp/src/components/clickhouse_cluster/variables.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_cluster/variables.tf
@@ -1,9 +1,25 @@
+locals {
+  backups = {
+    tables = [
+      "ctl_api.otel_log_records",
+      # omitted
+      # "ctl_api.runner_heart_beats",
+      # "ctl_api.runner_health_checks",
+    ]
+  }
+}
+
 variable "install_id" {
   type = string
 }
 
 variable "project_id" {
   type = string
+}
+
+variable "clickhouse_bucket_name" {
+  type        = string
+  description = "Name of the GCS bucket used for ClickHouse backups."
 }
 
 variable "region" {


### PR DESCRIPTION
## Summary

The Nuon BYOC on GCP config was missing persistent volume claims for clickhouse. This PR adds that, missing scheduling config, and a runbook we can use to verify that clickhouse is operating normally.