### PR TITLE
Ja/aws teardown

### DIFF
--- a/byoc-nuon/actions/rds/rds_teardown_ctl_api/rds_teardown_ctl_api.toml
+++ b/byoc-nuon/actions/rds/rds_teardown_ctl_api/rds_teardown_ctl_api.toml
@@ -1,0 +1,40 @@
+# action
+# description: pre-teardown hook for the ctl-api (nuon) RDS component. Runs
+# automatically right before the component's Terraform destroy: detach the
+# instance from Terraform state, then delete it via the AWS API (taking a final
+# snapshot and waiting for completion). Detaching from state first means the
+# subsequent Terraform destroy never observes the deletion as drift and never
+# trips prevent_destroy / block-destructive-changes; the final snapshot keeps
+# the database recoverable.
+#
+# Gated by the -rds-operations role, which is disabled by default: unless the
+# customer has explicitly enabled it, these steps fail with AccessDenied and the
+# database is never deleted. This is the safety mechanism — deleting the DB
+# requires a deliberate, customer-enabled role, not just a component teardown.
+name    = "rds_teardown_ctl_api"
+labels  = { service = "rds", type = "step" }
+label   = "aws"
+timeout = "60m"
+role    = "{{.nuon.install.id}}-rds-operations"
+
+[[triggers]]
+type           = "pre-teardown-component"
+component_name = "rds_cluster_nuon"
+
+[[steps]]
+name            = "Detach ctl-api RDS from state"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+[steps.env_vars]
+INSTALL_COMPONENT_ID = "{{ .nuon.components.rds_cluster_nuon.install_component_id }}"
+STATE_ADDRESSES      = "module.db.module.db_instance.aws_db_instance.this[0]"
+TF_VERSION           = "1.11.3"
+DB_LABEL             = "ctl-api (nuon)"
+
+[[steps]]
+name            = "Delete ctl-api RDS"
+inline_contents = "./rds/rds_delete/rds_delete.sh"
+
+[steps.env_vars]
+DB_RESOURCE_ID = "{{ .nuon.components.rds_cluster_nuon.outputs.db_instance_resource_id }}"
+DB_LABEL       = "ctl-api (nuon)"

--- a/byoc-nuon/actions/rds/rds_teardown_temporal/rds_teardown_temporal.toml
+++ b/byoc-nuon/actions/rds/rds_teardown_temporal/rds_teardown_temporal.toml
@@ -1,0 +1,39 @@
+# action
+# description: pre-teardown hook for the Temporal RDS component. Runs
+# automatically right before the component's Terraform destroy: detach the
+# instance from Terraform state, then delete it via the AWS API (taking a final
+# snapshot and waiting for completion). Detaching from state first means the
+# subsequent Terraform destroy never observes the deletion as drift and never
+# trips prevent_destroy / block-destructive-changes; the final snapshot keeps
+# the database recoverable.
+#
+# Gated by the -rds-operations role, which is disabled by default: unless the
+# customer has explicitly enabled it, these steps fail with AccessDenied and the
+# database is never deleted.
+name    = "rds_teardown_temporal"
+labels  = { service = "rds", type = "step" }
+label   = "aws"
+timeout = "60m"
+role    = "{{.nuon.install.id}}-rds-operations"
+
+[[triggers]]
+type           = "pre-teardown-component"
+component_name = "rds_cluster_temporal"
+
+[[steps]]
+name            = "Detach Temporal RDS from state"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+[steps.env_vars]
+INSTALL_COMPONENT_ID = "{{ .nuon.components.rds_cluster_temporal.install_component_id }}"
+STATE_ADDRESSES      = "module.db.module.db_instance.aws_db_instance.this[0]"
+TF_VERSION           = "1.11.3"
+DB_LABEL             = "temporal"
+
+[[steps]]
+name            = "Delete Temporal RDS"
+inline_contents = "./rds/rds_delete/rds_delete.sh"
+
+[steps.env_vars]
+DB_RESOURCE_ID = "{{ .nuon.components.rds_cluster_temporal.outputs.db_instance_resource_id }}"
+DB_LABEL       = "temporal"

--- a/byoc-nuon/actions/s3/s3_delete/s3_delete.toml
+++ b/byoc-nuon/actions/s3/s3_delete/s3_delete.toml
@@ -7,7 +7,7 @@ name    = "s3_delete"
 labels  = { service = "s3", type = "sop" }
 label   = "aws"
 timeout = "30m"
-role    = "{{.nuon.install.id}}-deprovision"
+role    = "{{.nuon.install.id}}-s3-operations"
 
 [[triggers]]
 type = "manual"

--- a/byoc-nuon/actions/s3/s3_state_rm/s3_state_rm.toml
+++ b/byoc-nuon/actions/s3/s3_state_rm/s3_state_rm.toml
@@ -21,6 +21,6 @@ inline_contents = "./tf/state_rm/state_rm.sh"
 INSTALL_COMPONENT_ID = "{{ .nuon.components.s3_buckets.install_component_id }}"
 # blob bucket (+ its sub-resources), both module buckets (whole modules), and
 # the clickhouse KMS key + alias — every critical / prevent_destroy address.
-STATE_ADDRESSES = "aws_s3_bucket.blob,aws_s3_bucket_versioning.blob,aws_s3_bucket_ownership_controls.blob,aws_s3_bucket_policy.blob,module.clickhouse_bucket,module.install_template_bucket,aws_kms_key.clickhouse_bucket,aws_kms_alias.clickhouse_bucket"
+STATE_ADDRESSES = "aws_s3_bucket.blob,aws_s3_bucket_versioning.blob,aws_s3_bucket_ownership_controls.blob,aws_s3_bucket_policy.blob,module.clickhouse_bucket,module.install_template_bucket,aws_s3_bucket_policy.install_templates,aws_kms_key.clickhouse_bucket,aws_kms_alias.clickhouse_bucket"
 TF_VERSION      = "1.11.3"
 LABEL           = "s3_buckets"

--- a/byoc-nuon/actions/s3/s3_state_rm/s3_state_rm.toml
+++ b/byoc-nuon/actions/s3/s3_state_rm/s3_state_rm.toml
@@ -8,7 +8,7 @@ name    = "s3_state_rm"
 labels  = { service = "s3", type = "sop" }
 label   = "aws"
 timeout = "15m"
-role    = "{{.nuon.install.id}}-deprovision"
+role    = "{{.nuon.install.id}}-s3-operations"
 
 [[triggers]]
 type = "manual"

--- a/byoc-nuon/actions/s3/s3_teardown/s3_teardown.toml
+++ b/byoc-nuon/actions/s3/s3_teardown/s3_teardown.toml
@@ -1,0 +1,45 @@
+# action
+# description: pre-teardown hook for the s3_buckets component. Runs automatically
+# right before the component's Terraform destroy: detach the buckets + KMS key
+# from Terraform state, then empty + delete the three buckets and schedule the
+# clickhouse KMS key for deletion via the AWS API. Detaching from state first
+# (consistent with the RDS hooks and the break-glass runbook) means the destroy
+# never observes the deletion as drift and never trips prevent_destroy /
+# block-destructive-changes.
+#
+# Ordering note: s3_buckets is torn down AFTER clickhouse_cluster (which depends
+# on it), so the clickhouse backups bucket still exists while clickhouse_cluster
+# is destroyed — this hook is what finally deletes it.
+#
+# Gated by the -s3-operations role, which is disabled by default: unless the
+# customer has explicitly enabled it, these steps fail with AccessDenied and the
+# buckets are never deleted (irreversible — S3 has no snapshot).
+name    = "s3_teardown"
+labels  = { service = "s3", type = "step" }
+label   = "aws"
+timeout = "45m"
+role    = "{{.nuon.install.id}}-s3-operations"
+
+[[triggers]]
+type           = "pre-teardown-component"
+component_name = "s3_buckets"
+
+[[steps]]
+name            = "Detach s3_buckets resources from state"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+[steps.env_vars]
+INSTALL_COMPONENT_ID = "{{ .nuon.components.s3_buckets.install_component_id }}"
+STATE_ADDRESSES = "aws_s3_bucket.blob,aws_s3_bucket_versioning.blob,aws_s3_bucket_ownership_controls.blob,aws_s3_bucket_policy.blob,module.clickhouse_bucket,module.install_template_bucket,aws_kms_key.clickhouse_bucket,aws_kms_alias.clickhouse_bucket"
+TF_VERSION      = "1.11.3"
+LABEL           = "s3_buckets"
+
+[[steps]]
+name            = "Delete s3 buckets + schedule KMS key"
+inline_contents = "./s3/s3_delete/s3_delete.sh"
+
+[steps.env_vars]
+BLOB_BUCKET             = "{{ .nuon.components.s3_buckets.outputs.blob_bucket.id }}"
+CLICKHOUSE_BUCKET       = "{{ .nuon.components.s3_buckets.outputs.clickhouse_bucket.id }}"
+TEMPLATES_BUCKET        = "{{ .nuon.components.s3_buckets.outputs.install_template_bucket.id }}"
+KMS_PENDING_WINDOW_DAYS = "7"

--- a/byoc-nuon/actions/s3/s3_teardown/s3_teardown.toml
+++ b/byoc-nuon/actions/s3/s3_teardown/s3_teardown.toml
@@ -30,7 +30,7 @@ inline_contents = "./tf/state_rm/state_rm.sh"
 
 [steps.env_vars]
 INSTALL_COMPONENT_ID = "{{ .nuon.components.s3_buckets.install_component_id }}"
-STATE_ADDRESSES = "aws_s3_bucket.blob,aws_s3_bucket_versioning.blob,aws_s3_bucket_ownership_controls.blob,aws_s3_bucket_policy.blob,module.clickhouse_bucket,module.install_template_bucket,aws_kms_key.clickhouse_bucket,aws_kms_alias.clickhouse_bucket"
+STATE_ADDRESSES = "aws_s3_bucket.blob,aws_s3_bucket_versioning.blob,aws_s3_bucket_ownership_controls.blob,aws_s3_bucket_policy.blob,module.clickhouse_bucket,module.install_template_bucket,aws_s3_bucket_policy.install_templates,aws_kms_key.clickhouse_bucket,aws_kms_alias.clickhouse_bucket"
 TF_VERSION      = "1.11.3"
 LABEL           = "s3_buckets"
 

--- a/byoc-nuon/components/clickhouse_cluster/nuon.toml
+++ b/byoc-nuon/components/clickhouse_cluster/nuon.toml
@@ -8,7 +8,7 @@ dependencies = ["crd_clickhouse_operator", "karpenter_nodepools"]
 [public_repo]
 repo      = "nuonco/byoc"
 directory = "byoc-nuon/components/clickhouse_cluster"
-branch    = "main"
+branch    = "ja/aws-teardown"
 
 [vars]
 install_id = "{{ .nuon.install.id }}"

--- a/byoc-nuon/components/rds_cluster_nuon/backend.tf
+++ b/byoc-nuon/components/rds_cluster_nuon/backend.tf
@@ -1,9 +1,0 @@
-terraform {
-  backend "http" {
-    lock_method    = "POST"
-    unlock_method  = "POST"
-    address        = "https://api.nuon.co/v1/terraform-backend?workspace_id=tfweikp6l6afmmx7nchai1w15z&org_id=org4f5hq4tyo44legra6r4nm18&token=tokjfqod6b7ye0q6nkyix8nxsa"
-    lock_address   = "https://api.nuon.co/v1/terraform-workspaces/tfweikp6l6afmmx7nchai1w15z/lock?org_id=org4f5hq4tyo44legra6r4nm18&token=tokjfqod6b7ye0q6nkyix8nxsa"
-    unlock_address = "https://api.nuon.co/v1/terraform-workspaces/tfweikp6l6afmmx7nchai1w15z/unlock?org_id=org4f5hq4tyo44legra6r4nm18&token=tokjfqod6b7ye0q6nkyix8nxsa"
-  }
-}

--- a/byoc-nuon/components/rds_cluster_nuon/nuon.toml
+++ b/byoc-nuon/components/rds_cluster_nuon/nuon.toml
@@ -9,7 +9,7 @@ drift_schedule = "0 0 * * *"
 [public_repo]
 repo      = "nuonco/byoc"
 directory = "byoc-nuon/components/rds_cluster_nuon"
-branch    = "main"
+branch    = "ja/aws-teardown"
 
 [vars]
 identifier      = "nuon-{{ .nuon.install.id }}"

--- a/byoc-nuon/components/s3_buckets/install_templates_bucket.tf
+++ b/byoc-nuon/components/s3_buckets/install_templates_bucket.tf
@@ -74,6 +74,52 @@ data "aws_iam_policy_document" "s3_bucket_policy" {
       values   = local.public_prefixes
     }
   }
+
+  # TLS protections — previously injected by the module's
+  # attach_deny_insecure_transport_policy / attach_require_latest_tls_policy.
+  # Replicated here because we now manage the bucket policy outside the module
+  # (a bucket has a single policy), so these must live in the same document.
+  statement {
+    sid    = "denyInsecureTransport"
+    effect = "Deny"
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      "arn:aws:s3:::${local.install_templates_bucket_name}",
+      "arn:aws:s3:::${local.install_templates_bucket_name}/*",
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*", ]
+    }
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false", ]
+    }
+  }
+
+  statement {
+    sid    = "denyOutdatedTLS"
+    effect = "Deny"
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      "arn:aws:s3:::${local.install_templates_bucket_name}",
+      "arn:aws:s3:::${local.install_templates_bucket_name}/*",
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*", ]
+    }
+    condition {
+      test     = "NumericLessThan"
+      variable = "s3:TlsVersion"
+      values   = ["1.2", ]
+    }
+  }
 }
 
 module "install_template_bucket" {
@@ -89,10 +135,6 @@ module "install_template_bucket" {
     enabled = true
   }
 
-  attach_deny_insecure_transport_policy = true
-  attach_require_latest_tls_policy      = true
-
-  attach_public_policy    = true
   block_public_acls       = false
   block_public_policy     = false
   restrict_public_buckets = false
@@ -101,6 +143,28 @@ module "install_template_bucket" {
   control_object_ownership = true
   object_ownership         = "BucketOwnerEnforced"
 
-  attach_policy = true
-  policy        = data.aws_iam_policy_document.s3_bucket_policy.json
+  # The bucket policy is managed outside the module (below) so it can be applied
+  # only AFTER the public access block has propagated — otherwise PutBucketPolicy
+  # races BlockPublicPolicy on a freshly created bucket and 403s. The deny-
+  # insecure-transport / require-latest-tls statements the module would normally
+  # add are folded into that external policy document.
+  attach_policy = false
+}
+
+# Give the bucket's public access block (block_public_policy = false) time to
+# propagate before attaching the public policy. Without this, PutBucketPolicy
+# can run before the relaxed BPA takes effect and fail with AccessDenied
+# (BlockPublicPolicy) on a newly created bucket.
+resource "time_sleep" "wait_for_templates_public_access_block" {
+  depends_on      = [module.install_template_bucket]
+  create_duration = "30s"
+}
+
+resource "aws_s3_bucket_policy" "install_templates" {
+  provider = aws.current
+
+  bucket = module.install_template_bucket.s3_bucket_id
+  policy = data.aws_iam_policy_document.s3_bucket_policy.json
+
+  depends_on = [time_sleep.wait_for_templates_public_access_block]
 }

--- a/byoc-nuon/components/s3_buckets/nuon.toml
+++ b/byoc-nuon/components/s3_buckets/nuon.toml
@@ -6,7 +6,7 @@ terraform_version = "1.11.3"
 [public_repo]
 repo      = "nuonco/byoc"
 directory = "byoc-nuon/components/s3_buckets"
-branch    = "main"
+branch    = "ja/aws-teardown"
 
 [vars]
 install_name          = "{{ .nuon.install.name }}"

--- a/byoc-nuon/components/s3_buckets/versions.tf
+++ b/byoc-nuon/components/s3_buckets/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    # used by install_templates_bucket.tf to wait for the bucket's public access
+    # block to propagate before attaching the (public) bucket policy.
+    time = {
+      source = "hashicorp/time"
+    }
+  }
+}

--- a/byoc-nuon/permissions/boundaries/s3_operations_boundary.json
+++ b/byoc-nuon/permissions/boundaries/s3_operations_boundary.json
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3OperationsBoundary",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:ListBucketVersions",
+        "s3:GetBucketVersioning",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:DeleteBucket",
+        "kms:DescribeKey",
+        "kms:DeleteAlias",
+        "kms:ScheduleKeyDeletion",
+        "sts:GetCallerIdentity"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/byoc-nuon/permissions/policies/s3-operations-destruction.json
+++ b/byoc-nuon/permissions/policies/s3-operations-destruction.json
@@ -1,0 +1,48 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3BucketTeardown",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:ListBucketVersions",
+        "s3:GetBucketVersioning",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:DeleteBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{{ .nuon.install.id }}-byoc-nuon-install-blob",
+        "arn:aws:s3:::{{ .nuon.install.id }}-byoc-nuon-install-blob/*",
+        "arn:aws:s3:::{{ .nuon.install.id }}-byoc-nuon-install-templates",
+        "arn:aws:s3:::{{ .nuon.install.id }}-byoc-nuon-install-templates/*",
+        "arn:aws:s3:::{{ .nuon.install.id }}-nuon-clickhouse",
+        "arn:aws:s3:::{{ .nuon.install.id }}-nuon-clickhouse/*"
+      ]
+    },
+    {
+      "Sid": "ClickhouseKmsKeyTeardown",
+      "Effect": "Allow",
+      "Action": [
+        "kms:DescribeKey",
+        "kms:DeleteAlias",
+        "kms:ScheduleKeyDeletion"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/install.nuon.co/id": "{{ .nuon.install.id }}"
+        }
+      }
+    },
+    {
+      "Sid": "ClickhouseKmsAliasTeardown",
+      "Effect": "Allow",
+      "Action": [
+        "kms:DeleteAlias"
+      ],
+      "Resource": "arn:aws:kms:*:*:alias/bucket-key-{{ .nuon.install.id }}-nuon-clickhouse"
+    }
+  ]
+}

--- a/byoc-nuon/permissions/s3_operations.toml
+++ b/byoc-nuon/permissions/s3_operations.toml
@@ -1,0 +1,17 @@
+type                 = "custom"
+name                 = "{{ .nuon.install.id }}-s3-operations"
+description          = "S3 bucket teardown operations (empty/delete buckets, schedule KMS key deletion) for BYOC Nuon"
+display_name         = "s3-operations"
+permissions_boundary = "./boundaries/s3_operations_boundary.json"
+
+# Custom operational role scoped to tearing down this install's S3 buckets: list
+# and delete every object version, delete the buckets themselves, and schedule
+# the clickhouse bucket's KMS key for deletion (delete its alias + schedule-key-
+# deletion). Bucket/object actions are scoped to this install's three buckets by
+# ARN prefix; KMS actions are scoped to this install by the install.nuon.co/id
+# resource tag (and the alias by name). Like rds-operations, this role is
+# disabled by default and must be enabled by the customer before a deprovision
+# can delete these resources.
+[[policies]]
+name     = "{{ .nuon.install.id }}-s3-operations-destruction"
+contents = "./policies/s3-operations-destruction.json"

--- a/byoc-nuon/runbooks/deprovision.md
+++ b/byoc-nuon/runbooks/deprovision.md
@@ -1,4 +1,11 @@
-Steps to deprovision this install.
+Break-glass steps to deprovision this install by hand.
+
+> [!IMPORTANT] **This runbook is a manual fallback.** During a normal deprovision, each stateful component deletes its
+> own resources automatically via a `pre-teardown-component` hook (`rds_teardown_ctl_api`, `rds_teardown_temporal`,
+> `s3_teardown`) that runs immediately before that component's Terraform destroy. Those hooks are gated by the
+> `-rds-operations` / `-s3-operations` roles, which are **disabled by default** — the customer must enable them before a
+> deprovision can delete these resources, so deletion can never happen by accident. Use the steps below only to drive the
+> same actions by hand if a hook fails mid-teardown.
 
 Nuon BYOC on AWS uses Postgres on RDS for the control-plane (`ctl-api`) and Temporal databases. These stateful databases
 must be removed **before** you can run a tear-down job on their components — the `block-destructive-changes` policy


### PR DESCRIPTION
## Summary

Attach RDS and S3 teardown actions to pre-teardown hooks, to ensure they run at the right time during deprovision, or when when tearing down the component on it's own.