### PR TITLE
policies: skip no-cluster-roles on teardown/delete

### DIFF
--- a/byoc-nuon-gcp/policies/no-cluster-roles.rego
+++ b/byoc-nuon-gcp/policies/no-cluster-roles.rego
@@ -19,5 +19,14 @@ import future.keywords.in
 
 warn contains msg if {
 	input.review.kind.kind in {"ClusterRole", "ClusterRoleBinding"}
+	not is_deletion
 	msg := sprintf("%s '%s' uses cluster-wide RBAC; prefer namespaced RBAC (Role/RoleBinding) to limit blast radius.", [input.review.kind.kind, input.review.object.metadata.name])
+}
+
+# Objects being removed (e.g. a helm uninstall / teardown) are exempt: tearing
+# down existing cluster-wide RBAC reduces blast radius and must not be warned on.
+# Only an explicit DELETE operation suppresses the rule; an unknown/absent
+# operation fails safe and is still treated as a creation.
+is_deletion if {
+	input.review.operation == "DELETE"
 }

--- a/byoc-nuon/policies/no-cluster-roles.rego
+++ b/byoc-nuon/policies/no-cluster-roles.rego
@@ -19,5 +19,14 @@ import future.keywords.in
 
 deny contains msg if {
 	input.review.kind.kind in {"ClusterRole", "ClusterRoleBinding"}
+	not is_deletion
 	msg := sprintf("%s '%s' is not allowed: this component must use namespaced RBAC (Role/RoleBinding), not cluster-wide RBAC.", [input.review.kind.kind, input.review.object.metadata.name])
+}
+
+# Objects being removed (e.g. a helm uninstall / teardown) are exempt: tearing
+# down existing cluster-wide RBAC reduces blast radius and must not be blocked.
+# Only an explicit DELETE operation suppresses the rule; an unknown/absent
+# operation fails safe and is still treated as a creation.
+is_deletion if {
+	input.review.operation == "DELETE"
 }


### PR DESCRIPTION
Exempt ClusterRole/ClusterRoleBinding objects from the no-cluster-roles deny/warn when the admission review operation is DELETE, so tearing down an install that predates the policy is not blocked. Fails safe: an absent operation is still treated as a creation.