### PR TITLE
feat: save api probe steps as runbook

### DIFF
--- a/byoc-nuon/actions/ctl_api/api_probe/acm_cert.sh
+++ b/byoc-nuon/actions/ctl_api/api_probe/acm_cert.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+
+# Cluster check 4/4 — "Is the shared wildcard TLS cert issued?"
+# Step of the ctl_api_api_health_probe runbook. The https endpoints (public,
+# runner, auth) share one wildcard ACM cert; until it is ISSUED their ALBs can't
+# terminate TLS and won't come up. Needs AWS read perms (run under -provision).
+# Does NOT use set -e.
+#
+# Required env:
+#   CERT_ARN  the wildcard public-domain certificate ARN
+
+set -u
+export AWS_PAGER=""
+
+CERT_ARN="${CERT_ARN:-}"
+
+echo "==================================================================="
+echo " Is the shared wildcard TLS cert issued?"
+echo "==================================================================="
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "  aws CLI not available — cannot inspect ACM. (Is this running under -provision?)"
+  echo "probe complete."
+  exit 0
+fi
+
+if [ -z "$CERT_ARN" ]; then
+  echo "  CERT_ARN not provided — nothing to check."
+  echo "probe complete."
+  exit 0
+fi
+
+echo "cert: ${CERT_ARN}"
+st=$(aws acm describe-certificate --certificate-arn "$CERT_ARN" \
+  --query 'Certificate.Status' --output text 2>&1)
+echo "  status: ${st}"
+case "$st" in
+  ISSUED) echo "  -> OK: https endpoints can terminate TLS." ;;
+  PENDING_VALIDATION) echo "  -> NOT validated yet: DNS validation records likely missing — https ALBs will not come up." ;;
+  *) echo "  -> unexpected status; inspect the cert (validation records / ARN)." ;;
+esac
+
+echo ""
+echo "  Note: this only gates the https endpoints (public/runner/auth). The admin"
+echo "        endpoint is plain http and does not depend on this cert."
+echo ""
+echo "probe complete."

--- a/byoc-nuon/actions/ctl_api/api_probe/alb_controller.sh
+++ b/byoc-nuon/actions/ctl_api/api_probe/alb_controller.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+
+# Cluster check 2/4 — "Is the LB controller running and is its IRSA actually wired?"
+# Step of the ctl_api_api_health_probe runbook. Inspects the AWS Load Balancer
+# Controller pod, its ServiceAccount role-arn annotation, the injected IRSA env
+# (AWS_ROLE_ARN / token path), and its logs for credential errors.
+# Read-only, kubectl only (no AWS role). Does NOT use set -e.
+
+set -u
+
+echo "==================================================================="
+echo " Is the LB controller running and is its IRSA actually wired?"
+echo "==================================================================="
+lbc_ns=$(kubectl get pods -A 2>/dev/null | grep -i "aws-load-balancer-controller" | awk '{print $1}' | head -1)
+if [ -z "$lbc_ns" ]; then
+  echo "  controller pod NOT found cluster-wide (grep aws-load-balancer-controller)."
+  echo "  Try: kubectl get pods -A | grep -i load-balancer"
+  echo ""
+  echo "probe complete."
+  exit 0
+fi
+
+echo "namespace: ${lbc_ns}"
+kubectl get -n "$lbc_ns" pods 2>&1 | grep -iE "NAME|load-balancer" || true
+
+lbc_pod=$(kubectl get -n "$lbc_ns" pods -o name 2>/dev/null | grep -i load-balancer | head -1)
+if [ -n "$lbc_pod" ]; then
+  lbc_sa=$(kubectl get -n "$lbc_ns" "$lbc_pod" -o jsonpath='{.spec.serviceAccountName}' 2>/dev/null)
+  echo ""
+  echo "serviceAccountName: ${lbc_sa:-<unknown>}"
+  if [ -n "${lbc_sa:-}" ]; then
+    echo "  SA role-arn annotation: $(kubectl get -n "$lbc_ns" sa "$lbc_sa" -o jsonpath='{.metadata.annotations.eks\.amazonaws\.com/role-arn}' 2>&1)"
+  fi
+
+  echo ""
+  echo "--- injected IRSA env (role + token path) ---"
+  kubectl get -n "$lbc_ns" "$lbc_pod" \
+    -o jsonpath='{range .spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' 2>/dev/null \
+    | grep -iE "AWS_ROLE_ARN|AWS_WEB_IDENTITY_TOKEN_FILE|AWS_STS_REGIONAL" \
+    || echo "  (no AWS_ROLE_ARN env — IRSA webhook injected nothing; SA annotation likely missing)"
+
+  echo ""
+  echo "  => the role's trust policy MUST allow sub: system:serviceaccount:${lbc_ns}:${lbc_sa:-<unknown>}"
+
+  echo ""
+  echo "--- controller logs: AssumeRoleWithWebIdentity / credential errors (last 200) ---"
+  kubectl logs -n "$lbc_ns" "$lbc_pod" --tail=200 2>&1 \
+    | grep -iE "AssumeRoleWithWebIdentity|credential|WebIdentity|AccessDenied|oidc" | tail -30 \
+    || echo "  (no matching log lines)"
+fi
+
+echo ""
+echo "  Interpreting:"
+echo "    * no AWS_ROLE_ARN env      => SA annotation missing; the IRSA webhook injected nothing."
+echo "    * env present + AssumeRoleWithWebIdentity 403 in logs => env is fine but STS rejects the"
+echo "      assume; the role trust policy / OIDC provider is the problem (see the IRSA trust step)."
+echo ""
+echo "probe complete."

--- a/byoc-nuon/actions/ctl_api/api_probe/alb_ingress_status.sh
+++ b/byoc-nuon/actions/ctl_api/api_probe/alb_ingress_status.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+
+# Cluster check 1/4 — "Are ALBs being built for the ingresses at all?"
+# Step of the ctl_api_api_health_probe runbook. Lists every ctl-api ingress and
+# whether it has an ALB address yet, plus its FailedBuildModel event count.
+# Read-only, kubectl only (no AWS role). Does NOT use set -e.
+
+set -u
+
+NS="${NAMESPACE:-ctl-api}"
+
+echo "==================================================================="
+echo " Are ALBs being built for the ${NS} ingresses at all?"
+echo "==================================================================="
+for ing in $(kubectl get -n "$NS" ingress -o name 2>/dev/null); do
+  alb=$(kubectl get -n "$NS" "$ing" -o jsonpath='{.status.loadBalancer.ingress[*].hostname}' 2>/dev/null)
+  fbm=$(kubectl describe -n "$NS" "$ing" 2>/dev/null | grep -c "FailedBuildModel")
+  echo "  ${ing}: alb=[${alb:-<none>}] FailedBuildModel_events=${fbm}"
+done
+echo ""
+echo "  Interpreting:"
+echo "    * alb=<none> + FailedBuildModel>0 on EVERY ingress => controller-wide failure;"
+echo "      the controller can't build any ALB. Continue to the controller + IRSA steps."
+echo "    * alb=<none> on just ONE ingress => endpoint-specific; check that endpoint's probe step."
+echo "    * alb set on all => ALBs are built; the problem (if any) is downstream (DNS / the service)."
+echo ""
+echo "probe complete."

--- a/byoc-nuon/actions/ctl_api/api_probe/alb_irsa_trust.sh
+++ b/byoc-nuon/actions/ctl_api/api_probe/alb_irsa_trust.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+
+# Cluster check 3/4 — "Can the controller actually assume its role?"
+# Step of the ctl_api_api_health_probe runbook. Compares the cluster OIDC issuer,
+# the registered IAM OIDC providers, and the alb-controller role's trust policy.
+# Re-derives the controller pod / role / SA itself (steps are independent runs).
+# Needs AWS read perms (run under -provision). Does NOT use set -e.
+
+set -u
+export AWS_PAGER=""
+
+echo "==================================================================="
+echo " Can the controller actually assume its role?"
+echo "==================================================================="
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "  aws CLI not available — cannot inspect IAM/EKS. (Is this running under -provision?)"
+  echo "probe complete."
+  exit 0
+fi
+
+# re-derive the controller pod, its SA, and the role it assumes (this step is a
+# separate process from the controller step, so nothing is shared).
+lbc_ns=$(kubectl get pods -A 2>/dev/null | grep -i "aws-load-balancer-controller" | awk '{print $1}' | head -1)
+lbc_pod=""; lbc_sa=""; role_arn=""
+if [ -n "$lbc_ns" ]; then
+  lbc_pod=$(kubectl get -n "$lbc_ns" pods -o name 2>/dev/null | grep -i load-balancer | head -1)
+  if [ -n "$lbc_pod" ]; then
+    lbc_sa=$(kubectl get -n "$lbc_ns" "$lbc_pod" -o jsonpath='{.spec.serviceAccountName}' 2>/dev/null)
+    role_arn=$(kubectl get -n "$lbc_ns" "$lbc_pod" \
+      -o jsonpath='{range .spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' 2>/dev/null \
+      | awk -F= '/^AWS_ROLE_ARN=/{print $2}')
+  fi
+fi
+echo "role the controller assumes = [${role_arn:-<unknown>}]"
+role_name=$(echo "$role_arn" | sed 's#.*role/##')
+
+echo ""
+echo "--- EKS cluster OIDC issuer(s) ---"
+for c in $(aws eks list-clusters --query 'clusters[]' --output text 2>&1); do
+  iss=$(aws eks describe-cluster --name "$c" --query 'cluster.identity.oidc.issuer' --output text 2>&1)
+  echo "  cluster ${c}: ${iss}"
+done
+
+echo ""
+echo "--- registered IAM OIDC identity providers ---"
+aws iam list-open-id-connect-providers --query 'OpenIDConnectProviderList[].Arn' --output text 2>&1 \
+  | tr '\t' '\n' | sed 's/^/  /' || true
+
+echo ""
+echo "--- alb-controller role trust policy ---"
+if [ -n "$role_name" ]; then
+  aws iam get-role --role-name "$role_name" --query 'Role.AssumeRolePolicyDocument' --output json 2>&1
+else
+  echo "  (could not determine role name from pod env)"
+fi
+
+echo ""
+echo "  Interpreting:"
+echo "    * cluster OIDC issuer has NO matching IAM OIDC provider above => provider missing (root cause A)."
+echo "    * provider exists but trust policy Principal.Federated / <issuer>:aud (sts.amazonaws.com) /"
+echo "      <issuer>:sub (system:serviceaccount:${lbc_ns:-?}:${lbc_sa:-?}) don't match => fix trust policy (B)."
+echo "    * a 403 ALSO happens if the role was DELETED — AWS returns the same"
+echo "      'Not authorized to perform sts:AssumeRoleWithWebIdentity' whether the trust mismatches OR the"
+echo "      role is absent, so confirm the role above actually exists."
+echo "    * fix lives in the install/runner IRSA + OIDC infra, not the byoc-nuon app components."
+echo ""
+echo "probe complete."

--- a/byoc-nuon/actions/ctl_api/api_probe/endpoint_probe.sh
+++ b/byoc-nuon/actions/ctl_api/api_probe/endpoint_probe.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env sh
+
+# Generic, env-driven health probe for a single ctl-api HTTP endpoint. One of
+# the per-endpoint steps of the ctl_api_api_health_probe runbook; the shared
+# cluster-wide ALB/IRSA checks live in the alb_* / acm_cert steps (run once).
+#
+# Funnels: enablement -> reachability -> DNS -> ingress/ALB. Read-only,
+# kubectl/curl only (no AWS role). Does NOT use set -e — every check runs and
+# reports independently.
+#
+# Required env:
+#   NAMESPACE     k8s namespace of the ingress (e.g. ctl-api)
+#   INGRESS_NAME  ingress object name (e.g. ctl-api-public)
+#   HOSTNAME      full hostname (e.g. api.<public_domain>)
+#   ZONE          public | internal  (which Route53 zone the record should live in)
+#   SCHEME        http | https
+#   HEALTH_PATH   path to curl (e.g. /readyz)
+# Optional env:
+#   ENABLE        "true"|"false" — if false, the endpoint is intentionally not
+#                 deployed and absence is expected (gated endpoints). Default true.
+
+set -u
+
+NAMESPACE="${NAMESPACE:?NAMESPACE is required}"
+INGRESS_NAME="${INGRESS_NAME:?INGRESS_NAME is required}"
+HOSTNAME="${HOSTNAME:?HOSTNAME is required}"
+ZONE="${ZONE:-public}"
+SCHEME="${SCHEME:-https}"
+HEALTH_PATH="${HEALTH_PATH:-/readyz}"
+ENABLE="${ENABLE:-true}"
+
+echo "==================================================================="
+echo " endpoint probe: ${INGRESS_NAME}  (${SCHEME}://${HOSTNAME}${HEALTH_PATH})"
+echo " zone=${ZONE} namespace=${NAMESPACE}"
+echo "==================================================================="
+
+if [ "$ENABLE" = "false" ]; then
+  echo ""
+  echo "ENABLE=false — this endpoint is intentionally disabled for this install."
+  echo "A missing ingress / NXDOMAIN here is EXPECTED, not a fault. Nothing to debug."
+  echo "probe complete."
+  exit 0
+fi
+
+# ── 1. reachability ──────────────────────────────────────────────────────────
+echo ""
+echo "--- 1. reachability (curl ${SCHEME}://${HOSTNAME}${HEALTH_PATH}) ---"
+rc=0
+code=$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' \
+  "${SCHEME}://${HOSTNAME}${HEALTH_PATH}") || rc=$?
+echo "curl exit=${rc} http_code=${code}"
+if [ "$rc" -eq 0 ] && [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 500 ]; then
+  echo "  -> REACHABLE (2xx-4xx; 401/403 just means up-but-unauthed). Endpoint is serving."
+else
+  case "$rc" in
+    6)  echo "  -> exit 6: DNS does not resolve — see steps 2-3 (record missing / ALB not built)" ;;
+    7)  echo "  -> exit 7: connection refused (resolves, but nothing listening yet)" ;;
+    28) echo "  -> exit 28: timeout (resolves, but no/slow response — ALB still provisioning)" ;;
+    3)  echo "  -> exit 3: malformed URL (check HOSTNAME/SCHEME)" ;;
+    0)  echo "  -> HTTP ${code} (5xx) — reached the ALB/pod but the service is erroring" ;;
+    *)  echo "  -> curl failed (exit ${rc})" ;;
+  esac
+fi
+
+# ── 2. DNS ───────────────────────────────────────────────────────────────────
+echo ""
+echo "--- 2. DNS resolution (expected in the ${ZONE} Route53 zone) ---"
+getent hosts "$HOSTNAME" || echo "  getent: NO resolution for ${HOSTNAME}"
+if command -v nslookup >/dev/null 2>&1; then
+  nslookup "$HOSTNAME" 2>&1 | sed 's/^/  /' || true
+fi
+if [ "$ZONE" = "internal" ]; then
+  echo "  note: internal-zone records resolve only inside the VPC (this action runs in-cluster, so that's fine)."
+fi
+
+# ── 3. ingress / ALB ─────────────────────────────────────────────────────────
+echo ""
+echo "--- 3. ingress ${NAMESPACE}/${INGRESS_NAME} (ALB address + annotations) ---"
+if ! kubectl get -n "$NAMESPACE" ingress "$INGRESS_NAME" >/dev/null 2>&1; then
+  echo "  ingress ${INGRESS_NAME} NOT found — the helm release did not create it."
+else
+  alb=$(kubectl get -n "$NAMESPACE" ingress "$INGRESS_NAME" \
+    -o jsonpath='{.status.loadBalancer.ingress[*].hostname}' 2>/dev/null)
+  echo "  ALB address: [${alb:-<none>}]"
+  echo "  external-dns hostname: $(kubectl get -n "$NAMESPACE" ingress "$INGRESS_NAME" -o jsonpath='{.metadata.annotations.external-dns\.alpha\.kubernetes\.io/hostname}' 2>&1)"
+  echo "  ALB scheme: $(kubectl get -n "$NAMESPACE" ingress "$INGRESS_NAME" -o jsonpath='{.metadata.annotations.alb\.ingress\.kubernetes\.io/scheme}' 2>&1) (expected: ${ZONE} => $( [ "$ZONE" = internal ] && echo internal || echo internet-facing ))"
+  echo "  cert-arn: $(kubectl get -n "$NAMESPACE" ingress "$INGRESS_NAME" -o jsonpath='{.metadata.annotations.alb\.ingress\.kubernetes\.io/certificate-arn}' 2>&1)"
+  echo "  recent events:"
+  kubectl describe -n "$NAMESPACE" ingress "$INGRESS_NAME" 2>&1 | sed -n '/Events:/,$p' | head -20 | sed 's/^/    /'
+  if [ -z "$alb" ]; then
+    echo ""
+    echo "  >> No ALB address. The ingress exists but no load balancer was built."
+    echo "     This is almost always a CLUSTER-WIDE problem, not this endpoint —"
+    echo "     check the cluster steps (ALB ingress status / controller / IRSA trust / cert)."
+  fi
+fi
+
+echo ""
+echo "probe complete."

--- a/byoc-nuon/actions/ctl_api/ctl_api_acm_cert/ctl_api_acm_cert.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_acm_cert/ctl_api_acm_cert.toml
@@ -1,0 +1,20 @@
+# action
+# description: cluster check 4/4 — "is the shared wildcard TLS cert issued?"
+# Checks the wildcard public-domain ACM certificate status (https endpoints
+# can't terminate TLS until it is ISSUED). Read-only; needs admin AWS perms.
+name    = "ctl_api_acm_cert"
+labels  = { service = "ctl-api", type = "debug" }
+label   = "aws"
+timeout = "5m"
+# reads ACM; needs admin AWS perms
+role    = "{{.nuon.install.id}}-provision"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Wildcard ACM certificate status"
+inline_contents = "./ctl_api/api_probe/acm_cert.sh"
+
+[steps.env_vars]
+CERT_ARN = "{{ .nuon.components.certificate_wildcard_public.outputs.public_domain_certificate_arn }}"

--- a/byoc-nuon/actions/ctl_api/ctl_api_alb_controller/ctl_api_alb_controller.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_alb_controller/ctl_api_alb_controller.toml
@@ -1,0 +1,14 @@
+# action
+# description: cluster check 2/4 — "is the LB controller running and is its IRSA
+# actually wired?" Controller pod, SA role-arn annotation, injected AWS_ROLE_ARN,
+# and credential errors in its logs. Read-only, kubectl only.
+name    = "ctl_api_alb_controller"
+labels  = { service = "ctl-api", type = "debug" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "LB controller workload + IRSA wiring"
+inline_contents = "./ctl_api/api_probe/alb_controller.sh"

--- a/byoc-nuon/actions/ctl_api/ctl_api_alb_ingress_status/ctl_api_alb_ingress_status.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_alb_ingress_status/ctl_api_alb_ingress_status.toml
@@ -1,0 +1,17 @@
+# action
+# description: cluster check 1/4 — "are ALBs being built for the ctl-api
+# ingresses at all?" Lists each ingress's ALB address + FailedBuildModel count.
+# Read-only, kubectl only.
+name    = "ctl_api_alb_ingress_status"
+labels  = { service = "ctl-api", type = "debug" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "ALB ingress build status"
+inline_contents = "./ctl_api/api_probe/alb_ingress_status.sh"
+
+[steps.env_vars]
+NAMESPACE = "ctl-api"

--- a/byoc-nuon/actions/ctl_api/ctl_api_alb_irsa_trust/ctl_api_alb_irsa_trust.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_alb_irsa_trust/ctl_api_alb_irsa_trust.toml
@@ -1,0 +1,17 @@
+# action
+# description: cluster check 3/4 — "can the controller actually assume its role?"
+# Compares the cluster OIDC issuer, registered IAM OIDC providers, and the
+# alb-controller role's trust policy. Read-only; needs admin AWS perms.
+name    = "ctl_api_alb_irsa_trust"
+labels  = { service = "ctl-api", type = "debug" }
+label   = "aws"
+timeout = "5m"
+# reads IAM/EKS; needs admin AWS perms
+role    = "{{.nuon.install.id}}-provision"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "IRSA trust chain (OIDC provider + role trust policy)"
+inline_contents = "./ctl_api/api_probe/alb_irsa_trust.sh"

--- a/byoc-nuon/actions/ctl_api/ctl_api_probe_admin/ctl_api_probe_admin.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_probe_admin/ctl_api_probe_admin.toml
@@ -1,0 +1,22 @@
+# action
+# description: per-endpoint health probe for the ctl-api ADMIN API
+# (admin.<internal_domain>, http, internal-scheme ALB, private Route53 zone).
+# Reachability + DNS + ingress/ALB. Read-only, kubectl/curl only.
+name    = "ctl_api_probe_admin"
+labels  = { service = "ctl-api", type = "debug" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Probe ctl-api admin endpoint"
+inline_contents = "./ctl_api/api_probe/endpoint_probe.sh"
+
+[steps.env_vars]
+NAMESPACE    = "ctl-api"
+INGRESS_NAME = "ctl-api-admin"
+HOSTNAME     = "admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+ZONE         = "internal"
+SCHEME       = "http"
+HEALTH_PATH  = "/readyz"

--- a/byoc-nuon/actions/ctl_api/ctl_api_probe_auth/ctl_api_probe_auth.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_probe_auth/ctl_api_probe_auth.toml
@@ -1,0 +1,22 @@
+# action
+# description: per-endpoint health probe for the ctl-api AUTH API
+# (auth.<public_domain>, https, internet-facing ALB). Reachability + DNS +
+# ingress/ALB. Read-only, kubectl/curl only.
+name    = "ctl_api_probe_auth"
+labels  = { service = "ctl-api", type = "debug" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Probe ctl-api auth endpoint"
+inline_contents = "./ctl_api/api_probe/endpoint_probe.sh"
+
+[steps.env_vars]
+NAMESPACE    = "ctl-api"
+INGRESS_NAME = "ctl-api-auth"
+HOSTNAME     = "auth.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
+ZONE         = "public"
+SCHEME       = "https"
+HEALTH_PATH  = "/readyz"

--- a/byoc-nuon/actions/ctl_api/ctl_api_probe_public/ctl_api_probe_public.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_probe_public/ctl_api_probe_public.toml
@@ -1,0 +1,22 @@
+# action
+# description: per-endpoint health probe for the ctl-api PUBLIC API
+# (api.<public_domain>, https, internet-facing ALB). Reachability + DNS +
+# ingress/ALB. Read-only, kubectl/curl only.
+name    = "ctl_api_probe_public"
+labels  = { service = "ctl-api", type = "debug" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Probe ctl-api public endpoint"
+inline_contents = "./ctl_api/api_probe/endpoint_probe.sh"
+
+[steps.env_vars]
+NAMESPACE    = "ctl-api"
+INGRESS_NAME = "ctl-api-public"
+HOSTNAME     = "api.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
+ZONE         = "public"
+SCHEME       = "https"
+HEALTH_PATH  = "/readyz"

--- a/byoc-nuon/actions/ctl_api/ctl_api_probe_runner/ctl_api_probe_runner.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_probe_runner/ctl_api_probe_runner.toml
@@ -1,0 +1,22 @@
+# action
+# description: per-endpoint health probe for the ctl-api RUNNER API
+# (runner.<public_domain>, https, internet-facing ALB). Reachability + DNS +
+# ingress/ALB. Read-only, kubectl/curl only.
+name    = "ctl_api_probe_runner"
+labels  = { service = "ctl-api", type = "debug" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Probe ctl-api runner endpoint"
+inline_contents = "./ctl_api/api_probe/endpoint_probe.sh"
+
+[steps.env_vars]
+NAMESPACE    = "ctl-api"
+INGRESS_NAME = "ctl-api-runner"
+HOSTNAME     = "runner.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
+ZONE         = "public"
+SCHEME       = "https"
+HEALTH_PATH  = "/readyz"

--- a/byoc-nuon/components/clickhouse_cluster/nuon.toml
+++ b/byoc-nuon/components/clickhouse_cluster/nuon.toml
@@ -8,7 +8,7 @@ dependencies = ["crd_clickhouse_operator", "karpenter_nodepools"]
 [public_repo]
 repo      = "nuonco/byoc"
 directory = "byoc-nuon/components/clickhouse_cluster"
-branch    = "ja/aws-teardown"
+branch    = "main"
 
 [vars]
 install_id = "{{ .nuon.install.id }}"

--- a/byoc-nuon/components/rds_cluster_nuon/nuon.toml
+++ b/byoc-nuon/components/rds_cluster_nuon/nuon.toml
@@ -9,7 +9,7 @@ drift_schedule = "0 0 * * *"
 [public_repo]
 repo      = "nuonco/byoc"
 directory = "byoc-nuon/components/rds_cluster_nuon"
-branch    = "ja/aws-teardown"
+branch    = "main"
 
 [vars]
 identifier      = "nuon-{{ .nuon.install.id }}"

--- a/byoc-nuon/components/s3_buckets/nuon.toml
+++ b/byoc-nuon/components/s3_buckets/nuon.toml
@@ -6,7 +6,7 @@ terraform_version = "1.11.3"
 [public_repo]
 repo      = "nuonco/byoc"
 directory = "byoc-nuon/components/s3_buckets"
-branch    = "ja/aws-teardown"
+branch    = "main"
 
 [vars]
 install_name          = "{{ .nuon.install.name }}"

--- a/byoc-nuon/runbooks/ctl_api_api_health_probe.md
+++ b/byoc-nuon/runbooks/ctl_api_api_health_probe.md
@@ -1,0 +1,67 @@
+Diagnose why a ctl-api HTTP endpoint is unreachable for install `{{ .nuon.install.id }}`.
+
+Use this when an endpoint won't answer — e.g. the `ctl_api_post_deploy` **runners-update-version** step failing with
+"admin API never became reachable", or a 5xx / DNS failure on `api`, `runner`, or `auth`. Every step is **read-only**.
+
+> [!NOTE] This runbook covers **HTTP / ingress-backed** ctl-api endpoints only (public, admin, runner, auth). Non-HTTP
+> or non-ingress services (Temporal gRPC, ClickHouse, anything on a Service/NLB rather than an ALB ingress) don't fit
+> this funnel and need a different approach.
+
+## How it works
+
+The funnel has two layers. **Steps 1–4 are the cluster-wide backbone** — there is one AWS Load Balancer Controller per
+cluster, so if it can't build ALBs (or the shared TLS cert isn't issued), *every* endpoint fails at once. They run
+first, ordered symptom → root cause. **Steps 5–8 probe each endpoint individually** (reachability → DNS → ingress/ALB).
+All steps run even if an earlier one finds the fault, so one pass gives the full picture.
+
+### 1. Are ALBs being built at all? — `ctl_api_alb_ingress_status`
+
+kubectl only. Lists every ctl-api ingress with its ALB address and `FailedBuildModel` event count. `alb=<none>` +
+`FailedBuildModel` on *every* ingress = controller-wide; on just one = endpoint-specific.
+
+### 2. Is the LB controller running and is its IRSA actually wired? — `ctl_api_alb_controller`
+
+kubectl only. The AWS Load Balancer Controller pod, its ServiceAccount `role-arn` annotation, the injected `AWS_ROLE_ARN`
+/ token path, and credential errors in its logs. No `AWS_ROLE_ARN` env ⇒ the SA annotation is missing; env present but a
+`403` in the logs ⇒ the env is fine and STS is rejecting the assume (continue to step 3).
+
+### 3. Can the controller actually assume its role? — `ctl_api_alb_irsa_trust`
+
+Runs under the `{{ .nuon.install.id }}-provision` role (IAM/EKS reads). Compares the **cluster OIDC issuer ↔ registered
+IAM OIDC providers ↔ the controller role's trust policy**. Distinguishes: OIDC provider missing, trust-policy
+`Federated`/`sub`/`aud` mismatch, or a deleted role (AWS returns the same 403 either way — confirm the role exists).
+
+### 4. Is the shared wildcard TLS cert issued? — `ctl_api_acm_cert`
+
+Runs under the `{{ .nuon.install.id }}-provision` role (ACM read). The https endpoints (public/runner/auth) share one
+wildcard ACM cert; until it is `ISSUED` their ALBs can't terminate TLS. (The admin endpoint is plain http and doesn't
+depend on it.)
+
+### 5–8. Per-endpoint probes — `ctl_api_probe_{public,admin,runner,auth}`
+
+Each checks one endpoint: a `curl` to its health path (treating 2xx–4xx as reachable — 401/403 just means up-but-unauthed),
+DNS resolution in the expected zone, and the ingress's ALB address / annotations / events.
+
+| endpoint | host | zone | scheme |
+| --- | --- | --- | --- |
+| public | `api.<public_domain>` | public (internet-facing) | https |
+| admin | `admin.<internal_domain>` | internal (private zone, VPC-only) | http |
+| runner | `runner.<public_domain>` | public (internet-facing) | https |
+| auth | `auth.<public_domain>` | public (internet-facing) | https |
+
+## Reading the output
+
+- **All endpoints show "no ALB address" + step 1 shows `FailedBuildModel` everywhere** → cluster-wide. Read step 3's
+  trust chain:
+  - cluster OIDC issuer has **no matching IAM OIDC provider** → the provider is missing (register it / re-provision IRSA).
+  - provider exists but the role's trust policy `Federated`/`:sub`/`:aud` don't match → fix the role trust policy.
+  - the same 403 (`Not authorized to perform sts:AssumeRoleWithWebIdentity`) also appears if the controller's IAM **role
+    was deleted** — AWS returns an identical error whether the trust mismatches or the role is absent, so confirm the
+    role actually exists.
+- **https endpoints down but step 4's ACM cert is `PENDING_VALIDATION`** → the cert's DNS validation records are missing;
+  the https ALBs won't come up until it's `ISSUED`.
+- **One endpoint down, others fine, steps 1–4 healthy** → endpoint-specific: check that ingress's events, its
+  `external-dns` hostname annotation, and whether its record landed in the right zone (internal vs public).
+
+> [!IMPORTANT] These checks are read-only. The fixes for cluster-wide failures (IRSA role / OIDC provider / ACM
+> validation) live in the install / runner infrastructure, **not** the byoc-nuon app components.

--- a/byoc-nuon/runbooks/ctl_api_api_health_probe.toml
+++ b/byoc-nuon/runbooks/ctl_api_api_health_probe.toml
@@ -1,0 +1,50 @@
+name        = "ctl_api_api_health_probe"
+description = "Diagnose why a ctl-api HTTP endpoint (public/admin/runner/auth) is unreachable. Runs the shared cluster ALB/IRSA/OIDC/cert backbone once, then probes each endpoint (reachability -> DNS -> ingress/ALB) to isolate the broken link. Read-only."
+readme      = "./runbooks/ctl_api_api_health_probe.md"
+labels      = { service = "ctl-api", type = "debug" }
+
+# Steps 1-4 are the cluster-wide backbone: if the LB controller can't build
+# ALBs (IRSA / OIDC / trust policy) or the wildcard cert isn't issued, EVERY
+# endpoint's ALB fails — so run them first, symptom -> root cause. Steps 5-8
+# then probe each endpoint individually. All steps are read-only and all run
+# even if an earlier one finds the fault.
+
+[[steps]]
+name        = "Are ALBs being built at all?"
+type        = "action"
+action_name = "ctl_api_alb_ingress_status"
+
+[[steps]]
+name        = "Is the LB controller running + IRSA wired?"
+type        = "action"
+action_name = "ctl_api_alb_controller"
+
+[[steps]]
+name        = "Can the controller assume its role?"
+type        = "action"
+action_name = "ctl_api_alb_irsa_trust"
+
+[[steps]]
+name        = "Is the wildcard TLS cert issued?"
+type        = "action"
+action_name = "ctl_api_acm_cert"
+
+[[steps]]
+name        = "Probe public endpoint"
+type        = "action"
+action_name = "ctl_api_probe_public"
+
+[[steps]]
+name        = "Probe admin endpoint"
+type        = "action"
+action_name = "ctl_api_probe_admin"
+
+[[steps]]
+name        = "Probe runner endpoint"
+type        = "action"
+action_name = "ctl_api_probe_runner"
+
+[[steps]]
+name        = "Probe auth endpoint"
+type        = "action"
+action_name = "ctl_api_probe_auth"


### PR DESCRIPTION
## Summary

In a test install, the admin api wasn't reachable. After doing some debugging, I thought it would be useful to document the steps I took to debug in a runbook.

As far as debugging goes, this is a pretty simple process. It inspects every component in the stack to see why requests might be failing.

1. Are ALBs being built at all?
2. Is the LB controller running and is its IRSA actually wired?
3. Can the controller actually assume its role? (turned out this is where my install was failing, because I had accidentally deleted the role while cleaning up old roles from other installs.)
4. Is the shared wildcard TLS cert issued?
5. -8 Is each API endpoint reachable? (public, admin, runner, auth)