### PR TITLE
feat: (byoc-nuon) enable CoreDNS query logging

### DIFF
--- a/byoc-nuon/sandbox.tfvars
+++ b/byoc-nuon/sandbox.tfvars
@@ -38,6 +38,31 @@ cluster_addons = {
           effect : "NoSchedule"
         },
       ]
+
+      # Full Corefile override. EKS-managed CoreDNS does not support the
+      # coredns-custom ConfigMap, so the entire Corefile must be supplied here.
+      # This mirrors the EKS default Corefile and adds the `log` plugin so DNS
+      # queries/failures are emitted to stdout and collected by the Datadog agent.
+      corefile = <<-EOT
+        .:53 {
+            log
+            errors
+            health {
+                lameduck 5s
+            }
+            ready
+            kubernetes cluster.local in-addr.arpa ip6.arpa {
+                pods insecure
+                fallthrough in-addr.arpa ip6.arpa
+            }
+            prometheus :9153
+            forward . /etc/resolv.conf
+            cache 30
+            loop
+            reload
+            loadbalance
+        }
+      EOT
     }
   }
   eks-pod-identity-agent = {}


### PR DESCRIPTION
## What

Enable CoreDNS query logging on BYOC EKS clusters by adding the CoreDNS `log` plugin to the EKS managed `coredns` add-on Corefile in `byoc-nuon/sandbox.tfvars`.

## Why

We needed to diagnose suspected CoreDNS resolution issues on a prod install but found **zero CoreDNS logs in Datadog over the last 7 days**. Root cause: the default EKS Corefile only has `errors` (+ startup banners) and no `log` plugin, so CoreDNS emits nothing for normal/failed queries. Datadog log collection itself is already on (`logs.enabled` + `containerCollectAll` in the datadog component) and tails other `kube-system` pods (e.g. kube-proxy), so once CoreDNS emits query logs they will flow to DD automatically — no app/datadog config change required.

## How

EKS-managed CoreDNS does not support the `coredns-custom` ConfigMap, so the full Corefile must be supplied via the add-on's `configuration_values.corefile`. The sandbox module (`nuonco/aws-eks-karpenter-sandbox@v1.7.0`) accepts `configuration_values` as a native HCL object and `jsonencode`s it internally. The override mirrors the EKS default Corefile (k8s 1.34) and only adds `log`; existing tolerations are preserved.

## Impact / rollout

- Applying triggers a CoreDNS add-on update → CoreDNS pod rollout. DNS stays available via the add-on PDB and `lameduck 5s`.
- `log` logs **every** DNS query — expect meaningful DD log volume/cost on busy clusters. Recommend treating this as a diagnostic and reverting once the SERVFAIL/timeout pattern is captured (or scoping `log` to failures only).


