### PR TITLE
feat: add inspect_migrations runbook

### DIFF
--- a/byoc-nuon-gcp/README.md
+++ b/byoc-nuon-gcp/README.md
@@ -338,6 +338,35 @@ section.</nuon-banner>{{ end }}
   </div>
 </div>
 
+{{ $migAction := default dict (index (default dict .nuon.actions.workflows) "inspect_migrations") }}
+{{ $migOutputs := default dict (dig "outputs" dict $migAction) }}
+{{ $migSteps := dig "steps" dict $migOutputs }}
+{{ $migrations := dig "migrations" (dict) $migSteps }}
+
+<div style="display:flex;align-items:baseline;gap:0.75rem;margin-top:1.5rem;"><h3 style="margin:0;">Migrations</h3><a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/runbooks/inspect_migrations" style="font-size:0.85em;">See more →</a>{{ with dig "updated_at" "" $migOutputs }}<span style="margin-left:auto;font-size:0.85em;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</div>
+
+{{ if gt (len $migrations) 0 }}
+{{ $themeMap := dict "applied" "success" "in_progress" "info" "error" "error" "unknown" "neutral" }}
+
+<table>
+  <thead><tr><th>Name</th><th>Status</th><th>Created</th></tr></thead>
+  <tbody>
+  {{ range $_, $m := $migrations }}
+    {{ $status := dig "status" "" $m }}
+    <tr>
+      <td>{{ dig "name" "—" $m }}<br><small style="opacity:0.6;"><code>{{ dig "id" "—" $m }}</code></small></td>
+      <td>{{ if $status }}<nuon-label-badge theme="{{ dig (lower $status) "neutral" $themeMap }}" label="{{ $status }}"></nuon-label-badge>{{ else }}—{{ end }}</td>
+      <td>{{ with dig "created_at" "" $m }}<nuon-time time="{{ printf "%sZ" (substr 0 19 .) }}" format="short-datetime"></nuon-time>{{ else }}—{{ end }}</td>
+    </tr>
+  {{ end }}
+  </tbody>
+</table>
+
+{{ else if not (dig "updated_at" "" $migOutputs) }}<nuon-banner theme="warn">Waiting on inspect_migrations. Run it to populate this section.</nuon-banner>{{ else }}<nuon-banner theme="info">No migrations reported.</nuon-banner>{{ end }}
+
+</nuon-tab>
+<nuon-tab name="Infrastructure">
+
 <div style="padding-top:1rem;"></div>
 
 <div style="display:flex;gap:1.5rem;align-items:flex-start;">

--- a/byoc-nuon-gcp/actions/ctl_api/inspect_migrations/inspect_migrations.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/inspect_migrations/inspect_migrations.toml
@@ -24,7 +24,7 @@ inline_contents = '''
 # Inspect ctl-api schema migrations via the admin API (GET /v1/general/migrations).
 # Emits one JSON object per migration keyed by "<created_at>_<id>" so the README
 # map-range renders them oldest -> newest; any error / in-progress migration is
-# naturally the most recent (last) row. Limited to the last 20 by created_at.
+# naturally the most recent (last) row. Limited to the last 10 by created_at.
 
 set -e
 set -o pipefail
@@ -58,7 +58,7 @@ echo "[inspect_migrations] $count migration(s) returned"
 echo "$migrations" | jq -c '
   [ .[] | { id, name, status: (.status // "unknown"), created_at, updated_at } ]
   | sort_by(.created_at)
-  | .[-20:][]
+  | .[-10:][]
   | { ("\(.created_at)_\(.id)"): . }
 ' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
 

--- a/byoc-nuon-gcp/actions/ctl_api/inspect_migrations/inspect_migrations.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/inspect_migrations/inspect_migrations.toml
@@ -1,0 +1,69 @@
+# action
+# description: lists ctl-api schema migrations (last 20 by updated_at) for the
+# README Migrations section, via the admin API.
+name    = "inspect_migrations"
+labels  = { service = "ctl-api", type = "report" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "timestamp"
+inline_contents = '''
+#!/usr/bin/env bash
+set -euo pipefail
+jq -nc --arg ts "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" '{updated_at: $ts}' >> $NUON_ACTIONS_OUTPUT_FILEPATH
+'''
+
+[[steps]]
+name = "migrations"
+inline_contents = '''
+#!/usr/bin/env bash
+#
+# Inspect ctl-api schema migrations via the admin API (GET /v1/general/migrations).
+# Emits one JSON object per migration keyed by "<created_at>_<id>" so the README
+# map-range renders them oldest -> newest; any error / in-progress migration is
+# naturally the most recent (last) row. Limited to the last 20 by created_at.
+
+set -e
+set -o pipefail
+set -u
+
+admin_api_addr="$ADMIN_API_URL"
+
+echo "[inspect_migrations] GET $admin_api_addr/v1/general/migrations"
+body_file=$(mktemp)
+http_code=$(curl --max-time 30 -q -s -o "$body_file" -w '%{http_code}' \
+  "$admin_api_addr/v1/general/migrations" \
+  -H 'accept: application/json' \
+  -H 'X-Nuon-Admin-Email: jon@nuon.co')
+migrations=$(cat "$body_file")
+rm -f "$body_file"
+
+echo "[inspect_migrations] -> $http_code"
+if [ "$http_code" != "200" ]; then
+  echo "[inspect_migrations] non-200 response: $migrations" >&2
+  exit 1
+fi
+
+if ! echo "$migrations" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  echo "[inspect_migrations] expected JSON array, got: $migrations" >&2
+  exit 1
+fi
+
+count=$(echo "$migrations" | jq 'length')
+echo "[inspect_migrations] $count migration(s) returned"
+
+echo "$migrations" | jq -c '
+  [ .[] | { id, name, status: (.status // "unknown"), created_at, updated_at } ]
+  | sort_by(.created_at)
+  | .[-20:][]
+  | { ("\(.created_at)_\(.id)"): . }
+' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+echo "[inspect_migrations] done"
+'''
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"

--- a/byoc-nuon-gcp/runbooks/inspect_migrations.md
+++ b/byoc-nuon-gcp/runbooks/inspect_migrations.md
@@ -1,0 +1,48 @@
+{{ $migAction := default dict (index (default dict .nuon.actions.workflows) "inspect_migrations") }}
+{{ $migOutputs := default dict (dig "outputs" dict $migAction) }}
+{{ $migActionID := dig "id" "" $migAction }}
+{{ $migSteps := dig "steps" dict $migOutputs }}
+{{ $themeMap := dict "applied" "success" "in_progress" "info" "error" "error" "unknown" "neutral" }}
+
+<div style="padding-top:1rem;"></div>
+
+<nuon-group gap="2" align="center" justify="start">{{ with dig "updated_at" "" $migOutputs }}<span style="margin-left:auto;font-size:0.85em;">Last updated by <a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/actions/{{ $migActionID }}">inspect_migrations</a> <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</nuon-group>
+
+<div style="padding-bottom:1rem;"></div>
+
+{{ if and $migAction (dig "populated" false $migAction) (eq (dig "status" "" $migAction) "finished") }}
+
+{{ $migrations := dig "migrations" (dict) $migSteps }}
+{{ if gt (len $migrations) 0 }}
+
+  <table>
+      <thead>
+          <tr>
+              <th>Name</th>
+              <th>Status</th>
+              <th>Created At</th>
+          </tr>
+      </thead>
+      <tbody>
+      {{ range $_, $m := $migrations }}
+          {{ $status := dig "status" "" $m }}
+          <tr>
+              <td>{{ dig "name" "—" $m }}<br><small style="opacity:0.6;"><code>{{ dig "id" "—" $m }}</code></small></td>
+              <td>{{ if $status }}<nuon-label-badge theme="{{ dig (lower $status) "neutral" $themeMap }}" label="{{ $status }}"></nuon-label-badge>{{ else }}—{{ end }}</td>
+              <td>{{ with dig "created_at" "" $m }}<nuon-time time="{{ printf "%sZ" (substr 0 19 .) }}" format="short-datetime"></nuon-time>{{ else }}—{{ end }}</td>
+          </tr>
+      {{ end }}
+      </tbody>
+  </table>
+
+{{ else }}
+
+<div style="padding-top: 1rem;"><nuon-banner theme="info">No migrations reported.</nuon-banner></div>
+
+{{ end }}
+
+{{ else }}
+
+<nuon-banner theme="warn">Waiting on inspect_migrations action. Run it to populate this runbook.</nuon-banner>
+
+{{ end }}

--- a/byoc-nuon-gcp/runbooks/inspect_migrations.toml
+++ b/byoc-nuon-gcp/runbooks/inspect_migrations.toml
@@ -1,0 +1,9 @@
+name        = "inspect_migrations"
+description = "Inspect ctl-api schema migrations — the last 20 by created_at, with status."
+readme      = "./runbooks/inspect_migrations.md"
+labels      = { service = "ctl-api", type = "debug" }
+
+[[steps]]
+name        = "Inspect: migrations"
+type        = "action"
+action_name = "inspect_migrations"

--- a/byoc-nuon-gcp/runbooks/inspect_migrations.toml
+++ b/byoc-nuon-gcp/runbooks/inspect_migrations.toml
@@ -1,5 +1,5 @@
 name        = "inspect_migrations"
-description = "Inspect ctl-api schema migrations — the last 20 by created_at, with status."
+description = "Inspect ctl-api schema migrations — the last 10 by created_at, with status."
 readme      = "./runbooks/inspect_migrations.md"
 labels      = { service = "ctl-api", type = "debug" }
 

--- a/byoc-nuon-gcp/runbooks/refresh_readme.md
+++ b/byoc-nuon-gcp/runbooks/refresh_readme.md
@@ -9,6 +9,7 @@ after a deploy, or any time the README looks stale.
 | `dashboard_status`                | Dashboard status badge, version/git labels                   |
 | `inspect_runners`                 | Runners section                                              |
 | `inspect_installs`                | Installs section                                             |
+| `inspect_migrations`              | Migrations section                                           |
 | `inspect_apps`                    | Apps section                                                 |
 | `inspect_orgs`                    | Orgs section                                                 |
 | `healthcheck_temporal`            | Temporal healthcheck indicator                               |

--- a/byoc-nuon-gcp/runbooks/refresh_readme.toml
+++ b/byoc-nuon-gcp/runbooks/refresh_readme.toml
@@ -27,3 +27,8 @@ action_name = "inspect_runners"
 name        = "Inspect: installs"
 type        = "action"
 action_name = "inspect_installs"
+
+[[steps]]
+name        = "Inspect: migrations"
+type        = "action"
+action_name = "inspect_migrations"

--- a/byoc-nuon/README.md
+++ b/byoc-nuon/README.md
@@ -328,6 +328,32 @@
   </div>
 </div>
 
+{{ $migAction := default dict (index (default dict .nuon.actions.workflows) "inspect_migrations") }}
+{{ $migOutputs := default dict (dig "outputs" dict $migAction) }}
+{{ $migSteps := dig "steps" dict $migOutputs }}
+{{ $migrations := dig "migrations" (dict) $migSteps }}
+
+<div style="display:flex;align-items:baseline;gap:0.75rem;margin-top:1.5rem;"><h3 style="margin:0;">Migrations</h3><a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/runbooks/inspect_migrations" style="font-size:0.85em;">See more →</a>{{ with dig "updated_at" "" $migOutputs }}<span style="margin-left:auto;font-size:0.85em;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</div>
+
+{{ if gt (len $migrations) 0 }}
+{{ $themeMap := dict "applied" "success" "in_progress" "info" "error" "error" "unknown" "neutral" }}
+
+<table>
+  <thead><tr><th>Name</th><th>Status</th><th>Created</th></tr></thead>
+  <tbody>
+  {{ range $_, $m := $migrations }}
+    {{ $status := dig "status" "" $m }}
+    <tr>
+      <td>{{ dig "name" "—" $m }}<br><small style="opacity:0.6;"><code>{{ dig "id" "—" $m }}</code></small></td>
+      <td>{{ if $status }}<nuon-label-badge theme="{{ dig (lower $status) "neutral" $themeMap }}" label="{{ $status }}"></nuon-label-badge>{{ else }}—{{ end }}</td>
+      <td>{{ with dig "created_at" "" $m }}<nuon-time time="{{ printf "%sZ" (substr 0 19 .) }}" format="short-datetime"></nuon-time>{{ else }}—{{ end }}</td>
+    </tr>
+  {{ end }}
+  </tbody>
+</table>
+
+{{ else if not (dig "updated_at" "" $migOutputs) }}<nuon-banner theme="warn">Waiting on inspect_migrations. Run it to populate this section.</nuon-banner>{{ else }}<nuon-banner theme="info">No migrations reported.</nuon-banner>{{ end }}
+
 </nuon-tab>
 <nuon-tab name="Infrastructure">
 

--- a/byoc-nuon/actions/ctl_api/inspect_migrations/inspect-migrations.sh
+++ b/byoc-nuon/actions/ctl_api/inspect_migrations/inspect-migrations.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Inspect ctl-api schema migrations via the admin API (GET /v1/general/migrations).
+# Emits one JSON object per migration to $NUON_ACTIONS_OUTPUT_FILEPATH, keyed by
+# "<created_at>_<id>" so the README map-range renders them oldest -> newest.
+# Migrations run in sequence, so any error / in-progress migration is naturally
+# the most recent (last) row. Limited to the last 20 by created_at.
+
+set -e
+set -o pipefail
+set -u
+
+admin_api_addr="$ADMIN_API_URL"
+
+echo "[inspect_migrations] GET $admin_api_addr/v1/general/migrations"
+migrations=$(curl --max-time 30 -s "$admin_api_addr/v1/general/migrations")
+
+if ! echo "$migrations" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  echo "[inspect_migrations] expected JSON array, got: $migrations" >&2
+  exit 1
+fi
+
+count=$(echo "$migrations" | jq 'length')
+echo "[inspect_migrations] $count migration(s) returned"
+
+echo "$migrations" | jq -c '
+  [ .[] | { id, name, status: (.status // "unknown"), created_at, updated_at } ]
+  | sort_by(.created_at)
+  | .[-20:][]
+  | { ("\(.created_at)_\(.id)"): . }
+' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+echo "[inspect_migrations] done"

--- a/byoc-nuon/actions/ctl_api/inspect_migrations/inspect-migrations.sh
+++ b/byoc-nuon/actions/ctl_api/inspect_migrations/inspect-migrations.sh
@@ -4,7 +4,7 @@
 # Emits one JSON object per migration to $NUON_ACTIONS_OUTPUT_FILEPATH, keyed by
 # "<created_at>_<id>" so the README map-range renders them oldest -> newest.
 # Migrations run in sequence, so any error / in-progress migration is naturally
-# the most recent (last) row. Limited to the last 20 by created_at.
+# the most recent (last) row. Limited to the last 10 by created_at.
 
 set -e
 set -o pipefail
@@ -26,7 +26,7 @@ echo "[inspect_migrations] $count migration(s) returned"
 echo "$migrations" | jq -c '
   [ .[] | { id, name, status: (.status // "unknown"), created_at, updated_at } ]
   | sort_by(.created_at)
-  | .[-20:][]
+  | .[-10:][]
   | { ("\(.created_at)_\(.id)"): . }
 ' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
 

--- a/byoc-nuon/actions/ctl_api/inspect_migrations/inspect_migrations.toml
+++ b/byoc-nuon/actions/ctl_api/inspect_migrations/inspect_migrations.toml
@@ -1,0 +1,24 @@
+# action
+# description: lists ctl-api schema migrations (last 20 by updated_at) for the
+# README Migrations section, via the admin API.
+name    = "inspect_migrations"
+labels  = { service = "ctl-api", type = "report" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "timestamp"
+inline_contents = '''
+#!/usr/bin/env bash
+set -euo pipefail
+jq -nc --arg ts "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" '{updated_at: $ts}' >> $NUON_ACTIONS_OUTPUT_FILEPATH
+'''
+
+[[steps]]
+name            = "migrations"
+inline_contents = "./ctl_api/inspect_migrations/inspect-migrations.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"

--- a/byoc-nuon/runbooks/inspect_migrations.md
+++ b/byoc-nuon/runbooks/inspect_migrations.md
@@ -1,0 +1,48 @@
+{{ $migAction := default dict (index (default dict .nuon.actions.workflows) "inspect_migrations") }}
+{{ $migOutputs := default dict (dig "outputs" dict $migAction) }}
+{{ $migActionID := dig "id" "" $migAction }}
+{{ $migSteps := dig "steps" dict $migOutputs }}
+{{ $themeMap := dict "applied" "success" "in_progress" "info" "error" "error" "unknown" "neutral" }}
+
+<div style="padding-top:1rem;"></div>
+
+<nuon-group gap="2" align="center" justify="start">{{ with dig "updated_at" "" $migOutputs }}<span style="margin-left:auto;font-size:0.85em;">Last updated by <a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/actions/{{ $migActionID }}">inspect_migrations</a> <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</nuon-group>
+
+<div style="padding-bottom:1rem;"></div>
+
+{{ if and $migAction (dig "populated" false $migAction) (eq (dig "status" "" $migAction) "finished") }}
+
+{{ $migrations := dig "migrations" (dict) $migSteps }}
+{{ if gt (len $migrations) 0 }}
+
+  <table>
+      <thead>
+          <tr>
+              <th>Name</th>
+              <th>Status</th>
+              <th>Created At</th>
+          </tr>
+      </thead>
+      <tbody>
+      {{ range $_, $m := $migrations }}
+          {{ $status := dig "status" "" $m }}
+          <tr>
+              <td>{{ dig "name" "—" $m }}<br><small style="opacity:0.6;"><code>{{ dig "id" "—" $m }}</code></small></td>
+              <td>{{ if $status }}<nuon-label-badge theme="{{ dig (lower $status) "neutral" $themeMap }}" label="{{ $status }}"></nuon-label-badge>{{ else }}—{{ end }}</td>
+              <td>{{ with dig "created_at" "" $m }}<nuon-time time="{{ printf "%sZ" (substr 0 19 .) }}" format="short-datetime"></nuon-time>{{ else }}—{{ end }}</td>
+          </tr>
+      {{ end }}
+      </tbody>
+  </table>
+
+{{ else }}
+
+<div style="padding-top: 1rem;"><nuon-banner theme="info">No migrations reported.</nuon-banner></div>
+
+{{ end }}
+
+{{ else }}
+
+<nuon-banner theme="warn">Waiting on inspect_migrations action. Run it to populate this runbook.</nuon-banner>
+
+{{ end }}

--- a/byoc-nuon/runbooks/inspect_migrations.toml
+++ b/byoc-nuon/runbooks/inspect_migrations.toml
@@ -1,0 +1,9 @@
+name        = "inspect_migrations"
+description = "Inspect ctl-api schema migrations — the last 20 by created_at, with status."
+readme      = "./runbooks/inspect_migrations.md"
+labels      = { service = "ctl-api", type = "debug" }
+
+[[steps]]
+name        = "Inspect: migrations"
+type        = "action"
+action_name = "inspect_migrations"

--- a/byoc-nuon/runbooks/inspect_migrations.toml
+++ b/byoc-nuon/runbooks/inspect_migrations.toml
@@ -1,5 +1,5 @@
 name        = "inspect_migrations"
-description = "Inspect ctl-api schema migrations — the last 20 by created_at, with status."
+description = "Inspect ctl-api schema migrations — the last 10 by created_at, with status."
 readme      = "./runbooks/inspect_migrations.md"
 labels      = { service = "ctl-api", type = "debug" }
 

--- a/byoc-nuon/runbooks/refresh_readme.md
+++ b/byoc-nuon/runbooks/refresh_readme.md
@@ -8,6 +8,7 @@ Runs every action that populates a section of the install README, so the rendere
 | `dashboard_status` | Dashboard status badge, version/git labels |
 | `inspect_runners` | Runners section |
 | `inspect_installs` | Installs section |
+| `inspect_migrations` | Migrations section |
 | `inspect_apps` | Apps section |
 | `inspect_orgs` | Orgs section |
 | `healthcheck_temporal` | Temporal healthcheck indicator |

--- a/byoc-nuon/runbooks/refresh_readme.toml
+++ b/byoc-nuon/runbooks/refresh_readme.toml
@@ -27,3 +27,8 @@ action_name = "inspect_runners"
 name        = "Inspect: installs"
 type        = "action"
 action_name = "inspect_installs"
+
+[[steps]]
+name        = "Inspect: migrations"
+type        = "action"
+action_name = "inspect_migrations"


### PR DESCRIPTION
Adds the last 10 database migrations, when they ran, and their status to the refresh readme runbook. 