### PR TITLE
feat(byoc-nuon): make datadog a toggleable component

### DIFF
--- a/byoc-nuon/components/datadog/nuon.toml
+++ b/byoc-nuon/components/datadog/nuon.toml
@@ -2,6 +2,8 @@ name              = "datadog"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 dependencies      = ["temporal", "ctl_api", "dashboard_ui"]
+toggleable        = true
+default_enabled   = true
 
 [public_repo]
 repo      = "nuonco/byoc"
@@ -19,6 +21,5 @@ install_id   = "{{ .nuon.install.id }}"
 org_id       = "{{ .nuon.org.id }}"
 org_name     = "{{ .nuon.org.name }}"
 
-datadog_enabled = "{{ .nuon.inputs.inputs.datadog_enabled }}"
 datadog_api_key = "{{ .nuon.inputs.inputs.datadog_api_key }}"
 datadog_app_key = "{{ .nuon.inputs.inputs.datadog_app_key }}"

--- a/byoc-nuon/components/datadog/variables.tf
+++ b/byoc-nuon/components/datadog/variables.tf
@@ -1,25 +1,8 @@
 locals {
-  name            = "datadog-agent"
-  namespace       = "datadog"
-  datadog_enabled = lower(var.datadog_enabled) == "true"
-  has_keys        = (var.datadog_api_key != "" && var.datadog_app_key != "")
-  enabled         = local.datadog_enabled && local.has_keys
-}
-
-variable "datadog_enabled" {
-  type        = string
-  description = "Enable or disable the Datadog component"
-  default     = "false"
-
-  validation {
-    condition     = !(lower(var.datadog_enabled) == "true" && var.datadog_api_key == "")
-    error_message = "datadog_enabled is true but datadog_api_key is not set."
-  }
-
-  validation {
-    condition     = !(lower(var.datadog_enabled) == "true" && var.datadog_app_key == "")
-    error_message = "datadog_enabled is true but datadog_app_key is not set."
-  }
+  name      = "datadog-agent"
+  namespace = "datadog"
+  has_keys  = (var.datadog_api_key != "" && var.datadog_app_key != "")
+  enabled   = local.has_keys
 }
 
 variable "datadog_api_key" {

--- a/byoc-nuon/inputs/datadog/datadog_enabled.toml
+++ b/byoc-nuon/inputs/datadog/datadog_enabled.toml
@@ -1,5 +1,0 @@
-name         = "datadog_enabled"
-description  = "Enable or disable the Datadog component"
-default      = "false"
-display_name = "Enable Datadog"
-group        = "datadog"


### PR DESCRIPTION
## What

Makes the `datadog` component in `byoc-nuon` a platform-**toggleable** component, enabled by default, and retires the now-redundant internal `datadog_enabled` input/variable.

```toml
# components/datadog/nuon.toml
toggleable      = true
default_enabled = true
```

## Why

`datadog` is the only component in this config that is both a **graph leaf** and **semantically optional** (pure observability).

Previously the on/off switch was a custom `datadog_enabled` **input** read inside the Terraform module (`enabled = datadog_enabled && has_keys`). That meant disabling DD still ran a no-op `terraform apply`. With the component toggleable, the platform **skips deploying it entirely** when disabled, and the enabled state now surfaces in the dashboard/CLI toggle UI alongside every other toggleable component.

Keeping both switches would be incoherent (two competing enable flags), so the redundant `datadog_enabled` input + Terraform variable are removed. The platform toggle is now the single source of truth for whether DD is deployed.

## Changes

- `components/datadog/nuon.toml` — add `toggleable = true` + `default_enabled = true`; drop the `datadog_enabled` var wiring.
- `components/datadog/variables.tf` — remove the `datadog_enabled` variable, local, and its two validations; `enabled` is now driven solely by `has_keys`.
- `inputs/datadog/datadog_enabled.toml` — deleted.

The `datadog_api_key` / `datadog_app_key` inputs and the `datadog` input group are unchanged.

## Behavior

- **`default_enabled = true`** — chosen deliberately so existing environments are **not** torn down on sync. The component stays enabled unless an install explicitly disables it.
- **Keyless no-op preserved:** if the component is enabled but no API/app keys are provided, `enabled = has_keys = false` → 0 helm releases. So envs that never set DD keys remain a no-op even though the component is now enabled by default — no new DD agent gets deployed and nothing breaks.
- To turn DD **off** for an install, set the component toggle to `false` (install config `[component_toggles]`, dashboard, or CLI).