### PR TITLE
Ja/aws teardown

### DIFF
--- a/byoc-nuon-gcp/README.md
+++ b/byoc-nuon-gcp/README.md
@@ -9,18 +9,20 @@
 <img class="mt-0 block dark:hidden" src="https://mintlify.s3-us-west-1.amazonaws.com/nuoninc/logo/light.svg" style="margin:0;padding:0;"/>
 <img class="mt-0 hidden dark:block" src="https://mintlify.s3-us-west-1.amazonaws.com/nuoninc/logo/dark.svg" style="margin:0;padding:0;"/>
 
-{{/* Setup runbooks (config label: type=setup). The README template can't read runbook labels at
-     render time, so list each type=setup runbook here with its completion check. Keep in sync as
-     setup runbooks are added/removed. */}}
+{{/* Feature & setup runbooks. The README template can't read runbook labels at render time, so
+     mirror them here: each type=feature runbook goes in $featureRunbooks (Features tab) and each
+     type=setup runbook in $setupRunbooks (Setup tab), with its completion check. Keep in sync as
+     these runbooks are added/removed. */}}
 {{ $slackDone := false }}{{ with index (default dict .nuon.actions.workflows) "sync_slack_secrets" }}{{ if eq .status "finished" }}{{ $slackDone = true }}{{ end }}{{ end }}
-{{ $setupRunbooks := list (dict "name" "slack_setup" "label" "Slack" "complete" $slackDone) }}
-{{ $incomplete := list }}{{ range $setupRunbooks }}{{ if not .complete }}{{ $incomplete = append $incomplete . }}{{ end }}{{ end }}
+{{ $loopsDone := false }}{{ with index (default dict .nuon.actions.workflows) "sync_loops_secret" }}{{ if eq .status "finished" }}{{ $loopsDone = true }}{{ end }}{{ end }}
+{{ $s3Done := false }}{{ with index (default dict .nuon.actions.workflows) "s3_bucket" }}{{ if eq .status "finished" }}{{ $s3Done = true }}{{ end }}{{ end }}
+{{ $dnsDone := false }}{{ if dig "dns_zone" "" (default dict (default dict .nuon.components.management).outputs) }}{{ $dnsDone = true }}{{ end }}
+{{ $featureRunbooks := list (dict "name" "slack_setup" "label" "Slack" "complete" $slackDone) }}
+{{ $setupRunbooks := list (dict "name" "dns_setup" "label" "DNS" "complete" $dnsDone) (dict "name" "s3_bucket" "label" "S3 Bucket" "complete" $s3Done) (dict "name" "loops_setup" "label" "Loops" "complete" $loopsDone) }}
+{{ $incomplete := list }}{{ range (concat $featureRunbooks $setupRunbooks) }}{{ if not .complete }}{{ $incomplete = append $incomplete . }}{{ end }}{{ end }}
 {{ if gt (len $incomplete) 0 }}
 <nuon-banner theme="warn">
-<strong>Some setup is still required.</strong> Once the install is provisioned, finish the setup runbook(s) below:
-<ul>
-{{ range $incomplete }}<li><a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/runbooks/{{ .name }}">{{ .label }}</a> <nuon-run-runbook name="{{ .name }}"></nuon-run-runbook></li>
-{{ end }}</ul>
+<strong>Some setup is still required.</strong> Once the install is provisioned, finish the runbook(s) in the Features and Setup tabs below.
 </nuon-banner>
 {{ end }}
 
@@ -469,6 +471,52 @@ ctl_api_sa_unique_id = "" # awaiting ctl_api_wi deployment
 <!-- prettier-ignore-end -->
 
 {{ end }}
+
+</nuon-tab>
+
+<nuon-tab name="Features">
+
+<div style="padding-top:1rem;"></div>
+
+### Feature runbooks
+
+Optional integrations you can enable for this install.
+
+<table>
+  <thead><tr><th>Runbook</th><th>Status</th><th>Run</th></tr></thead>
+  <tbody>
+  {{ range $featureRunbooks }}
+    <tr>
+      <td><a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/runbooks/{{ .name }}">{{ .label }}</a></td>
+      <td>{{ if .complete }}<nuon-status status="finished" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
+      <td><nuon-run-runbook name="{{ .name }}"></nuon-run-runbook></td>
+    </tr>
+  {{ end }}
+  </tbody>
+</table>
+
+</nuon-tab>
+
+<nuon-tab name="Setup">
+
+<div style="padding-top:1rem;"></div>
+
+### Setup runbooks
+
+Once the install is provisioned, finish the setup runbook(s) below.
+
+<table>
+  <thead><tr><th>Runbook</th><th>Status</th><th>Run</th></tr></thead>
+  <tbody>
+  {{ range $setupRunbooks }}
+    <tr>
+      <td><a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/runbooks/{{ .name }}">{{ .label }}</a></td>
+      <td>{{ if .complete }}<nuon-status status="finished" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
+      <td><nuon-run-runbook name="{{ .name }}"></nuon-run-runbook></td>
+    </tr>
+  {{ end }}
+  </tbody>
+</table>
 
 </nuon-tab>
 

--- a/byoc-nuon-gcp/README.md
+++ b/byoc-nuon-gcp/README.md
@@ -2,29 +2,27 @@
 {{ $root_domain := (dig "root_domain" "" $inputs) }}
 {{ $public_domain  := (dig "outputs" "nuon_dns" "public_domain"  "name" $root_domain .nuon.sandbox) }}
 
+{{/* Feature & setup runbooks. The README template can't read runbook labels at render time, so
+     mirror them here: each type=feature runbook goes in $featureRunbooks (Features tab) and each
+     type=setup runbook in $setupRunbooks (Setup tab), with its completion check. Keep in sync as
+     these runbooks are added/removed. */}} {{ $slackDone := false }}{{ with index (default dict .nuon.actions.workflows) "sync_slack_secrets" }}{{ if eq .status "finished" }}{{ $slackDone = true }}{{ end }}{{ end }}
+{{ $loopsDone := false }}{{ with index (default dict .nuon.actions.workflows) "sync_loops_secret" }}{{ if eq .status "finished" }}{{ $loopsDone = true }}{{ end }}{{ end }}
+{{ $s3Done := false }}{{ with index (default dict .nuon.actions.workflows) "s3_bucket" }}{{ if eq .status "finished" }}{{ $s3Done = true }}{{ end }}{{ end }}
+{{ $dnsDone := false }}{{ if dig "dns_zone" "" (default dict (default dict .nuon.components.management).outputs) }}{{ $dnsDone = true }}{{ end }}
+{{ $featureRunbooks := list (dict "name" "slack_setup" "label" "Slack" "complete" $slackDone "desc" "Set up the Slack integration: create the Slack app, provision and populate the central secret, set the install inputs, then sync the secrets into the ctl-api namespace and verify.") }}
+{{ $setupRunbooks := list (dict "name" "dns_setup" "label" "DNS" "complete" $dnsDone "desc" "Show the DNS delegation records (nameservers) to share with the customer so they can delegate their domain to this install.") (dict "name" "s3_bucket" "label" "S3 Bucket" "complete" $s3Done "desc" "Enable and inspect the AWS S3 install-templates bucket integration used for install templates.") (dict "name" "loops_setup" "label" "Loops" "complete" $loopsDone "desc" "Set up the Loops integration: provision and populate the central secret, set the loops_secret_arn input, then sync the API key into the ctl-api namespace.") }}
+{{ $incomplete := list }}{{ range (concat $featureRunbooks $setupRunbooks) }}{{ if not .complete }}{{ $incomplete = append $incomplete . }}{{ end }}{{ end }}
+{{ if gt (len $incomplete) 0 }}<nuon-banner theme="warn"> <strong>Setup is incomplete.</strong> Complete the runbooks in
+the Setup tab. </nuon-banner>
+
+<div style="padding-bottom:1.5rem;"></div>{{ end }}
+
 <div style="float:right;">
   <nuon-run-runbook name="refresh_readme"></nuon-run-runbook>
 </div>
 
 <img class="mt-0 block dark:hidden" src="https://mintlify.s3-us-west-1.amazonaws.com/nuoninc/logo/light.svg" style="margin:0;padding:0;"/>
 <img class="mt-0 hidden dark:block" src="https://mintlify.s3-us-west-1.amazonaws.com/nuoninc/logo/dark.svg" style="margin:0;padding:0;"/>
-
-{{/* Feature & setup runbooks. The README template can't read runbook labels at render time, so
-     mirror them here: each type=feature runbook goes in $featureRunbooks (Features tab) and each
-     type=setup runbook in $setupRunbooks (Setup tab), with its completion check. Keep in sync as
-     these runbooks are added/removed. */}}
-{{ $slackDone := false }}{{ with index (default dict .nuon.actions.workflows) "sync_slack_secrets" }}{{ if eq .status "finished" }}{{ $slackDone = true }}{{ end }}{{ end }}
-{{ $loopsDone := false }}{{ with index (default dict .nuon.actions.workflows) "sync_loops_secret" }}{{ if eq .status "finished" }}{{ $loopsDone = true }}{{ end }}{{ end }}
-{{ $s3Done := false }}{{ with index (default dict .nuon.actions.workflows) "s3_bucket" }}{{ if eq .status "finished" }}{{ $s3Done = true }}{{ end }}{{ end }}
-{{ $dnsDone := false }}{{ if dig "dns_zone" "" (default dict (default dict .nuon.components.management).outputs) }}{{ $dnsDone = true }}{{ end }}
-{{ $featureRunbooks := list (dict "name" "slack_setup" "label" "Slack" "complete" $slackDone) }}
-{{ $setupRunbooks := list (dict "name" "dns_setup" "label" "DNS" "complete" $dnsDone) (dict "name" "s3_bucket" "label" "S3 Bucket" "complete" $s3Done) (dict "name" "loops_setup" "label" "Loops" "complete" $loopsDone) }}
-{{ $incomplete := list }}{{ range (concat $featureRunbooks $setupRunbooks) }}{{ if not .complete }}{{ $incomplete = append $incomplete . }}{{ end }}{{ end }}
-{{ if gt (len $incomplete) 0 }}
-<nuon-banner theme="warn">
-<strong>Some setup is still required.</strong> Once the install is provisioned, finish the runbook(s) in the Features and Setup tabs below.
-</nuon-banner>
-{{ end }}
 
 <nuon-tabs>
 <nuon-tab name="Application">
@@ -297,7 +295,7 @@
 </div>
 
 </nuon-tab>
-<nuon-tab name="Services">
+<nuon-tab name="System">
 
 {{ $api  := dict }}{{ $apiActionID  := "" }}{{ with index .nuon.actions.workflows "api_status"       }}{{ with .outputs }}{{ $api  = . }}{{ end }}{{ $apiActionID  = dig "id" "" . }}{{ end }}
 {{ $dash := dict }}{{ $dashActionID := "" }}{{ with index .nuon.actions.workflows "dashboard_status" }}{{ with .outputs }}{{ $dash = . }}{{ end }}{{ $dashActionID = dig "id" "" . }}{{ end }}
@@ -339,9 +337,6 @@ section.</nuon-banner>{{ end }}
 
   </div>
 </div>
-
-</nuon-tab>
-<nuon-tab name="Infrastructure">
 
 <div style="padding-top:1rem;"></div>
 
@@ -385,111 +380,22 @@ section.</nuon-banner>{{ end }}
 
 </nuon-tab>
 
-<nuon-tab name="DNS">
-
-#### Current DNS Configurations
-
-When an install is created, a Route53 zone will be created for each of the domains. When these are ready, you can use
-those details to configure your domain in your registrar to use the AWS nameservers.
-
-{{ if (and .nuon.sandbox.populated .nuon.sandbox.outputs) }}
-
-##### Root Domain
-
-| Attribute   | Value                                                                                          |
-| ----------- | ---------------------------------------------------------------------------------------------- |
-| Domain Name | {{ $public_domain }}                                                                           |
-| Zone ID     | {{ dig "outputs" "nuon_dns" "public_domain" "zone_id" "Z00XXXXXXXXXXXXXXXXXX" .nuon.sandbox }} |
-
-<!-- prettier-ignore-start -->
-| Value     | Record Type | priority |
-| --------- | ----------- | -------- |
-{{ range $i, $ns := dig "nuon_dns" "public_domain" "nameservers" (list) (default dict .nuon.sandbox.outputs) }}| {{ $ns }} | NS          | {{$i}}   |
-{{ end }}
-<!-- prettier-ignore-end -->
-
-{{ else }}
-
-> [!WARNING] Waiting on Sandbox Provision. Once the Sandbox is ready, results will be visible here.
-
-{{ end }}
-
-{{ $dnsZone := dig "dns_zone" dict (default dict (default dict .nuon.components.management).outputs) }}
-{{ if $dnsZone }}
-
-##### Nuon DNS Delegation Domain
-
-| Attribute   | Value                                       |
-| ----------- | ------------------------------------------- |
-| Domain Name | {{ dig "domain" "" $dnsZone }}  |
-| Zone ID     | {{ dig "zone_id" "" $dnsZone }} |
-
-<!-- prettier-ignore-start -->
-| Value     | Record Type | priority |
-| --------- | ----------- | -------- |
-{{ range $i, $ns := dig "nameservers" (list) $dnsZone }}| {{ $ns }} | NS          | {{$i}}   |
-{{ end }}
-<!-- prettier-ignore-end -->
-
-{{ else }}
-
-<!-- prettier-ignore-start -->
-> [!WARNING]
-> Waiting on Sandbox Provision. Once the Sandbox is ready, results will be visible here.
-<!-- prettier-ignore-end -->
-
-{{ end }}
-
-Additional Documentation
-
-- [Creating a subdomain that uses Amazon Route 53 as the DNS service without migrating the parent domain](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingNewSubdomain.html)
-
-</nuon-tab>
-
-<nuon-tab name="S3 Bucket">
-
-# AWS S3 Bucket
-
-The AWS S3 Bucket can be created using the following values in the tfvars.
-
-```hcl
-install_id           = "{{ .nuon.install.id }}"
-region               = "{{ dig "install_stack_template_bucket_region" "" $inputs }}"
-{{ $ctlApiSaUniqueID := dig "service_account_unique_id" "" (default dict .nuon.components.ctl_api_wi.outputs) }}
-{{ if $ctlApiSaUniqueID }}
-ctl_api_sa_unique_id = "{{ $ctlApiSaUniqueID }}"
-{{ else }}
-ctl_api_sa_unique_id = "" # awaiting ctl_api_wi deployment
-{{ end }}
-```
-
-{{ if not $ctlApiSaUniqueID }}
-
-<!-- prettier-ignore-start -->
-> [!WARNING]
-> The `ctl_api_wi` component has not been applied yet.
-<!-- prettier-ignore-end -->
-
-{{ end }}
-
-</nuon-tab>
-
 <nuon-tab name="Features">
 
 <div style="padding-top:1rem;"></div>
 
-### Feature runbooks
+### Features
 
-Optional integrations you can enable for this install.
+Optional features that can be enabled for this install.
 
 <table>
-  <thead><tr><th>Runbook</th><th>Status</th><th>Run</th></tr></thead>
+  <thead><tr><th>Status</th><th>Runbook</th><th>Description</th></tr></thead>
   <tbody>
   {{ range $featureRunbooks }}
     <tr>
-      <td><a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/runbooks/{{ .name }}">{{ .label }}</a></td>
       <td>{{ if .complete }}<nuon-status status="finished" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
-      <td><nuon-run-runbook name="{{ .name }}"></nuon-run-runbook></td>
+      <td><a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/runbooks/{{ .name }}">{{ .label }}</a></td>
+      <td>{{ .desc }}</td>
     </tr>
   {{ end }}
   </tbody>
@@ -501,18 +407,18 @@ Optional integrations you can enable for this install.
 
 <div style="padding-top:1rem;"></div>
 
-### Setup runbooks
+### Setup
 
-Once the install is provisioned, finish the setup runbook(s) below.
+Tasks required to make this install of Nuon BYOC on GCP fully operational.
 
 <table>
-  <thead><tr><th>Runbook</th><th>Status</th><th>Run</th></tr></thead>
+  <thead><tr><th>Status</th><th>Runbook</th><th>Description</th></tr></thead>
   <tbody>
   {{ range $setupRunbooks }}
     <tr>
-      <td><a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/runbooks/{{ .name }}">{{ .label }}</a></td>
       <td>{{ if .complete }}<nuon-status status="finished" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
-      <td><nuon-run-runbook name="{{ .name }}"></nuon-run-runbook></td>
+      <td><a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/runbooks/{{ .name }}">{{ .label }}</a></td>
+      <td>{{ .desc }}</td>
     </tr>
   {{ end }}
   </tbody>

--- a/byoc-nuon-gcp/actions/aws/s3_bucket/inspect.sh
+++ b/byoc-nuon-gcp/actions/aws/s3_bucket/inspect.sh
@@ -3,29 +3,38 @@
 # s3_bucket / inspect (GCP)
 #
 # Inspects the AWS S3 install-stack template bucket
-# (install_stack_template_bucket) — the bucket the ctl-api uses to hold the
-# CloudFormation install-stack templates for the AWS installs this control
-# plane manages. Prints the bucket name, region, a little metadata (versioning
-# + default encryption), and lists up to 5 objects.
+# (install_stack_template_bucket) — the bucket ctl-api uploads CloudFormation
+# install-stack templates to for the AWS installs this GCP control plane
+# manages. Prints the bucket name, region, a little metadata (versioning +
+# default encryption), and lists up to 5 objects.
 #
-# A GCP install has no AWS identity, so — exactly like the sync_slack_secrets
-# action — it federates: the runner mints a Google-signed OIDC token for its
-# GCP identity (via the metadata server) and exchanges it for temporary AWS
-# credentials via sts:AssumeRoleWithWebIdentity against the bucket's role
-# (install_stack_template_bucket_role_arn). That role must grant
-# s3:GetBucket*/s3:ListBucket on the bucket for this action to succeed;
-# otherwise the AWS calls fail with AccessDenied.
-# See docs/aws-gcp-identity-federation.md.
+# IDENTITY: a GCP install has no AWS identity, so it federates — mint a
+# Google-signed OIDC token, exchange it via sts:AssumeRoleWithWebIdentity for
+# temporary AWS credentials against install_stack_template_bucket_role_arn.
+# That role's trust policy is scoped to the *ctl-api* service account's
+# unique_id (from ctl_api_wi) — because in production it's ctl-api, not the
+# runner, that uploads templates. This action runs on the runner, whose own
+# identity (runner_service_account_email) is NOT trusted by the role.
+#
+# So we IMPERSONATE ctl-api: the runner SA is granted token-creator on the
+# ctl-api SA (ctl_api_wi.runner_impersonate_ctl_api), and we ask the IAM
+# Credentials API to mint an OIDC ID token AS ctl-api (sub = ctl-api's
+# unique_id). That token matches the role's trust policy, so the assume-role
+# succeeds — verifying the exact federation path ctl-api uses in production.
+#
+# The role must grant s3:GetBucket*/s3:ListBucket on the bucket; otherwise the
+# AWS calls fail with AccessDenied.
 #
 # Required env:
-#   BUCKET         - the S3 bucket name. Empty => skip (no-op).
-#   ROLE_ARN       - AWS IAM role to assume via web identity
-#                    (install_stack_template_bucket_role_arn). Empty => error.
-#   AUDIENCE       - OIDC audience the role's trust policy expects (sts.amazonaws.com).
-#   INSTALL_ID     - used for the STS role session name.
+#   BUCKET            - the S3 bucket name. Empty => skip (no-op).
+#   ROLE_ARN          - install_stack_template_bucket_role_arn. Empty => error.
+#   CTL_API_SA_EMAIL  - ctl-api service account email (ctl_api_wi output) to
+#                       impersonate. Empty => error.
+#   AUDIENCE          - OIDC audience the role's trust policy expects (sts.amazonaws.com).
+#   INSTALL_ID        - used for the STS role session name.
 # Optional env:
-#   BUCKET_REGION  - the bucket's region (from install_stack_template_bucket_region).
-#                    Used for the initial API region; falls back to us-east-1.
+#   BUCKET_REGION     - the bucket's region (install_stack_template_bucket_region).
+#                       Used for the initial API region; falls back to us-east-1.
 set -euo pipefail
 set -o errtrace
 
@@ -41,21 +50,34 @@ if [[ -z "${ROLE_ARN:-}" ]]; then
   exit 1
 fi
 
+if [[ -z "${CTL_API_SA_EMAIL:-}" ]]; then
+  echo "CTL_API_SA_EMAIL is empty; cannot impersonate ctl-api to mint a trusted token. Deploy ctl_api_wi first." >&2
+  exit 1
+fi
+
 # Region used for the initial STS/S3 calls. S3 is global for naming but the API
 # wants a region; the bucket's real region is reported below via get-bucket-location.
 region="${BUCKET_REGION:-us-east-1}"
 [[ -z "$region" ]] && region="us-east-1"
 
-# 1. Mint a Google-signed OIDC identity token for this runner's GCP identity.
-echo "minting GCP identity token (audience: $AUDIENCE)"
-WEB_IDENTITY_TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
-  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${AUDIENCE}&format=full")
+# ── 1. mint a Google OIDC token AS ctl-api (impersonation) ────────────────────
+# The runner SA calls IAM Credentials generateIdToken on the ctl-api SA; the
+# resulting token's sub is ctl-api's unique_id — what the role trusts.
+echo "minting OIDC token as ctl-api SA via impersonation (audience: $AUDIENCE)"
+echo "  ctl-api SA: $CTL_API_SA_EMAIL"
+WEB_IDENTITY_TOKEN=$(gcloud auth print-identity-token \
+  --impersonate-service-account="$CTL_API_SA_EMAIL" \
+  --audiences="$AUDIENCE" \
+  --include-email 2>/dev/null || true)
+
 if [[ -z "$WEB_IDENTITY_TOKEN" ]]; then
-  echo "failed to mint GCP identity token from the metadata server" >&2
+  echo "ERROR: failed to mint an identity token as ctl-api." >&2
+  echo "Check that ctl_api_wi has been deployed (it grants the runner SA" >&2
+  echo "roles/iam.serviceAccountTokenCreator on $CTL_API_SA_EMAIL)." >&2
   exit 1
 fi
 
-# 2. Exchange it for temporary AWS credentials (no pre-existing AWS creds needed).
+# ── 2. exchange the ctl-api token for temporary AWS credentials ───────────────
 echo "assuming AWS role via web identity"
 echo "  role:   $ROLE_ARN"
 echo "  region: $region"

--- a/byoc-nuon-gcp/actions/aws/s3_bucket/s3_bucket.toml
+++ b/byoc-nuon-gcp/actions/aws/s3_bucket/s3_bucket.toml
@@ -8,7 +8,7 @@
 name    = "s3_bucket"
 labels  = { service = "s3", type = "debug" }
 label   = "aws"
-timeout = "2m"
+timeout = "3m"
 
 [[triggers]]
 type = "manual"
@@ -18,8 +18,9 @@ name            = "inspect"
 inline_contents = "./aws/s3_bucket/inspect.sh"
 
 [steps.env_vars]
-BUCKET        = "{{ or .nuon.inputs.inputs.install_stack_template_bucket \"\" }}"
-BUCKET_REGION = "{{ or .nuon.inputs.inputs.install_stack_template_bucket_region \"\" }}"
-ROLE_ARN      = "{{ or .nuon.inputs.inputs.install_stack_template_bucket_role_arn \"\" }}"
-AUDIENCE      = "sts.amazonaws.com"
-INSTALL_ID    = "{{ .nuon.install.id }}"
+BUCKET           = "{{ or .nuon.inputs.inputs.install_stack_template_bucket \"\" }}"
+BUCKET_REGION    = "{{ or .nuon.inputs.inputs.install_stack_template_bucket_region \"\" }}"
+ROLE_ARN         = "{{ or .nuon.inputs.inputs.install_stack_template_bucket_role_arn \"\" }}"
+CTL_API_SA_EMAIL = "{{ .nuon.components.ctl_api_wi.outputs.service_account_email }}"
+AUDIENCE         = "sts.amazonaws.com"
+INSTALL_ID       = "{{ .nuon.install.id }}"

--- a/byoc-nuon-gcp/actions/ctl_api/api_status/version.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/api_status/version.sh
@@ -6,7 +6,33 @@ set -e
 set -o pipefail
 set -u
 
-resp=$(curl -sS --max-time 10 "${API_URL}/version" || echo '{}')
+# Fetch /version, retrying until it returns a valid JSON body. This step also
+# runs post-deploy (right after ctl-api deploys), so the API is often not serving
+# JSON yet: curl may return a 2xx with an HTML gateway/error page, or an empty
+# body on a closed connection — both exit 0, so a bare `|| echo '{}'` does NOT
+# catch them and `jq --argjson` then aborts with "invalid JSON text". Poll until
+# the body parses as JSON, falling back to {} (→ "unknown") if it never does.
+fetch_version() {
+  attempts="${ATTEMPTS:-6}"
+  i=1
+  while true; do
+    body=$(curl -sS --max-time 10 "${API_URL}/version" || true)
+    if printf '%s' "$body" | jq -e . >/dev/null 2>&1; then
+      printf '%s' "$body"
+      return 0
+    fi
+    if [ "$i" -ge "$attempts" ]; then
+      echo "ctl-api /version did not return valid JSON after ${attempts} attempts; emitting unknown." >&2
+      echo '{}'
+      return 0
+    fi
+    echo "ctl-api /version not ready (attempt ${i}/${attempts}), retrying in 10s..." >&2
+    i=$((i + 1))
+    sleep 10
+  done
+}
+
+resp=$(fetch_version)
 
 jq -cn --argjson r "$resp" '{
   ctl_api_version: ($r.version // "unknown"),

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_init_db/ctl_api_init_db.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_init_db/ctl_api_init_db.toml
@@ -1,7 +1,7 @@
 # action
 name    = "ctl_api_init_db"
 labels  = { service = "ctl-api", type = "step" }
-timeout = "5m"
+timeout = "10m"
 
 [[triggers]]
 type           = "pre-deploy-component"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_init_db/init-db.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_init_db/init-db.sh
@@ -9,6 +9,34 @@ db_user="$DB_USER"
 db_addr="$DB_ADDR"
 db_port="$DB_PORT"
 
+# Wait for the GKE API server to be reachable before doing anything else. This
+# is a pre-deploy-component hook, so it's often the first kubectl call against a
+# freshly-provisioned cluster — the control-plane endpoint and its networking
+# can lag a few seconds behind the cluster reporting ready, so the first kubectl
+# call may i/o-timeout even though the cluster is healthy. Poll a lightweight
+# endpoint until it answers instead.
+wait_for_apiserver() {
+  attempts=24
+  i=1
+  while true; do
+    if kubectl get --raw='/healthz' --request-timeout=10s >/dev/null 2>&1; then
+      echo "[ctl_api init] API server reachable (attempt ${i})."
+      return 0
+    fi
+    if [ "$i" -ge "$attempts" ]; then
+      echo "[ctl_api init] ERROR: API server not reachable after ${attempts} attempts (~4m)." >&2
+      kubectl get --raw='/healthz' --request-timeout=10s || true # surface the real error
+      return 1
+    fi
+    echo "[ctl_api init] API server not reachable yet (attempt ${i}/${attempts}), retrying in 10s..."
+    i=$((i + 1))
+    sleep 10
+  done
+}
+
+echo "[ctl_api init] waiting for the API server"
+wait_for_apiserver
+
 # TODO: make the cluster's default/admin db and the ctl-api db distinct
 
 echo "[ctl_api init] kubectl auth whoami"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_init_db/init-db.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_init_db/init-db.sh
@@ -34,6 +34,39 @@ wait_for_apiserver() {
   done
 }
 
+# Run a kubectl command, retrying ONLY on transient GKE control-plane
+# connectivity errors. Even after wait_for_apiserver passes, the public API
+# endpoint can drop a connection mid-deploy (endpoint warm-up, brief LB/SNAT
+# reconvergence), so any single kubectl call can i/o-timeout. Real errors (auth
+# failures, psql errors, missing resources) don't match the connectivity
+# patterns, so they fail fast on the first attempt and are never masked.
+kubectl_retry() {
+  attempts=5
+  i=1
+  while true; do
+    out=$(kubectl "$@" 2>&1) && { printf '%s\n' "$out"; return 0; }
+    status=$?
+    case "$out" in
+      *"Unable to connect to the server"* | *"i/o timeout"* | *"dial tcp"* | \
+      *"TLS handshake timeout"* | *"connection refused"* | *"unexpected EOF"* | \
+      *"http2: client connection lost"* | *"EOF"*)
+        if [ "$i" -ge "$attempts" ]; then
+          printf '%s\n' "$out" >&2
+          echo "[ctl_api init] ERROR: 'kubectl $*' failed after ${attempts} attempts (transient API-server connectivity)." >&2
+          return "$status"
+        fi
+        echo "[ctl_api init] transient API-server error on 'kubectl $*' (attempt ${i}/${attempts}), retrying in 5s..." >&2
+        i=$((i + 1))
+        sleep 5
+        ;;
+      *)
+        printf '%s\n' "$out" >&2
+        return "$status"
+        ;;
+    esac
+  done
+}
+
 echo "[ctl_api init] waiting for the API server"
 wait_for_apiserver
 
@@ -41,18 +74,18 @@ wait_for_apiserver
 
 echo "[ctl_api init] kubectl auth whoami"
 echo "pwd: "`pwd`
-kubectl auth whoami -o json | jq -c
+kubectl_retry auth whoami -o json | jq -c
 
 echo "[ctl_api init] scale up the deployment"
-kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
-kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
+kubectl_retry scale -n ctl-api --replicas=1 deployment/ctl-api-init
+kubectl_retry wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
 
 echo "[ctl_api init] get a pod from the deployment"
-pod=`kubectl -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name'`
+pod=`kubectl_retry -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name'`
 
 echo "[ctl_api init] reading db access secrets from k8s"
-admin_username=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
-admin_password=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
+admin_username=$(kubectl_retry get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
+admin_password=$(kubectl_retry get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
 
 echo "[ctl_api init] sanity check"
 echo "these two should match"
@@ -62,7 +95,7 @@ echo "username=$admin_username"
 echo "[ctl_api init] preparing to initialize"
 function run_cmd() {
   echo " > cmd: $@"
-  kubectl \
+  kubectl_retry \
     --namespace=ctl-api \
     exec  -i \
     $pod -- \
@@ -97,7 +130,7 @@ echo "[ctl_api init] hstore"
 run_cmd "ctl_api" "/var/init-config/create_hstore.sql"
 
 echo "[ctl_api init] validate"
-kubectl \
+kubectl_retry \
   --namespace=ctl-api \
   exec  -i \
   $pod -- \
@@ -105,4 +138,4 @@ kubectl \
   psql --no-psqlrc -d "ctl_api" -c "\du"
 
 echo "[ctl_api init] scale down the deployment"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
+kubectl_retry scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/ctl_api_post_deploy.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/ctl_api_post_deploy.toml
@@ -19,27 +19,6 @@ inline_contents = "https://raw.githubusercontent.com/nuonco/actions/refs/heads/m
 NAMESPACE = "ctl-api"
 
 [[steps]]
-name            = "runners-update-version"
-inline_contents = "./ctl_api/ctl_api_post_deploy/update-version.sh"
-
-[steps.env_vars]
-ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
-
-[[steps]]
-name            = "promote-callback"
-inline_contents = "./ctl_api/ctl_api_post_deploy/promote.sh"
-
-[steps.env_vars]
-ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
-
-[[steps]]
-name            = "get-migrations-callback"
-inline_contents = "./ctl_api/ctl_api_post_deploy/get-migrations.sh"
-
-[steps.env_vars]
-ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
-
-[[steps]]
 name            = "public-route-healthcheck"
 inline_contents = "./ctl_api/ctl_api_post_deploy/healthcheck.sh"
 
@@ -62,3 +41,24 @@ inline_contents = "./ctl_api/ctl_api_post_deploy/healthcheck.sh"
 [steps.env_vars]
 ROUTE_NAME      = "ctl-api-admin"
 ROUTE_NAMESPACE = "ctl-api"
+
+[[steps]]
+name            = "runners-update-version"
+inline_contents = "./ctl_api/ctl_api_post_deploy/update-version.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+
+[[steps]]
+name            = "promote-callback"
+inline_contents = "./ctl_api/ctl_api_post_deploy/promote.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+
+[[steps]]
+name            = "get-migrations-callback"
+inline_contents = "./ctl_api/ctl_api_post_deploy/get-migrations.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/get-migrations.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy/get-migrations.sh
@@ -6,12 +6,43 @@ set -u
 
 admin_api_addr="$ADMIN_API_URL"
 
+# Fetch the migrations list from the admin API, retrying until it returns a valid
+# JSON array. This step runs right after restart-deployments has rolled every
+# ctl-api deployment (including ctl-api-admin), so on a fresh provision the admin
+# API is often not back up yet — curl returns an empty/early body, and because
+# the original `migrations=$(curl ... | jq -c)` is a command-substitution
+# assignment, `set -e` does NOT catch the failure: `migrations` ends up empty and
+# the later `jq --argjson` fails with "invalid JSON text passed to --argjson".
+# Poll until the endpoint actually returns a JSON array instead.
+fetch_migrations() {
+  attempts=30
+  i=1
+  while true; do
+    body=$(curl -s --max-time 10 "$admin_api_addr/v1/general/migrations" || true)
+    if printf '%s' "$body" | jq -e 'type == "array"' >/dev/null 2>&1; then
+      printf '%s' "$body" | jq -c
+      return 0
+    fi
+    if [ "$i" -ge "$attempts" ]; then
+      echo "ERROR: admin API did not return a valid migrations array after ${attempts} attempts (~5m)." >&2
+      echo "last response: ${body:-<empty>}" >&2
+      return 1
+    fi
+    echo "admin migrations endpoint not ready (attempt ${i}/${attempts}), retrying in 10s..." >&2
+    i=$((i + 1))
+    sleep 10
+  done
+}
+
 echo "get ctl-api migrations data"
-migrations=`curl -s  "$admin_api_addr/v1/general/migrations" | jq -c`
+migrations=$(fetch_migrations)
 
 echo "format migrations data"
-echo $migrations | jq -r '.[] | "\(.created_at) \(.status) \(.name)"'
-outputs=`jq --null-input --argjson migrationsVar "$migrations" '{"migrations": $migrationsVar}'`
+echo "$migrations" | jq -r '.[] | "\(.created_at) \(.status) \(.name)"'
+# -c: the outputs file is parsed one JSON object PER LINE, so this must be a
+# single compact line. Without -c, jq pretty-prints multi-line and the runner
+# fails parsing the first fragment ("unexpected end of JSON input").
+outputs=$(jq -c --null-input --argjson migrationsVar "$migrations" '{"migrations": $migrationsVar}')
 
 echo "save migrations data to outputs"
-echo $outputs >> $NUON_ACTIONS_OUTPUT_FILEPATH
+echo "$outputs" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_db/ctl_api_query_db.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_db/ctl_api_query_db.toml
@@ -11,7 +11,8 @@ name            = "Query the DB"
 inline_contents = "./ctl_api/ctl_api_query_db/query-db.sh"
 
 [steps.env_vars]
-DB_USER = "{{ .nuon.components.cloudsql_nuon.outputs.db_instance_username }}"
+DB_USER          = "{{ .nuon.components.ctl_api_wi.outputs.db_user }}"
+CTL_API_SA_EMAIL = "{{ .nuon.components.ctl_api_wi.outputs.service_account_email }}"
 DB_NAME = "ctl_api"
 DB_ADDR = "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
 DB_PORT = "5432"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_db/query-db.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_db/query-db.sh
@@ -24,14 +24,19 @@ kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True -
 echo "[ctl_api query] get a pod from the deployment"
 pod=`kubectl -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name'`
 
-echo "[ctl_api query] reading db access secrets from k8s"
-admin_username=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
-admin_password=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
-
-echo "[ctl_api query] sanity check"
-echo "these two should match"
-echo "db_user=$db_user"
-echo "username=$admin_username"
+# Query as the ctl-api IAM role (the table owner) via Cloud SQL IAM auth. The
+# nuon-db admin user is NOT the owner and gets "permission denied". Impersonate
+# the ctl-api SA on the runner (ctl_api_wi grants the runner token-creator on it)
+# to mint a sqlservice.login-scoped token, used as the DB password over SSL.
+: "${CTL_API_SA_EMAIL:?CTL_API_SA_EMAIL is required (ctl_api_wi.service_account_email)}"
+echo "[ctl_api query] minting a Cloud SQL login token as ${CTL_API_SA_EMAIL}"
+db_token=$(gcloud auth print-access-token \
+  --impersonate-service-account="$CTL_API_SA_EMAIL" \
+  --scopes=https://www.googleapis.com/auth/sqlservice.login)
+if [[ -z "$db_token" ]]; then
+  echo "[ctl_api query] ERROR: failed to mint a login token as $CTL_API_SA_EMAIL." >&2
+  exit 1
+fi
 
 echo "[ctl_api query] preparing to initialize"
 function execute_query() {
@@ -40,7 +45,7 @@ function execute_query() {
     --namespace=ctl-api \
     exec  -i \
     $pod -- \
-    env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$admin_username" "PGPASSWORD=$admin_password" \
+    env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$db_user" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
     psql --no-psqlrc -d "ctl_api" -c "SET default_transaction_read_only = on; $1"
 }
 # sleep so logs have time to flush?

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_phone_home/ctl_api_query_phone_home.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_phone_home/ctl_api_query_phone_home.toml
@@ -11,7 +11,8 @@ name            = "Query phone home requests"
 inline_contents = "./ctl_api/ctl_api_query_phone_home/query-phone-home.sh"
 
 [steps.env_vars]
-DB_USER    = "{{ .nuon.components.cloudsql_nuon.outputs.db_instance_username }}"
+DB_USER          = "{{ .nuon.components.ctl_api_wi.outputs.db_user }}"
+CTL_API_SA_EMAIL = "{{ .nuon.components.ctl_api_wi.outputs.service_account_email }}"
 DB_NAME    = "ctl_api"
 DB_ADDR    = "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
 DB_PORT    = "5432"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_phone_home/query-phone-home.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_phone_home/query-phone-home.sh
@@ -27,9 +27,19 @@ kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True -
 pod=$(kubectl -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name')
 echo "[query phone-home] using pod: $pod"
 
-echo "[query phone-home] loading db credentials from k8s"
-admin_username=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
-admin_password=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
+# Query as the ctl-api IAM role (the table owner) via Cloud SQL IAM auth. The
+# nuon-db admin user is NOT the owner and gets "permission denied". Impersonate
+# the ctl-api SA on the runner (ctl_api_wi grants the runner token-creator on it)
+# to mint a sqlservice.login-scoped token, used as the DB password over SSL.
+: "${CTL_API_SA_EMAIL:?CTL_API_SA_EMAIL is required (ctl_api_wi.service_account_email)}"
+echo "[query phone-home] minting a Cloud SQL login token as ${CTL_API_SA_EMAIL}"
+db_token=$(gcloud auth print-access-token \
+  --impersonate-service-account="$CTL_API_SA_EMAIL" \
+  --scopes=https://www.googleapis.com/auth/sqlservice.login)
+if [[ -z "$db_token" ]]; then
+  echo "[query phone-home] ERROR: failed to mint a login token as $CTL_API_SA_EMAIL." >&2
+  exit 1
+fi
 
 sql="
 SET default_transaction_read_only = on;
@@ -63,7 +73,7 @@ SELECT json_build_object(
 
 echo "[query phone-home] running query"
 output=$(kubectl --namespace=ctl-api exec -i "$pod" -- \
-  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$admin_username" "PGPASSWORD=$admin_password" \
+  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$db_user" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -A -t -c "$sql" | tr -d '\r' | grep -v '^$' | tail -n 1)
 
 echo "[query phone-home] scale down ctl-api-init"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflow_steps/ctl_api_query_workflow_steps.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflow_steps/ctl_api_query_workflow_steps.toml
@@ -11,7 +11,8 @@ name            = "Query workflow steps"
 inline_contents = "./ctl_api/ctl_api_query_workflow_steps/query-workflow-steps.sh"
 
 [steps.env_vars]
-DB_USER = "{{ .nuon.components.cloudsql_nuon.outputs.db_instance_username }}"
+DB_USER          = "{{ .nuon.components.ctl_api_wi.outputs.db_user }}"
+CTL_API_SA_EMAIL = "{{ .nuon.components.ctl_api_wi.outputs.service_account_email }}"
 DB_NAME = "ctl_api"
 DB_ADDR = "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
 DB_PORT = "5432"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflow_steps/query-workflow-steps.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflow_steps/query-workflow-steps.sh
@@ -48,13 +48,19 @@ if [[ -z "$pod" || "$pod" == "null" ]]; then
 fi
 echo "[query workflow steps] using pod: $pod"
 
-echo "[query workflow steps] reading db access secrets from k8s"
-admin_username=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
-admin_password=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
-
-echo "[query workflow steps] sanity check"
-echo "db_user=$db_user"
-echo "username=$admin_username"
+# Query as the ctl-api IAM role (the table owner) via Cloud SQL IAM auth. The
+# nuon-db admin user is NOT the owner and gets "permission denied". Impersonate
+# the ctl-api SA on the runner (ctl_api_wi grants the runner token-creator on it)
+# to mint a sqlservice.login-scoped token, used as the DB password over SSL.
+: "${CTL_API_SA_EMAIL:?CTL_API_SA_EMAIL is required (ctl_api_wi.service_account_email)}"
+echo "[query workflow steps] minting a Cloud SQL login token as ${CTL_API_SA_EMAIL}"
+db_token=$(gcloud auth print-access-token \
+  --impersonate-service-account="$CTL_API_SA_EMAIL" \
+  --scopes=https://www.googleapis.com/auth/sqlservice.login)
+if [[ -z "$db_token" ]]; then
+  echo "[query workflow steps] ERROR: failed to mint a login token as $CTL_API_SA_EMAIL." >&2
+  exit 1
+fi
 
 read -r -d '' sql <<SQL || true
 SET default_transaction_read_only = on;
@@ -195,7 +201,7 @@ SQL
 
 echo "[query workflow steps] running query (limit=$limit workflow_id=${workflow_id:-<all>})"
 rows_json=$(kubectl --namespace=ctl-api exec -i "$pod" -- \
-  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$admin_username" "PGPASSWORD=$admin_password" \
+  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$db_user" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -A -t -q -c "$sql" \
   | tr -d '\r' | { grep -E '^\[' || true; } | tail -n 1)
 

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflows_by_type/ctl_api_query_workflows_by_type.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflows_by_type/ctl_api_query_workflows_by_type.toml
@@ -16,11 +16,17 @@ name            = "Query workflows grouped by type"
 inline_contents = "./ctl_api/ctl_api_query_workflows_by_type/query-workflows-by-type.sh"
 
 [steps.env_vars]
-DB_USER = "{{ .nuon.components.cloudsql_nuon.outputs.db_instance_username }}"
-DB_NAME = "ctl_api"
-DB_ADDR = "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
-DB_PORT = "5432"
-LIMIT   = "25"
+# The install_workflows table (and the other ctl-api tables) are owned by the
+# ctl-api IAM database role, so we must query as that role — the Cloud SQL admin
+# user (nuon-db) gets "permission denied". DB_USER is the IAM DB user;
+# CTL_API_SA_EMAIL is the SA the runner impersonates to mint a Cloud SQL login
+# token (Cloud SQL IAM auth).
+DB_USER          = "{{ .nuon.components.ctl_api_wi.outputs.db_user }}"
+CTL_API_SA_EMAIL = "{{ .nuon.components.ctl_api_wi.outputs.service_account_email }}"
+DB_NAME          = "ctl_api"
+DB_ADDR          = "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
+DB_PORT          = "5432"
+LIMIT            = "25"
 
 [[steps]]
 name            = "timestamp"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflows_by_type/query-workflows-by-type.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflows_by_type/query-workflows-by-type.sh
@@ -4,7 +4,16 @@
 # (across all types), joined with `accounts` so we can see which user ran
 # each workflow.
 #
+# The ctl-api tables (install_workflows, etc.) are owned by the ctl-api IAM
+# database role, so we query as that role via Cloud SQL IAM auth. The Cloud SQL
+# admin user (nuon-db) is NOT the table owner and gets "permission denied for
+# table install_workflows". We authenticate as ctl-api by impersonating its SA
+# on the runner (roles/iam.serviceAccountTokenCreator, granted by ctl_api_wi) to
+# mint a sqlservice.login-scoped token, used as the DB password over SSL.
+#
 # Env vars:
+#   DB_USER          (required)  the IAM database user (ctl_api_wi.db_user)
+#   CTL_API_SA_EMAIL (required)  ctl-api SA to impersonate (ctl_api_wi.service_account_email)
 #   LIMIT       (optional)  max rows to return; defaults to 25
 #   DB_NAME     (optional)  defaults to "ctl_api"
 #   DB_PORT     (optional)  defaults to "5432"
@@ -43,9 +52,25 @@ fi
 echo "[query workflows] db_addr=$db_addr"
 echo "[query workflows] limit=$limit"
 
-echo "[query workflows] loading db credentials from k8s"
-admin_username=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
-admin_password=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
+: "${DB_USER:?DB_USER is required (ctl_api_wi.db_user, the IAM database user)}"
+: "${CTL_API_SA_EMAIL:?CTL_API_SA_EMAIL is required (ctl_api_wi.service_account_email)}"
+
+# Mint a Cloud SQL login token AS the ctl-api service account. The ctl-api-init
+# pod is NOT workload-identity-bound to ctl-api (its metadata identity is the WI
+# pool, not the ctl-api GSA), so we can't use the pod's own token. Instead the
+# runner impersonates the ctl-api SA — the runner SA is granted
+# roles/iam.serviceAccountTokenCreator on it (ctl_api_wi.runner_impersonate_ctl_api),
+# same grant the s3_bucket inspect action uses. The token is scoped to
+# sqlservice.login, which Cloud SQL requires for direct (non-proxy) IAM auth.
+echo "[query workflows] minting a Cloud SQL login token as ${CTL_API_SA_EMAIL}"
+db_token=$(gcloud auth print-access-token \
+  --impersonate-service-account="$CTL_API_SA_EMAIL" \
+  --scopes=https://www.googleapis.com/auth/sqlservice.login)
+if [[ -z "$db_token" ]]; then
+  echo "[query workflows] ERROR: failed to mint a login token as $CTL_API_SA_EMAIL." >&2
+  echo "[query workflows] (does the runner SA have roles/iam.serviceAccountTokenCreator on it? redeploy ctl_api_wi.)" >&2
+  exit 1
+fi
 
 echo "[query workflows] scale up ctl-api-init"
 kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
@@ -161,7 +186,7 @@ FROM (
 
 echo "[query workflows] running query"
 workflows_json=$(kubectl --namespace=ctl-api exec -i "$pod" -- \
-  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$admin_username" "PGPASSWORD=$admin_password" \
+  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$DB_USER" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -A -t -q -c "$sql" \
   | tr -d '\r' | { grep -E '^[[\{]' || true; } | tail -n 1)
 

--- a/byoc-nuon-gcp/actions/ctl_api/dashboard_route_readiness/app-readiness.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/dashboard_route_readiness/app-readiness.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Polls the app (dashboard-ui) route over HTTP until it serves a healthy
+# response. Runs as a dashboard_ui post-deploy hook so a fresh provision does NOT
+# complete — and a human does not land — while the route is still in its
+# post-deploy window returning 5xx or an Envoy "fault filter abort". Unlike the
+# route-resource healthcheck (which only checks HTTPRoute Accepted/ResolvedRefs
+# conditions), this makes a real request, so it catches serving-time faults.
+#
+# Healthy = curl succeeds AND status is 2xx-4xx (the app's normal unauthenticated
+# response is a 302 redirect to auth; 401/403 also mean "up") AND the body is not
+# "fault filter abort". 5xx, connection failures, and the abort body all retry.
+#
+# Read-only; curl only, no cloud role.
+#
+# Env:
+#   APP_URL   the app URL to poll (https://app.<public_domain>)
+#   ATTEMPTS  max attempts, 10s apart (default 30 = ~5m)
+
+set -u
+
+url="${APP_URL:?APP_URL required}"
+attempts="${ATTEMPTS:-30}"
+
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
+
+i=1
+while true; do
+  code=$(curl -s --max-time 10 -o "$body" -w '%{http_code}' "$url")
+  rc=$?
+  abort=false
+  if grep -qi 'fault filter abort' "$body" 2>/dev/null; then
+    abort=true
+  fi
+
+  if [ "$rc" -eq 0 ] && [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 500 ] && [ "$abort" = false ]; then
+    echo "app route serving (http ${code}) after attempt ${i}."
+    exit 0
+  fi
+
+  if [ "$abort" = true ]; then
+    reason="fault filter abort (http ${code})"
+  elif [ "$rc" -ne 0 ]; then
+    reason="curl exit ${rc}"
+  else
+    reason="http ${code}"
+  fi
+
+  if [ "$i" -ge "$attempts" ]; then
+    echo "ERROR: app route ${url} did not become healthy after ${attempts} attempts (~5m). Last: ${reason}." >&2
+    echo "last body (first 200 chars): $(head -c 200 "$body" | tr '\n' ' ')" >&2
+    exit 1
+  fi
+
+  echo "app route not ready yet (attempt ${i}/${attempts}, ${reason}), retrying in 10s..."
+  i=$((i + 1))
+  sleep 10
+done

--- a/byoc-nuon-gcp/actions/ctl_api/dashboard_route_readiness/dashboard_route_readiness.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/dashboard_route_readiness/dashboard_route_readiness.toml
@@ -1,0 +1,25 @@
+# waits for the app (dashboard-ui) route to serve a healthy HTTP
+# response after deploy, so a fresh provision does not complete while the route
+# is still in its post-deploy window returning 5xx / "fault filter abort". Polls
+# https://app.<public_domain> until it returns 2xx-4xx (normally a 302 to auth)
+# with a non-abort body. Read-only; curl only, no cloud role.
+name    = "dashboard_route_readiness"
+labels  = { service = "ctl-api", type = "step" }
+timeout = "10m"
+
+# Runs after dashboard_ui_restart (index 1) so it waits on the restarted pods,
+# and before dashboard_status (index 5) so the status check sees a serving route.
+[[triggers]]
+type           = "post-deploy-component"
+component_name = "dashboard_ui"
+index          = 2
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Wait for app route to serve"
+inline_contents = "./ctl_api/dashboard_route_readiness/app-readiness.sh"
+
+[steps.env_vars]
+APP_URL = "https://app.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"

--- a/byoc-nuon-gcp/actions/ctl_api/dashboard_status/version.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/dashboard_status/version.sh
@@ -6,7 +6,33 @@ set -e
 set -o pipefail
 set -u
 
-resp=$(curl -sS --max-time 10 "${APP_URL}/version" || echo '{}')
+# Fetch /version, retrying until it returns a valid JSON body. This step also
+# runs post-deploy (right after dashboard_ui deploys), so the route is often not
+# serving JSON yet: curl may return a 2xx with an HTML gateway/error page, or an
+# empty body on a closed connection — both exit 0, so a bare `|| echo '{}'` does
+# NOT catch them and `jq --argjson` then aborts with "invalid JSON text". Poll
+# until the body parses as JSON, falling back to {} (→ "unknown") if it never does.
+fetch_version() {
+  attempts="${ATTEMPTS:-6}"
+  i=1
+  while true; do
+    body=$(curl -sS --max-time 10 "${APP_URL}/version" || true)
+    if printf '%s' "$body" | jq -e . >/dev/null 2>&1; then
+      printf '%s' "$body"
+      return 0
+    fi
+    if [ "$i" -ge "$attempts" ]; then
+      echo "dashboard-ui /version did not return valid JSON after ${attempts} attempts; emitting unknown." >&2
+      echo '{}'
+      return 0
+    fi
+    echo "dashboard-ui /version not ready (attempt ${i}/${attempts}), retrying in 10s..." >&2
+    i=$((i + 1))
+    sleep 10
+  done
+}
+
+resp=$(fetch_version)
 
 jq -cn --argjson r "$resp" '{
   dashboard_ui_version: ($r.ui.version // $r.version // "unknown"),

--- a/byoc-nuon-gcp/actions/ctl_api/temporal_hard_reset_cancel_queued_workflows/cancel-queued-workflows.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/temporal_hard_reset_cancel_queued_workflows/cancel-queued-workflows.sh
@@ -20,9 +20,20 @@ db_addr="$DB_ADDR"
 echo "[cancel-queued-workflows] kubectl auth whoami"
 kubectl auth whoami -o json | jq -c
 
-echo "[cancel-queued-workflows] loading db credentials from k8s"
-admin_username=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
-admin_password=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
+# Update as the ctl-api IAM role (the table owner) via Cloud SQL IAM auth. The
+# nuon-db admin user is NOT the owner and gets "permission denied". Impersonate
+# the ctl-api SA on the runner (ctl_api_wi grants the runner token-creator on it)
+# to mint a sqlservice.login-scoped token, used as the DB password over SSL.
+: "${DB_USER:?DB_USER is required (ctl_api_wi.db_user, the IAM database user)}"
+: "${CTL_API_SA_EMAIL:?CTL_API_SA_EMAIL is required (ctl_api_wi.service_account_email)}"
+echo "[cancel-queued-workflows] minting a Cloud SQL login token as ${CTL_API_SA_EMAIL}"
+db_token=$(gcloud auth print-access-token \
+  --impersonate-service-account="$CTL_API_SA_EMAIL" \
+  --scopes=https://www.googleapis.com/auth/sqlservice.login)
+if [[ -z "$db_token" ]]; then
+  echo "[cancel-queued-workflows] ERROR: failed to mint a login token as $CTL_API_SA_EMAIL." >&2
+  exit 1
+fi
 
 echo "[cancel-queued-workflows] scale up ctl-api-init"
 kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
@@ -53,7 +64,7 @@ RETURNING w.id;
 
 echo "[cancel-queued-workflows] running update"
 kubectl --namespace=ctl-api exec -i "$pod" -- \
-  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$admin_username" "PGPASSWORD=$admin_password" \
+  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$DB_USER" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -c "$sql"
 
 echo "[cancel-queued-workflows] scale down ctl-api-init"

--- a/byoc-nuon-gcp/actions/ctl_api/temporal_hard_reset_cancel_queued_workflows/temporal_hard_reset_cancel_queued_workflows.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/temporal_hard_reset_cancel_queued_workflows/temporal_hard_reset_cancel_queued_workflows.toml
@@ -13,7 +13,8 @@ name            = "Cancel queued workflows"
 inline_contents = "./ctl_api/temporal_hard_reset_cancel_queued_workflows/cancel-queued-workflows.sh"
 
 [steps.env_vars]
-DB_USER = "{{ .nuon.components.cloudsql_nuon.outputs.db_instance_username }}"
+DB_USER          = "{{ .nuon.components.ctl_api_wi.outputs.db_user }}"
+CTL_API_SA_EMAIL = "{{ .nuon.components.ctl_api_wi.outputs.service_account_email }}"
 DB_NAME = "ctl_api"
 DB_ADDR = "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
 DB_PORT = "5432"

--- a/byoc-nuon-gcp/actions/gcp/cloudsql_delete/cloudsql_delete.sh
+++ b/byoc-nuon-gcp/actions/gcp/cloudsql_delete/cloudsql_delete.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+# Deletes a single Cloud SQL instance via the gcloud API, taking a FINAL BACKUP
+# as part of the delete. This is the explicit destruction step of a Cloud SQL
+# teardown: it is intentionally decoupled from the Terraform deploy/teardown job
+# so deleting the database is always a deliberate, audited action rather than a
+# side effect of a plan.
+#
+# GCP note: deleting a Cloud SQL instance also deletes its automated and
+# on-demand backups. A FINAL BACKUP is the one artifact that survives deletion
+# (the GCP equivalent of an AWS final DB snapshot), so we always request one.
+#
+# Required env:
+#   DB_INSTANCE_NAME  the Cloud SQL instance name (cloudsql_*.outputs.db_instance_name)
+#   PROJECT_ID        the GCP project id
+# Optional env:
+#   DB_LABEL                     human-friendly label used in log output (defaults to "database")
+#   FINAL_BACKUP_RETENTION_DAYS  retention for the final backup, 1-365 (defaults to 30)
+
+db_instance_name="$DB_INSTANCE_NAME"
+project_id="$PROJECT_ID"
+db_label="${DB_LABEL:-database}"
+retention_days="${FINAL_BACKUP_RETENTION_DAYS:-30}"
+
+echo "==================================================================="
+echo " Cloud SQL delete: ${db_label}  (instance: ${db_instance_name})"
+echo "==================================================================="
+
+# ── does the instance still exist? ───────────────────────────────────────────
+if ! inst_state=$(gcloud sql instances describe "$db_instance_name" \
+  --project "$project_id" --format='value(state)' 2>/dev/null); then
+  echo "Instance ${db_instance_name} not found — already deleted. Nothing to do."
+  exit 0
+fi
+echo "Instance state: ${inst_state}"
+
+# ── refuse to delete a deletion-protected instance ───────────────────────────
+# We mirror the AWS behaviour: deletion protection must be cleared via the normal
+# config path (the component's deletion_protection var), not bypassed here. This
+# reads the API-level guard (settings.deletionProtectionEnabled).
+protected=$(gcloud sql instances describe "$db_instance_name" \
+  --project "$project_id" \
+  --format='value(settings.deletionProtectionEnabled)' 2>/dev/null || true)
+
+if [ "$protected" = "True" ] || [ "$protected" = "true" ]; then
+  echo "ERROR: ${db_instance_name} has deletion protection enabled." >&2
+  echo "Set deletion_protection=false on the component and redeploy before running this action." >&2
+  exit 1
+fi
+
+# Final backup description must be short; stamp it so re-runs are distinguishable.
+stamp=$(date -u +%Y%m%d-%H%M%S)
+description="byoc-nuon teardown ${db_instance_name} ${stamp}"
+
+echo ""
+echo "Deleting instance ${db_instance_name} with a final backup (retention ${retention_days}d)..."
+gcloud sql instances delete "$db_instance_name" \
+  --project "$project_id" \
+  --enable-final-backup \
+  --final-backup-retention-days "$retention_days" \
+  --final-backup-description "$description" \
+  --quiet
+
+echo ""
+echo "Instance ${db_instance_name} deleted. Final backup retained ${retention_days} day(s)."
+echo "  description: ${description}"
+echo "NOTE: the Terraform component still references this instance in its state."
+echo "      Detaching it from state is a separate step (the state_rm step of this hook)."
+
+# Surface the final backup description to downstream steps / the action output.
+if [ -n "${NUON_ACTIONS_OUTPUT_FILEPATH:-}" ]; then
+  echo "CLOUDSQL_FINAL_BACKUP_DESCRIPTION=${description}" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+fi

--- a/byoc-nuon-gcp/actions/gcp/cloudsql_delete_ctl_api/cloudsql_delete_ctl_api.toml
+++ b/byoc-nuon-gcp/actions/gcp/cloudsql_delete_ctl_api/cloudsql_delete_ctl_api.toml
@@ -1,0 +1,24 @@
+# action
+# description: deletes the ctl-api (nuon) Cloud SQL instance via the gcloud API,
+# taking a final backup as part of the deletion. Explicit destruction step of the
+# ctl-api Cloud SQL teardown — deliberately decoupled from the Terraform teardown
+# job. GCP equivalent of the AWS rds_delete_ctl_api action.
+name    = "cloudsql_delete_ctl_api"
+labels  = { service = "cloudsql", type = "sop" }
+label   = "gcp"
+timeout = "30m"
+role    = "{{.nuon.install.id}}-cloudsql-operations"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Delete ctl-api Cloud SQL"
+inline_contents = "./gcp/cloudsql_delete/cloudsql_delete.sh"
+
+[steps.env_vars]
+# Derived from install.id (cloudsql_nuon names the instance "nuon-<install_id>"),
+# not the component output — so this still resolves after the component is torn down.
+DB_INSTANCE_NAME = "nuon-{{ .nuon.install.id }}"
+PROJECT_ID       = "{{ .nuon.install_stack.outputs.project_id }}"
+DB_LABEL         = "ctl-api (nuon)"

--- a/byoc-nuon-gcp/actions/gcp/cloudsql_delete_temporal/cloudsql_delete_temporal.toml
+++ b/byoc-nuon-gcp/actions/gcp/cloudsql_delete_temporal/cloudsql_delete_temporal.toml
@@ -1,0 +1,24 @@
+# action
+# description: deletes the Temporal Cloud SQL instance via the gcloud API, taking
+# a final backup as part of the deletion. Explicit destruction step of the
+# Temporal Cloud SQL teardown — deliberately decoupled from the Terraform
+# teardown job. GCP equivalent of the AWS rds_delete_temporal action.
+name    = "cloudsql_delete_temporal"
+labels  = { service = "cloudsql", type = "sop" }
+label   = "gcp"
+timeout = "30m"
+role    = "{{.nuon.install.id}}-cloudsql-operations"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Delete Temporal Cloud SQL"
+inline_contents = "./gcp/cloudsql_delete/cloudsql_delete.sh"
+
+[steps.env_vars]
+# Derived from install.id (cloudsql_temporal names the instance "temporal-<install_id>"),
+# not the component output — so this still resolves after the component is torn down.
+DB_INSTANCE_NAME = "temporal-{{ .nuon.install.id }}"
+PROJECT_ID       = "{{ .nuon.install_stack.outputs.project_id }}"
+DB_LABEL         = "temporal"

--- a/byoc-nuon-gcp/actions/gcp/cloudsql_state_rm_ctl_api/cloudsql_state_rm_ctl_api.toml
+++ b/byoc-nuon-gcp/actions/gcp/cloudsql_state_rm_ctl_api/cloudsql_state_rm_ctl_api.toml
@@ -1,0 +1,27 @@
+# action
+# description: removes the ctl-api (nuon) Cloud SQL instance (and its
+# database/user) from its Terraform component state without destroying it, so the
+# remaining resources can tear down without tripping the
+# block-destructive-changes policy. Run after the instance has been deleted via
+# the gcloud API. GCP equivalent of the AWS rds_state_rm_ctl_api action.
+#
+# No cloud role: state removal only talks to the Nuon Terraform HTTP backend
+# using the runner's own credentials — it never calls a GCP API — so it does not
+# need the -cloudsql-operations role. (Piloted on GCP, to be ported back to AWS.)
+name    = "cloudsql_state_rm_ctl_api"
+labels  = { service = "cloudsql", type = "sop" }
+label   = "gcp"
+timeout = "15m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Detach ctl-api Cloud SQL from state"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+[steps.env_vars]
+INSTALL_COMPONENT_ID = "{{ .nuon.components.cloudsql_nuon.install_component_id }}"
+STATE_ADDRESSES      = "google_sql_database_instance.nuon,google_sql_database.nuonadmin,google_sql_user.nuon"
+TF_VERSION           = "1.11.3"
+DB_LABEL             = "ctl-api (nuon)"

--- a/byoc-nuon-gcp/actions/gcp/cloudsql_state_rm_temporal/cloudsql_state_rm_temporal.toml
+++ b/byoc-nuon-gcp/actions/gcp/cloudsql_state_rm_temporal/cloudsql_state_rm_temporal.toml
@@ -1,0 +1,27 @@
+# action
+# description: removes the Temporal Cloud SQL instance (and its database/user)
+# from its Terraform component state without destroying it, so the remaining
+# resources can tear down without tripping the block-destructive-changes policy.
+# Run after the instance has been deleted via the gcloud API. GCP equivalent of
+# the AWS rds_state_rm_temporal action.
+#
+# No cloud role: state removal only talks to the Nuon Terraform HTTP backend
+# using the runner's own credentials — it never calls a GCP API — so it does not
+# need the -cloudsql-operations role. (Piloted on GCP, to be ported back to AWS.)
+name    = "cloudsql_state_rm_temporal"
+labels  = { service = "cloudsql", type = "sop" }
+label   = "gcp"
+timeout = "15m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Detach Temporal Cloud SQL from state"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+[steps.env_vars]
+INSTALL_COMPONENT_ID = "{{ .nuon.components.cloudsql_temporal.install_component_id }}"
+STATE_ADDRESSES      = "google_sql_database_instance.temporal,google_sql_database.temporaladmin,google_sql_user.temporaladmin"
+TF_VERSION           = "1.11.3"
+DB_LABEL             = "temporal"

--- a/byoc-nuon-gcp/actions/gcp/cloudsql_teardown_ctl_api/cloudsql_teardown_ctl_api.toml
+++ b/byoc-nuon-gcp/actions/gcp/cloudsql_teardown_ctl_api/cloudsql_teardown_ctl_api.toml
@@ -1,0 +1,45 @@
+# action
+# description: pre-teardown hook for the ctl-api (nuon) Cloud SQL component. Runs
+# automatically right before the component's Terraform destroy: detach the
+# instance (and its database/user) from Terraform state, then delete it via the
+# gcloud API taking a FINAL BACKUP. Detaching from state first means the
+# subsequent Terraform destroy never observes the deletion as drift and never
+# trips prevent_destroy / block-destructive-changes; the final backup keeps the
+# database recoverable after the instance is gone (GCP deletes ordinary backups
+# with the instance, so a final backup is the only surviving artifact).
+#
+# Gated by the -cloudsql-operations role, which is disabled by default: unless
+# the customer has explicitly enabled it, these steps fail with a permission
+# error and the database is never deleted. This is the safety mechanism —
+# deleting the DB requires a deliberate, customer-enabled role, not just a
+# component teardown. GCP equivalent of the AWS rds_teardown_ctl_api hook.
+name    = "cloudsql_teardown_ctl_api"
+labels  = { service = "cloudsql", type = "step" }
+label   = "gcp"
+timeout = "60m"
+role    = "{{.nuon.install.id}}-cloudsql-operations"
+
+[[triggers]]
+type           = "pre-teardown-component"
+component_name = "cloudsql_nuon"
+
+[[steps]]
+name            = "Detach ctl-api Cloud SQL from state"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+[steps.env_vars]
+INSTALL_COMPONENT_ID = "{{ .nuon.components.cloudsql_nuon.install_component_id }}"
+STATE_ADDRESSES      = "google_sql_database_instance.nuon,google_sql_database.nuonadmin,google_sql_user.nuon"
+TF_VERSION           = "1.11.3"
+DB_LABEL             = "ctl-api (nuon)"
+
+[[steps]]
+name            = "Delete ctl-api Cloud SQL"
+inline_contents = "./gcp/cloudsql_delete/cloudsql_delete.sh"
+
+[steps.env_vars]
+# Derived from install.id (instance is "nuon-<install_id>"), not the component
+# output — robust even if the output is unavailable at teardown time.
+DB_INSTANCE_NAME = "nuon-{{ .nuon.install.id }}"
+PROJECT_ID       = "{{ .nuon.install_stack.outputs.project_id }}"
+DB_LABEL         = "ctl-api (nuon)"

--- a/byoc-nuon-gcp/actions/gcp/cloudsql_teardown_temporal/cloudsql_teardown_temporal.toml
+++ b/byoc-nuon-gcp/actions/gcp/cloudsql_teardown_temporal/cloudsql_teardown_temporal.toml
@@ -1,0 +1,45 @@
+# action
+# description: pre-teardown hook for the Temporal Cloud SQL component. Runs
+# automatically right before the component's Terraform destroy: detach the
+# instance (and its database/user) from Terraform state, then delete it via the
+# gcloud API taking a FINAL BACKUP. Detaching from state first means the
+# subsequent Terraform destroy never observes the deletion as drift and never
+# trips prevent_destroy / block-destructive-changes; the final backup keeps the
+# database recoverable after the instance is gone (GCP deletes ordinary backups
+# with the instance, so a final backup is the only surviving artifact).
+#
+# Gated by the -cloudsql-operations role, which is disabled by default: unless
+# the customer has explicitly enabled it, these steps fail with a permission
+# error and the database is never deleted. This is the safety mechanism —
+# deleting the DB requires a deliberate, customer-enabled role, not just a
+# component teardown. GCP equivalent of the AWS rds_teardown_temporal hook.
+name    = "cloudsql_teardown_temporal"
+labels  = { service = "cloudsql", type = "step" }
+label   = "gcp"
+timeout = "60m"
+role    = "{{.nuon.install.id}}-cloudsql-operations"
+
+[[triggers]]
+type           = "pre-teardown-component"
+component_name = "cloudsql_temporal"
+
+[[steps]]
+name            = "Detach Temporal Cloud SQL from state"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+[steps.env_vars]
+INSTALL_COMPONENT_ID = "{{ .nuon.components.cloudsql_temporal.install_component_id }}"
+STATE_ADDRESSES      = "google_sql_database_instance.temporal,google_sql_database.temporaladmin,google_sql_user.temporaladmin"
+TF_VERSION           = "1.11.3"
+DB_LABEL             = "temporal"
+
+[[steps]]
+name            = "Delete Temporal Cloud SQL"
+inline_contents = "./gcp/cloudsql_delete/cloudsql_delete.sh"
+
+[steps.env_vars]
+# Derived from install.id (instance is "temporal-<install_id>"), not the component
+# output — robust even if the output is unavailable at teardown time.
+DB_INSTANCE_NAME = "temporal-{{ .nuon.install.id }}"
+PROJECT_ID       = "{{ .nuon.install_stack.outputs.project_id }}"
+DB_LABEL         = "temporal"

--- a/byoc-nuon-gcp/actions/gcp/gateway_locate_faults/gateway_locate_faults.toml
+++ b/byoc-nuon-gcp/actions/gcp/gateway_locate_faults/gateway_locate_faults.toml
@@ -1,0 +1,15 @@
+# action
+# description: locates HTTP fault injection ("fault filter abort") in the cluster
+# — Istio VirtualService fault stanzas, EnvoyFilters, and Gateway API HTTPRoute
+# filters. Read-only; kubectl only, no cloud role.
+name    = "gateway_locate_faults"
+labels  = { service = "gateway", type = "debug" }
+label   = "gcp"
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Locate fault injection"
+inline_contents = "./gcp/gateway_locate_faults/locate-faults.sh"

--- a/byoc-nuon-gcp/actions/gcp/gateway_locate_faults/locate-faults.sh
+++ b/byoc-nuon-gcp/actions/gcp/gateway_locate_faults/locate-faults.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Locates HTTP fault injection ("fault filter abort") configured in the cluster.
+# A fault can live in any of three places, so it checks all of them. Read-only;
+# kubectl only, no cloud role.
+#
+# Prints a human-readable report to logs AND writes a structured result to
+# NUON_ACTIONS_OUTPUT_FILEPATH ({"faults":[{kind,ns,name,detail}, ...]}) so the
+# runbook README can render it.
+
+set -u
+
+faults='[]'
+add_fault() {
+  faults=$(printf '%s' "$faults" | jq -c \
+    --arg k "$1" --arg ns "$2" --arg n "$3" --arg d "$4" \
+    '. + [{kind:$k, ns:$ns, name:$n, detail:$d}]')
+}
+
+echo "==================================================================="
+echo " Searching for HTTP fault injection in the cluster"
+echo "==================================================================="
+
+echo ""
+echo "--- 1. Istio VirtualServices with a fault stanza ---"
+if kubectl get virtualservice -A >/dev/null 2>&1; then
+  vs_json=$(kubectl get virtualservice -A -o json 2>/dev/null)
+  hits=$(printf '%s' "$vs_json" | jq -c '.items[] | select([.spec.http[]?.fault] | length > 0) | {ns:.metadata.namespace, name:.metadata.name, fault:(.spec.http[].fault)}')
+  if [ -n "$hits" ]; then
+    printf '%s\n' "$hits" | while IFS= read -r h; do
+      ns=$(printf '%s' "$h" | jq -r '.ns'); name=$(printf '%s' "$h" | jq -r '.name'); det=$(printf '%s' "$h" | jq -c '.fault')
+      echo "  ${ns}/${name}: ${det}"
+    done
+    # accumulate (subshell-safe: re-iterate)
+    while IFS= read -r h; do
+      [ -n "$h" ] || continue
+      add_fault "VirtualService" "$(printf '%s' "$h" | jq -r '.ns')" "$(printf '%s' "$h" | jq -r '.name')" "$(printf '%s' "$h" | jq -c '.fault')"
+    done <<EOF
+$hits
+EOF
+  else
+    echo "  none"
+  fi
+else
+  echo "  (no VirtualService CRD — Istio not installed)"
+fi
+
+echo ""
+echo "--- 2. EnvoyFilters that reference a fault filter ---"
+if kubectl get envoyfilter -A >/dev/null 2>&1; then
+  ef_json=$(kubectl get envoyfilter -A -o json 2>/dev/null)
+  ef_hits=$(printf '%s' "$ef_json" | jq -c '.items[] | select((.. | strings? | test("fault"; "i")) // false) | {ns:.metadata.namespace, name:.metadata.name}' 2>/dev/null | sort -u)
+  if [ -n "$ef_hits" ]; then
+    while IFS= read -r h; do
+      [ -n "$h" ] || continue
+      ns=$(printf '%s' "$h" | jq -r '.ns'); name=$(printf '%s' "$h" | jq -r '.name')
+      echo "  ${ns}/${name} (references 'fault')"
+      add_fault "EnvoyFilter" "$ns" "$name" "references 'fault'"
+    done <<EOF
+$ef_hits
+EOF
+  else
+    echo "  none reference 'fault'"
+  fi
+else
+  echo "  (no EnvoyFilter CRD)"
+fi
+
+echo ""
+echo "--- 3. Gateway API HTTPRoute filters ---"
+kubectl get httproute -A -o json 2>/dev/null \
+  | jq -r '.items[] | select([.spec.rules[]?.filters[]?] | length > 0) | "  \(.metadata.namespace)/\(.metadata.name): filters=[\([.spec.rules[]?.filters[]?.type] | join(", "))]"' \
+  || true
+echo "  (routes with no filters omitted)"
+
+echo ""
+echo "Fix: remove the fault stanza (or set its percentage to 0) on whatever is"
+echo "listed above. This config is NOT in the byoc-nuon-gcp app config — it comes"
+echo "from the sandbox/gateway layer or was applied out-of-band."
+
+count=$(printf '%s' "$faults" | jq 'length')
+printf '%s' "$faults" | jq -c '{faults: ., fault_count: length}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+echo ""
+echo "(${count} fault definition(s) recorded to outputs)"

--- a/byoc-nuon-gcp/actions/gcp/gateway_probe_routes/gateway_probe_routes.toml
+++ b/byoc-nuon-gcp/actions/gcp/gateway_probe_routes/gateway_probe_routes.toml
@@ -1,0 +1,19 @@
+# action
+# description: probes each public ctl-api/dashboard route (app/api/auth/runner +
+# internal admin) and reports status, serving proxy, and whether the response is
+# an Envoy "fault filter abort". Read-only; curl only, no cloud role.
+name    = "gateway_probe_routes"
+labels  = { service = "gateway", type = "debug" }
+label   = "gcp"
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Probe public routes"
+inline_contents = "./gcp/gateway_probe_routes/probe-routes.sh"
+
+[steps.env_vars]
+PUBLIC_DOMAIN   = "{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
+INTERNAL_DOMAIN = "{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"

--- a/byoc-nuon-gcp/actions/gcp/gateway_probe_routes/probe-routes.sh
+++ b/byoc-nuon-gcp/actions/gcp/gateway_probe_routes/probe-routes.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Probes each public ctl-api/dashboard route and reports status, the serving
+# proxy, and whether the response is an Envoy "fault filter abort" (an HTTP
+# fault-injection filter aborting the request before it reaches the backend).
+# Read-only; curl only, no cloud role.
+#
+# Prints a human-readable report to logs AND writes a structured result to
+# NUON_ACTIONS_OUTPUT_FILEPATH ({"routes":[{name,url,code,server,fault}, ...]})
+# so the runbook README can render it.
+#
+# Env:
+#   PUBLIC_DOMAIN    public domain (app/api/auth/runner are subdomains)
+#   INTERNAL_DOMAIN  internal domain (admin is a subdomain; VPC-only, http)
+
+set -u
+
+pub="${PUBLIC_DOMAIN:?PUBLIC_DOMAIN required}"
+intd="${INTERNAL_DOMAIN:?INTERNAL_DOMAIN required}"
+
+hdr="$(mktemp)"
+body="$(mktemp)"
+trap 'rm -f "$hdr" "$body"' EXIT
+
+results='[]'
+
+check() {
+  name="$1"
+  url="$2"
+  echo ""
+  echo "=== ${name}: ${url} ==="
+  code=$(curl -s --max-time 10 -D "$hdr" -o "$body" -w '%{http_code}' "$url")
+  rc=$?
+  server=""
+  fault=false
+  if [ "$rc" -ne 0 ]; then
+    case "$rc" in
+      6)  code="dns-fail" ; echo "  curl exit 6: DNS does not resolve" ;;
+      7)  code="refused"  ; echo "  curl exit 7: connection refused" ;;
+      28) code="timeout"  ; echo "  curl exit 28: timed out (no/slow response)" ;;
+      *)  code="err-${rc}"; echo "  curl failed (exit ${rc})" ;;
+    esac
+  else
+    server=$(grep -i '^server:' "$hdr" | tr -d '\r' | cut -d' ' -f2-)
+    echo "  http_code: ${code}"
+    echo "  server:    ${server}"
+    if grep -qi 'fault filter abort' "$body"; then
+      fault=true
+      echo "  >> FAULT FILTER ABORT — an Envoy fault-injection filter is aborting this route."
+    fi
+    echo "  body (first 200 chars): $(head -c 200 "$body" | tr '\n' ' ')"
+  fi
+  results=$(printf '%s' "$results" | jq -c \
+    --arg n "$name" --arg u "$url" --arg c "${code:-}" --arg s "$server" --argjson f "$fault" \
+    '. + [{name:$n, url:$u, code:$c, server:$s, fault:$f}]')
+}
+
+echo "Probing public routes on ${pub} and admin on ${intd}..."
+check "app"    "https://app.${pub}"
+check "api"    "https://api.${pub}/v1/general/healthz"
+check "auth"   "https://auth.${pub}"
+check "runner" "https://runner.${pub}"
+check "admin"  "http://admin.${intd}/v1/general/healthz"
+
+echo ""
+echo "Interpreting:"
+echo "  - 'fault filter abort' on a route => fault injection is configured on it;"
+echo "    run the 'Locate fault injection' step to find and remove it."
+echo "  - all routes abort => mesh-wide / shared-gateway fault."
+echo "  - DNS/timeout (not abort) => a routing/LB problem, not fault injection."
+
+printf '%s' "$results" | jq -c '{routes: .}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/gcp/gateway_route_health/gateway_route_health.toml
+++ b/byoc-nuon-gcp/actions/gcp/gateway_route_health/gateway_route_health.toml
@@ -1,0 +1,15 @@
+# action
+# description: shows the gateway, HTTPRoutes (hosts/parents/backends), and the
+# dashboard-ui + ctl-api backend pods. Use when a route times out / 5xxs rather
+# than returning "fault filter abort". Read-only; kubectl only, no cloud role.
+name    = "gateway_route_health"
+labels  = { service = "gateway", type = "debug" }
+label   = "gcp"
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Route + backend health"
+inline_contents = "./gcp/gateway_route_health/route-health.sh"

--- a/byoc-nuon-gcp/actions/gcp/gateway_route_health/route-health.sh
+++ b/byoc-nuon-gcp/actions/gcp/gateway_route_health/route-health.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Shows the gateway, HTTPRoutes, and the backend pods behind the app/api routes.
+# Use when a route returns DNS/timeout rather than "fault filter abort" — i.e. a
+# routing or backend problem rather than fault injection. Read-only; kubectl
+# only, no cloud role.
+#
+# Prints a human-readable report to logs AND writes a structured result to
+# NUON_ACTIONS_OUTPUT_FILEPATH ({"httproutes":[{ns,name,hosts,backends}],
+# "dashboard_pods_ready", "ctl_api_pods_ready"}) so the README can render it.
+
+set -u
+
+echo "==================================================================="
+echo " Gateways"
+echo "==================================================================="
+kubectl get gateway -A 2>/dev/null || echo "  (no Gateway resources)"
+
+echo ""
+echo "==================================================================="
+echo " HTTPRoutes (name, hostnames, parent gateway, backend)"
+echo "==================================================================="
+routes_json=$(kubectl get httproute -A -o json 2>/dev/null || echo '{"items":[]}')
+printf '%s' "$routes_json" | jq -r '.items[] | "  \(.metadata.namespace)/\(.metadata.name)\n    hosts:    \(.spec.hostnames // [] | join(", "))\n    parents:  \([.spec.parentRefs[]?.name] | join(", "))\n    backends: \([.spec.rules[]?.backendRefs[]? | "\(.name):\(.port)"] | join(", "))"'
+
+echo ""
+echo "==================================================================="
+echo " dashboard-ui backend pods (the 'app' route)"
+echo "==================================================================="
+kubectl get pods -A 2>/dev/null | grep -i dashboard || echo "  no dashboard-ui pods found"
+
+echo ""
+echo "==================================================================="
+echo " ctl-api backend pods (api / auth / runner / admin routes)"
+echo "==================================================================="
+kubectl get pods -n ctl-api 2>/dev/null || echo "  ctl-api namespace not found"
+
+echo ""
+echo "Interpreting:"
+echo "  - a route with no/incorrect backendRefs, or a backend with 0 ready pods,"
+echo "    explains a timeout/5xx (NOT a 'fault filter abort')."
+echo "  - if pods are healthy and routes look correct but a route still aborts,"
+echo "    the cause is fault injection — use the 'Locate fault injection' step."
+
+# ── structured outputs ───────────────────────────────────────────────────────
+routes_out=$(printf '%s' "$routes_json" | jq -c '[.items[] | {
+  ns: .metadata.namespace,
+  name: .metadata.name,
+  hosts: (.spec.hostnames // []),
+  backends: [.spec.rules[]?.backendRefs[]? | "\(.name):\(.port)"]
+}]')
+dash_ready=$(kubectl get pods -A -o json 2>/dev/null | jq -r '[.items[] | select(.metadata.name | test("dashboard"; "i")) | select(.status.phase=="Running")] | length' 2>/dev/null || echo 0)
+ctl_ready=$(kubectl get pods -n ctl-api -o json 2>/dev/null | jq -r '[.items[] | select(.status.phase=="Running")] | length' 2>/dev/null || echo 0)
+jq -nc --argjson r "${routes_out:-[]}" --arg d "${dash_ready:-0}" --arg c "${ctl_ready:-0}" \
+  '{httproutes:$r, dashboard_pods_ready:($d|tonumber), ctl_api_pods_ready:($c|tonumber)}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/gcp/gcs_delete/gcs_delete.sh
+++ b/byoc-nuon-gcp/actions/gcp/gcs_delete/gcs_delete.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+# Empties and deletes the gcs_buckets component's three buckets (blob,
+# clickhouse, install-templates) via the gcloud API. Deliberately decoupled from
+# the Terraform teardown: the blob bucket has lifecycle.prevent_destroy and is a
+# block-destructive-changes critical resource, so deleting it must be an explicit
+# operator action, not a side effect of a plan.
+#
+# IRREVERSIBLE: GCS has no snapshot. Versioned buckets have every object version
+# and noncurrent version purged before the bucket is removed.
+#
+# GCP note (vs AWS S3): the buckets use Google-managed encryption, so there is no
+# customer KMS key to schedule for deletion — this script has no KMS step.
+#
+# Required env (set in the action from the gcs_buckets component outputs):
+#   BLOB_BUCKET        blob bucket name (blob_bucket.name output)
+#   CLICKHOUSE_BUCKET  clickhouse bucket name (clickhouse_bucket.name output)
+#   TEMPLATES_BUCKET   install-templates bucket name (install_template_bucket.name output)
+# Optional env:
+#   PROJECT_ID         the GCP project id (for explicit --project on bucket ops)
+
+: "${BLOB_BUCKET:?BLOB_BUCKET is required}"
+: "${CLICKHOUSE_BUCKET:?CLICKHOUSE_BUCKET is required}"
+: "${TEMPLATES_BUCKET:?TEMPLATES_BUCKET is required}"
+project_id="${PROJECT_ID:-}"
+
+# gcloud storage accepts a --project flag; only pass it when we have one.
+proj_args=""
+if [ -n "$project_id" ]; then
+  proj_args="--project=${project_id}"
+fi
+
+echo "==================================================================="
+echo " GCS delete: blob, clickhouse, install-templates"
+echo "==================================================================="
+
+empty_and_delete_bucket() {
+  b="$1"
+  if [ -z "$b" ] || [ "$b" = "null" ]; then
+    echo "  (empty bucket name, skipping)"
+    return 0
+  fi
+
+  # shellcheck disable=SC2086
+  if ! gcloud storage buckets describe "gs://${b}" $proj_args >/dev/null 2>&1; then
+    echo "  bucket ${b} not found (already deleted) — skipping"
+    return 0
+  fi
+
+  # `gcloud storage rm --recursive gs://<bucket>` deletes every object (including
+  # all noncurrent/versioned objects) and then the bucket itself, in one call.
+  echo "  emptying + deleting ${b} (objects, versions, then bucket)..."
+  # shellcheck disable=SC2086
+  gcloud storage rm --recursive "gs://${b}" $proj_args --quiet
+
+  # Belt-and-suspenders: if objects were removed but the bucket survived (partial
+  # run), delete it explicitly. Tolerate "not found".
+  # shellcheck disable=SC2086
+  if gcloud storage buckets describe "gs://${b}" $proj_args >/dev/null 2>&1; then
+    # shellcheck disable=SC2086
+    gcloud storage buckets delete "gs://${b}" $proj_args --quiet
+  fi
+  echo "  deleted ${b}"
+}
+
+for b in "$BLOB_BUCKET" "$CLICKHOUSE_BUCKET" "$TEMPLATES_BUCKET"; do
+  echo ""
+  echo "Bucket: ${b}"
+  empty_and_delete_bucket "$b"
+done
+
+echo ""
+echo "GCS delete complete."

--- a/byoc-nuon-gcp/actions/gcp/gcs_delete/gcs_delete.toml
+++ b/byoc-nuon-gcp/actions/gcp/gcs_delete/gcs_delete.toml
@@ -1,0 +1,26 @@
+# action
+# description: empties and deletes the gcs_buckets component's three buckets
+# (blob, clickhouse, install-templates) via the gcloud API. Explicit,
+# irreversible destruction step — deliberately decoupled from the Terraform
+# teardown (GCS has no snapshot). GCP equivalent of the AWS s3_delete action (no
+# KMS step: buckets use Google-managed encryption).
+name    = "gcs_delete"
+labels  = { service = "gcs", type = "sop" }
+label   = "gcp"
+timeout = "30m"
+role    = "{{.nuon.install.id}}-gcs-operations"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Delete gcs buckets"
+inline_contents = "./gcp/gcs_delete/gcs_delete.sh"
+
+[steps.env_vars]
+# Derived from install.id (gcs_buckets names them "<install_id>-..."), not the
+# component outputs — so these still resolve after the component is torn down.
+BLOB_BUCKET       = "{{ .nuon.install.id }}-byoc-nuon-install-blob"
+CLICKHOUSE_BUCKET = "{{ .nuon.install.id }}-nuon-clickhouse"
+TEMPLATES_BUCKET  = "{{ .nuon.install.id }}-byoc-nuon-install-templates"
+PROJECT_ID        = "{{ .nuon.install_stack.outputs.project_id }}"

--- a/byoc-nuon-gcp/actions/gcp/gcs_state_rm/gcs_state_rm.toml
+++ b/byoc-nuon-gcp/actions/gcp/gcs_state_rm/gcs_state_rm.toml
@@ -1,0 +1,27 @@
+# action
+# description: removes the gcs_buckets component's three buckets (and the
+# public-read IAM member) from Terraform state without destroying them, so the
+# component teardown isn't blocked by lifecycle.prevent_destroy or the
+# block-destructive-changes policy. Run after the buckets have been emptied and
+# deleted via the gcloud API. GCP equivalent of the AWS s3_state_rm action.
+#
+# No cloud role: state removal only talks to the Nuon Terraform HTTP backend
+# using the runner's own credentials — it never calls a GCP API — so it does not
+# need the -gcs-operations role. (Piloted on GCP, to be ported back to AWS.)
+name    = "gcs_state_rm"
+labels  = { service = "gcs", type = "sop" }
+label   = "gcp"
+timeout = "15m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Detach gcs_buckets resources from state"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+[steps.env_vars]
+INSTALL_COMPONENT_ID = "{{ .nuon.components.gcs_buckets.install_component_id }}"
+STATE_ADDRESSES      = "google_storage_bucket.clickhouse,google_storage_bucket.install_templates,google_storage_bucket_iam_member.install_templates_public_read,google_storage_bucket.blob"
+TF_VERSION           = "1.11.3"
+LABEL                = "gcs_buckets"

--- a/byoc-nuon-gcp/actions/gcp/gcs_teardown/gcs_teardown.toml
+++ b/byoc-nuon-gcp/actions/gcp/gcs_teardown/gcs_teardown.toml
@@ -1,0 +1,49 @@
+# action
+# description: pre-teardown hook for the gcs_buckets component. Runs
+# automatically right before the component's Terraform destroy: detach the three
+# buckets (and the public-read IAM member) from Terraform state, then empty +
+# delete them via the gcloud API. Detaching from state first (consistent with
+# the cloudsql hooks and the break-glass deprovision runbook) means the destroy
+# never observes the deletion as drift and never trips prevent_destroy /
+# block-destructive-changes.
+#
+# Ordering note: gcs_buckets is torn down AFTER clickhouse_cluster (which depends
+# on it), so the clickhouse backups bucket still exists while clickhouse_cluster
+# is destroyed — this hook is what finally deletes it.
+#
+# Gated by the -gcs-operations role, which is disabled by default: unless the
+# customer has explicitly enabled it, these steps fail with a permission error
+# and the buckets are never deleted (irreversible — GCS has no snapshot). GCP
+# equivalent of the AWS s3_teardown hook (no KMS step: buckets use
+# Google-managed encryption).
+name    = "gcs_teardown"
+labels  = { service = "gcs", type = "step" }
+label   = "gcp"
+timeout = "45m"
+role    = "{{.nuon.install.id}}-gcs-operations"
+
+[[triggers]]
+type           = "pre-teardown-component"
+component_name = "gcs_buckets"
+
+[[steps]]
+name            = "Detach gcs_buckets resources from state"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+[steps.env_vars]
+INSTALL_COMPONENT_ID = "{{ .nuon.components.gcs_buckets.install_component_id }}"
+STATE_ADDRESSES      = "google_storage_bucket.clickhouse,google_storage_bucket.install_templates,google_storage_bucket_iam_member.install_templates_public_read,google_storage_bucket.blob"
+TF_VERSION           = "1.11.3"
+LABEL                = "gcs_buckets"
+
+[[steps]]
+name            = "Delete gcs buckets"
+inline_contents = "./gcp/gcs_delete/gcs_delete.sh"
+
+[steps.env_vars]
+# Derived from install.id (buckets are "<install_id>-..."), not the component
+# outputs — robust even if the outputs are unavailable at teardown time.
+BLOB_BUCKET       = "{{ .nuon.install.id }}-byoc-nuon-install-blob"
+CLICKHOUSE_BUCKET = "{{ .nuon.install.id }}-nuon-clickhouse"
+TEMPLATES_BUCKET  = "{{ .nuon.install.id }}-byoc-nuon-install-templates"
+PROJECT_ID        = "{{ .nuon.install_stack.outputs.project_id }}"

--- a/byoc-nuon-gcp/actions/runners/temporal_hard_reset_cancel_shutdown_runner_jobs/cancel-shutdown-runner-jobs.sh
+++ b/byoc-nuon-gcp/actions/runners/temporal_hard_reset_cancel_shutdown_runner_jobs/cancel-shutdown-runner-jobs.sh
@@ -19,9 +19,20 @@ db_addr="$DB_ADDR"
 echo "[cancel-shutdown-runner-jobs] kubectl auth whoami"
 kubectl auth whoami -o json | jq -c
 
-echo "[cancel-shutdown-runner-jobs] loading db credentials from k8s"
-admin_username=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
-admin_password=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
+# Update as the ctl-api IAM role (the table owner) via Cloud SQL IAM auth. The
+# nuon-db admin user is NOT the owner and gets "permission denied". Impersonate
+# the ctl-api SA on the runner (ctl_api_wi grants the runner token-creator on it)
+# to mint a sqlservice.login-scoped token, used as the DB password over SSL.
+: "${DB_USER:?DB_USER is required (ctl_api_wi.db_user, the IAM database user)}"
+: "${CTL_API_SA_EMAIL:?CTL_API_SA_EMAIL is required (ctl_api_wi.service_account_email)}"
+echo "[cancel-shutdown-runner-jobs] minting a Cloud SQL login token as ${CTL_API_SA_EMAIL}"
+db_token=$(gcloud auth print-access-token \
+  --impersonate-service-account="$CTL_API_SA_EMAIL" \
+  --scopes=https://www.googleapis.com/auth/sqlservice.login)
+if [[ -z "$db_token" ]]; then
+  echo "[cancel-shutdown-runner-jobs] ERROR: failed to mint a login token as $CTL_API_SA_EMAIL." >&2
+  exit 1
+fi
 
 echo "[cancel-shutdown-runner-jobs] scale up ctl-api-init"
 kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
@@ -41,7 +52,7 @@ RETURNING id, type, status_description;
 
 echo "[cancel-shutdown-runner-jobs] running update"
 kubectl --namespace=ctl-api exec -i "$pod" -- \
-  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$admin_username" "PGPASSWORD=$admin_password" \
+  env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$DB_USER" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -c "$sql"
 
 echo "[cancel-shutdown-runner-jobs] scale down ctl-api-init"

--- a/byoc-nuon-gcp/actions/runners/temporal_hard_reset_cancel_shutdown_runner_jobs/temporal_hard_reset_cancel_shutdown_runner_jobs.toml
+++ b/byoc-nuon-gcp/actions/runners/temporal_hard_reset_cancel_shutdown_runner_jobs/temporal_hard_reset_cancel_shutdown_runner_jobs.toml
@@ -13,7 +13,8 @@ name            = "Cancel shutdown runner jobs"
 inline_contents = "./runners/temporal_hard_reset_cancel_shutdown_runner_jobs/cancel-shutdown-runner-jobs.sh"
 
 [steps.env_vars]
-DB_USER = "{{ .nuon.components.cloudsql_nuon.outputs.db_instance_username }}"
+DB_USER          = "{{ .nuon.components.ctl_api_wi.outputs.db_user }}"
+CTL_API_SA_EMAIL = "{{ .nuon.components.ctl_api_wi.outputs.service_account_email }}"
 DB_NAME = "ctl_api"
 DB_ADDR = "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
 DB_PORT = "5432"

--- a/byoc-nuon-gcp/actions/tf/state_rm/state_rm.sh
+++ b/byoc-nuon-gcp/actions/tf/state_rm/state_rm.sh
@@ -13,12 +13,24 @@ set -u
 # it here lets the remaining (non-critical) resources tear down cleanly.
 #
 # Required env:
-#   INSTALL_COMPONENT_ID  the install-component id that owns the terraform
-#                         workspace (set in the action from install_component_id)
 #   STATE_ADDRESSES       space/comma-separated Terraform addresses to remove.
 #                         May be individual resources (google_storage_bucket.blob)
 #                         or whole modules (module.foo).
+#   plus ONE workspace selector (see below).
+#
+# Workspace selector (pick one; precedence is top-to-bottom):
+#   WORKSPACE_ID          explicit terraform workspace id (e.g. tfw...). Skips the
+#                         lookup entirely — use the id from the "Use Terraform CLI"
+#                         modal when you already have it.
+#   WORKSPACE_OWNER_TYPE  match the workspace by owner_type. Use this to target the
+#                         sandbox: owner_type "install_sandbox_run". The runner's
+#                         workspace list is install-scoped, so there is exactly one
+#                         sandbox workspace. (Components are "install_deploy".)
+#   INSTALL_COMPONENT_ID  match the workspace by owner_id == this id — i.e. a
+#                         component's workspace (owner_type "install_deploy"). What
+#                         the cloudsql_state_rm / gcs_state_rm actions use.
 # Optional env:
+#   WORKSPACE_OWNER_ID    explicit owner_id to match (defaults to INSTALL_COMPONENT_ID).
 #   TF_VERSION            terraform version to use (default 1.11.3, match component)
 #   LABEL / DB_LABEL      human-friendly label for log output
 #
@@ -41,8 +53,15 @@ echo "==================================================================="
 
 # ── preflight ──────────────────────────────────────────────────────────────
 : "${RUNNER_API_URL:?RUNNER_API_URL not present in environment}"
-: "${INSTALL_COMPONENT_ID:?INSTALL_COMPONENT_ID is required}"
 : "${STATE_ADDRESSES:?STATE_ADDRESSES is required}"
+
+# resolve the owner_id to match (explicit WORKSPACE_OWNER_ID, else the component id)
+match_owner_id="${WORKSPACE_OWNER_ID:-${INSTALL_COMPONENT_ID:-}}"
+match_owner_type="${WORKSPACE_OWNER_TYPE:-}"
+if [ -z "${WORKSPACE_ID:-}" ] && [ -z "$match_owner_id" ] && [ -z "$match_owner_type" ]; then
+  echo "ERROR: provide a workspace selector: WORKSPACE_ID, WORKSPACE_OWNER_TYPE, or INSTALL_COMPONENT_ID." >&2
+  exit 1
+fi
 
 # normalize address separators to whitespace
 addresses=$(echo "$STATE_ADDRESSES" | tr ',' ' ')
@@ -74,29 +93,39 @@ if [ -z "${RUNNER_API_TOKEN:-}" ] || [ "$RUNNER_API_TOKEN" = "null" ]; then
   exit 1
 fi
 
-# ── resolve the component's terraform workspace id ───────────────────────────
-echo "Looking up terraform workspace for install component ${INSTALL_COMPONENT_ID}..."
-ws_json=$(curl -fsS -H "Authorization: Bearer ${RUNNER_API_TOKEN}" \
-  "${RUNNER_API_URL}/v1/terraform-workspaces")
-
-if command -v jq >/dev/null 2>&1; then
-  workspace_id=$(printf '%s' "$ws_json" \
-    | jq -r --arg oid "$INSTALL_COMPONENT_ID" '.[] | select(.owner_id==$oid) | .id' \
-    | head -n1)
-elif command -v python3 >/dev/null 2>&1; then
-  workspace_id=$(printf '%s' "$ws_json" | python3 -c '
-import sys, json, os
-oid = os.environ["INSTALL_COMPONENT_ID"]
-ws = json.load(sys.stdin)
-print(next((w["id"] for w in ws if w.get("owner_id") == oid), ""))')
+# ── resolve the terraform workspace id ───────────────────────────────────────
+# Precedence: explicit WORKSPACE_ID > match by owner_type / owner_id in the list.
+if [ -n "${WORKSPACE_ID:-}" ]; then
+  workspace_id="$WORKSPACE_ID"
+  echo "Using explicit workspace id: ${workspace_id}"
 else
-  echo "ERROR: need jq or python3 to parse the workspace list." >&2
-  exit 1
-fi
+  echo "Looking up terraform workspace (owner_id='${match_owner_id:-<any>}' owner_type='${match_owner_type:-<any>}')..."
+  ws_json=$(curl -fsS -H "Authorization: Bearer ${RUNNER_API_TOKEN}" \
+    "${RUNNER_API_URL}/v1/terraform-workspaces")
 
-if [ -z "${workspace_id:-}" ] || [ "$workspace_id" = "null" ]; then
-  echo "ERROR: no terraform workspace found with owner_id=${INSTALL_COMPONENT_ID}." >&2
-  exit 1
+  if command -v jq >/dev/null 2>&1; then
+    workspace_id=$(printf '%s' "$ws_json" \
+      | jq -r --arg oid "$match_owner_id" --arg otype "$match_owner_type" \
+        '.[] | select(($oid=="" or .owner_id==$oid) and ($otype=="" or .owner_type==$otype)) | .id' \
+      | head -n1)
+  elif command -v python3 >/dev/null 2>&1; then
+    workspace_id=$(printf '%s' "$ws_json" | MATCH_OID="$match_owner_id" MATCH_OTYPE="$match_owner_type" python3 -c '
+import sys, json, os
+oid = os.environ.get("MATCH_OID", "")
+otype = os.environ.get("MATCH_OTYPE", "")
+ws = json.load(sys.stdin)
+print(next((w["id"] for w in ws
+            if (oid == "" or w.get("owner_id") == oid)
+            and (otype == "" or w.get("owner_type") == otype)), ""))')
+  else
+    echo "ERROR: need jq or python3 to parse the workspace list." >&2
+    exit 1
+  fi
+
+  if [ -z "${workspace_id:-}" ] || [ "$workspace_id" = "null" ]; then
+    echo "ERROR: no terraform workspace found matching owner_id='${match_owner_id}' owner_type='${match_owner_type}'." >&2
+    exit 1
+  fi
 fi
 echo "Workspace: ${workspace_id}"
 

--- a/byoc-nuon-gcp/actions/tf/state_rm/state_rm.sh
+++ b/byoc-nuon-gcp/actions/tf/state_rm/state_rm.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+# Removes one or more resources (or whole modules) from a component's Terraform
+# state WITHOUT destroying them, by driving the Terraform CLI against the Nuon
+# HTTP state backend. Used as a teardown step: after a critical resource has been
+# deleted out-of-band via the cloud API, its address is still in Terraform state,
+# so a normal teardown plan would try to destroy it and be blocked (by the
+# block-destructive-changes policy and/or a lifecycle prevent_destroy). Detaching
+# it here lets the remaining (non-critical) resources tear down cleanly.
+#
+# Required env:
+#   INSTALL_COMPONENT_ID  the install-component id that owns the terraform
+#                         workspace (set in the action from install_component_id)
+#   STATE_ADDRESSES       space/comma-separated Terraform addresses to remove.
+#                         May be individual resources (google_storage_bucket.blob)
+#                         or whole modules (module.foo).
+# Optional env:
+#   TF_VERSION            terraform version to use (default 1.11.3, match component)
+#   LABEL / DB_LABEL      human-friendly label for log output
+#
+# Endpoint is read from the standard action environment (RUNNER_API_URL). The
+# runner API token is not exported into the action env, so we mint one the same
+# way the runner host does — `runner mng fetch-token` (cloud instance identity).
+#
+# NOTE: this drives the Terraform CLI against the Nuon runner HTTP state backend
+# using the backend's ?token= query-param auth. It is the interim mechanism
+# until a first-class "terraform state rm" runbook step exists. This script is
+# cloud-agnostic (it never calls a cloud provider CLI) and is shared verbatim
+# with the AWS app config.
+
+tf_version="${TF_VERSION:-1.11.3}"
+label="${LABEL:-${DB_LABEL:-component}}"
+
+echo "==================================================================="
+echo " Terraform state rm: ${label}"
+echo "==================================================================="
+
+# ── preflight ──────────────────────────────────────────────────────────────
+: "${RUNNER_API_URL:?RUNNER_API_URL not present in environment}"
+: "${INSTALL_COMPONENT_ID:?INSTALL_COMPONENT_ID is required}"
+: "${STATE_ADDRESSES:?STATE_ADDRESSES is required}"
+
+# normalize address separators to whitespace
+addresses=$(echo "$STATE_ADDRESSES" | tr ',' ' ')
+
+# ── mint a runner API token via instance identity ────────────────────────────
+# The runner fetches its token via cloud instance-identity and keeps it in
+# memory (not in the container env), so we re-mint one the same way the host
+# bootstrap does. fetch-token reads RUNNER_API_URL / RUNNER_AUTH_METHOD /
+# RUNNER_ID from the environment.
+if [ -z "${RUNNER_API_TOKEN:-}" ]; then
+  if ! command -v runner >/dev/null 2>&1; then
+    echo "ERROR: RUNNER_API_TOKEN not set and 'runner' binary not found to mint one." >&2
+    exit 1
+  fi
+  echo "Minting a runner API token via instance identity..."
+  token_json=$(runner mng fetch-token --json)
+  if command -v jq >/dev/null 2>&1; then
+    RUNNER_API_TOKEN=$(printf '%s' "$token_json" | jq -r '.token // empty')
+  elif command -v python3 >/dev/null 2>&1; then
+    RUNNER_API_TOKEN=$(printf '%s' "$token_json" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))')
+  else
+    echo "ERROR: need jq or python3 to parse the fetch-token response." >&2
+    exit 1
+  fi
+fi
+
+if [ -z "${RUNNER_API_TOKEN:-}" ] || [ "$RUNNER_API_TOKEN" = "null" ]; then
+  echo "ERROR: failed to obtain a runner API token." >&2
+  exit 1
+fi
+
+# ── resolve the component's terraform workspace id ───────────────────────────
+echo "Looking up terraform workspace for install component ${INSTALL_COMPONENT_ID}..."
+ws_json=$(curl -fsS -H "Authorization: Bearer ${RUNNER_API_TOKEN}" \
+  "${RUNNER_API_URL}/v1/terraform-workspaces")
+
+if command -v jq >/dev/null 2>&1; then
+  workspace_id=$(printf '%s' "$ws_json" \
+    | jq -r --arg oid "$INSTALL_COMPONENT_ID" '.[] | select(.owner_id==$oid) | .id' \
+    | head -n1)
+elif command -v python3 >/dev/null 2>&1; then
+  workspace_id=$(printf '%s' "$ws_json" | python3 -c '
+import sys, json, os
+oid = os.environ["INSTALL_COMPONENT_ID"]
+ws = json.load(sys.stdin)
+print(next((w["id"] for w in ws if w.get("owner_id") == oid), ""))')
+else
+  echo "ERROR: need jq or python3 to parse the workspace list." >&2
+  exit 1
+fi
+
+if [ -z "${workspace_id:-}" ] || [ "$workspace_id" = "null" ]; then
+  echo "ERROR: no terraform workspace found with owner_id=${INSTALL_COMPONENT_ID}." >&2
+  exit 1
+fi
+echo "Workspace: ${workspace_id}"
+
+# ── ensure a terraform binary is available ───────────────────────────────────
+workdir="$(pwd)/.tf_state_rm"
+mkdir -p "$workdir"
+
+if command -v terraform >/dev/null 2>&1; then
+  tf=terraform
+else
+  echo "terraform not on PATH — downloading ${tf_version}..."
+  os="linux"
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64) arch="amd64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    *) echo "ERROR: unsupported arch ${arch}" >&2; exit 1 ;;
+  esac
+  url="https://releases.hashicorp.com/terraform/${tf_version}/terraform_${tf_version}_${os}_${arch}.zip"
+  curl -fsSL "$url" -o "$workdir/terraform.zip"
+  unzip -oq "$workdir/terraform.zip" -d "$workdir"
+  tf="$workdir/terraform"
+fi
+
+# ── init a backend-only workspace (no module/provider code needed for state rm) ─
+cat > "$workdir/backend.tf" <<'EOF'
+terraform {
+  backend "http" {}
+}
+EOF
+
+addr="${RUNNER_API_URL}/v1/terraform-backend?workspace_id=${workspace_id}&token=${RUNNER_API_TOKEN}"
+lock="${RUNNER_API_URL}/v1/terraform-workspaces/${workspace_id}/lock?token=${RUNNER_API_TOKEN}"
+unlock="${RUNNER_API_URL}/v1/terraform-workspaces/${workspace_id}/unlock?token=${RUNNER_API_TOKEN}"
+
+echo "Initializing http backend..."
+(
+  cd "$workdir"
+  "$tf" init -reconfigure -input=false \
+    -backend-config="address=${addr}" \
+    -backend-config="lock_address=${lock}" \
+    -backend-config="lock_method=POST" \
+    -backend-config="unlock_address=${unlock}" \
+    -backend-config="unlock_method=POST" >/dev/null
+)
+
+# ── remove each requested address (idempotent: tolerate already-absent) ──────
+# Works for individual resources AND whole modules (module.<name>). We attempt
+# the rm and treat "no matching" as a no-op so re-runs and partial state are safe.
+for addr_to_rm in $addresses; do
+  if out=$(cd "$workdir" && "$tf" state rm "$addr_to_rm" 2>&1); then
+    echo "Removed from state: ${addr_to_rm}"
+  else
+    case "$out" in
+      *"No matching"* | *"no matching"* | *"not found"* | *"No instance"*)
+        echo "Not in state (already removed?), skipping: ${addr_to_rm}" ;;
+      *)
+        echo "$out" >&2
+        exit 1 ;;
+    esac
+  fi
+done
+
+echo ""
+echo "State detach complete for ${label}."

--- a/byoc-nuon-gcp/actions/tf/state_rm/state_rm.toml
+++ b/byoc-nuon-gcp/actions/tf/state_rm/state_rm.toml
@@ -1,0 +1,41 @@
+# action
+# description: generic break-glass "terraform state rm" — detach one or more
+# resources (or whole modules) from a Terraform workspace's state WITHOUT
+# destroying them, by driving the Terraform CLI against the Nuon HTTP state
+# backend. Run ad-hoc to unwedge a stuck deprovision (e.g. a namespace whose
+# delete hangs on finalizers): remove the offending address from state so the
+# destroy can skip it. Fill in the env vars when you run it.
+#
+# Pick a workspace selector (precedence: WORKSPACE_ID > WORKSPACE_OWNER_TYPE >
+# INSTALL_COMPONENT_ID):
+#   WORKSPACE_ID          explicit workspace id from the "Use Terraform CLI"
+#                         modal (e.g. tfw...). Use this for the sandbox workspace,
+#                         which the runner's workspace list does not surface.
+#   WORKSPACE_OWNER_TYPE  match by owner_type (components are "install_deploy").
+#   INSTALL_COMPONENT_ID  match a component workspace by owner_id.
+# STATE_ADDRESSES is required: comma/space-separated TF addresses, e.g.
+#   kubernetes_namespace_v1.main["clickhouse"]
+#
+# No cloud role: state removal only talks to the Nuon Terraform HTTP backend
+# using the runner's own credentials — it never calls a cloud API.
+name    = "state_rm"
+labels  = { service = "terraform", type = "sop" }
+label   = "tf"
+timeout = "15m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "Terraform state rm"
+inline_contents = "./tf/state_rm/state_rm.sh"
+
+# Defaults are empty — supply WORKSPACE_ID (or a selector) and STATE_ADDRESSES
+# when triggering the action.
+[steps.env_vars]
+WORKSPACE_ID         = ""
+WORKSPACE_OWNER_TYPE = ""
+INSTALL_COMPONENT_ID = ""
+STATE_ADDRESSES      = ""
+TF_VERSION           = "1.11.3"
+LABEL                = "ad-hoc state rm"

--- a/byoc-nuon-gcp/components/91-tf-ctl_api_wi.toml
+++ b/byoc-nuon-gcp/components/91-tf-ctl_api_wi.toml
@@ -10,6 +10,7 @@ directory = "byoc-nuon-gcp/src/components/ctl_api_wi"
 branch    = "main"
 
 [vars]
-install_id             = "{{ .nuon.install.id }}"
-project_id             = "{{ .nuon.install_stack.outputs.project_id }}"
-cloudsql_instance_name = "{{ .nuon.components.cloudsql_nuon.outputs.db_instance_name }}"
+install_id                   = "{{ .nuon.install.id }}"
+project_id                   = "{{ .nuon.install_stack.outputs.project_id }}"
+cloudsql_instance_name       = "{{ .nuon.components.cloudsql_nuon.outputs.db_instance_name }}"
+runner_service_account_email = "{{ .nuon.install_stack.outputs.runner_service_account_email }}"

--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -91,7 +91,6 @@ env:
   BLOB_STORAGE_REGION: "{{ .nuon.install_stack.outputs.region }}"
 
   SEGMENT_WRITE_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  LOOPS_API_KEY: "{{ .nuon.inputs.inputs.loops_api_key }}"
 
   # GCP management
   MANAGEMENT_GAR_REPOSITORY_URL: "{{ .nuon.components.management.outputs.gar.repository_url }}"
@@ -139,6 +138,11 @@ envSecrets:
     optional: true
     valueFrom:
       name: ctl-api-slack-state-jwt-secret
+      key: value
+  - name: "LOOPS_API_KEY"
+    optional: true
+    valueFrom:
+      name: ctl-api-loops-api-key
       key: value
 
 image:

--- a/byoc-nuon-gcp/docs/aws-gcp-config-deltas.md
+++ b/byoc-nuon-gcp/docs/aws-gcp-config-deltas.md
@@ -1,0 +1,70 @@
+# AWS ↔ GCP BYOC app config deltas
+
+Comparison of the two Nuon BYOC app configs — `byoc-nuon` (AWS) and `byoc-nuon-gcp` (GCP) — which deploy the same
+application and architecture (Kubernetes + Postgres + Temporal + ClickHouse + ctl-api/dashboard) on different clouds.
+The deltas are mostly (a) cloud-primitive substitutions and (b) operational tooling that exists on one side but not the
+other.
+
+> Status as of the deprovision-safety work (the `deprovision` runbook + pre-teardown hooks + gated `-cloudsql-operations`
+> / `-gcs-operations` roles on GCP). Items closed by that work are marked ✅.
+
+## 1. Architecture substitutions (expected, at parity)
+
+| Concern | AWS | GCP |
+| --- | --- | --- |
+| Relational DB | `rds_cluster_nuon`, `rds_cluster_temporal`, `rds_subnet` | `cloudsql_nuon`, `cloudsql_temporal`, `cloudsql_network` |
+| Object storage | `s3_buckets` | `gcs_buckets` |
+| TLS cert | `certificate` (ACM) | `wildcard-cert` (GCP cert-manager) |
+| Pod→cloud identity | IAM IRSA (`ctl_api_role`, `dashboard_ui_role`) | Workload Identity (`ctl_api_wi`, `dashboard_ui_wi`) |
+| DNS | external-dns bundled (Route53) | explicit `external_dns` component |
+| LB ingress | ALB + IRSA | proxy-only subnet + GCLB |
+
+Policy coverage tracks these well: `rds-data-protection` / `s3-data-protection` / `eks-endpoint-access` ↔
+`cloudsql-data-protection` / `gcs-data-protection` / `gke-endpoint-access`, plus GCP-only `gke-node-pool-service-account`.
+
+## 2. AWS-only capabilities GCP lacked
+
+- **✅ Deprovision / gated destruction (was the biggest gap) — NOW CLOSED.** GCP now has:
+  - pre-teardown hooks (`cloudsql_teardown_ctl_api`, `cloudsql_teardown_temporal`, `gcs_teardown`)
+  - the `deprovision` break-glass runbook (detach → sandbox-deprovision → optional-delete pilot structure)
+  - disabled-by-default destruction roles (`-cloudsql-operations` with final-backup perm, new `-gcs-operations`)
+  - CloudSQL recoverability via **final backup** (the AWS-final-snapshot equivalent)
+  - pilot improvements not yet on AWS: role-free state_rm, optional/deferred deletes, `sandbox_deprovision` step,
+    install.id-derived resource names.
+- **Still open — ctl-api endpoint diagnostic suite.** GCP has only `api_status`; no equivalent of
+  `ctl_api_api_health_probe` + the 8 ALB/IRSA/ACM/per-endpoint probe actions.
+- **Still open — Nuon Access login flow.** No `_nuon_access/enable` action, no `nuon_access_enable` runbook, no
+  `nuon_access_enabled` / `nuon_access_secret_arn` inputs on GCP.
+- **Still open — node autoscaling tooling.** AWS has `karpenter-nodepools` + 4 karpenter actions + nodepool kubectl
+  actions; GCP relies on native GKE autoscaling (defensible) but has no node-rotation/inspection actions.
+- **Still open — other AWS-only:** RDS Performance-Insights runbooks (`rds_inspect_ctl_api/temporal`), `acm_operations`
+  role, `helm_release_probe`, `cve_2026_46300_check`, `aws_subnet_ips`, RDS snapshot mgmt actions, `read-only`
+  cluster-access inputs.
+
+## 3. GCP-only capabilities AWS lacks
+
+- **ClickHouse verification suite**: `verify_clickhouse` runbook + `ch_verify_storage` / `ch_verify_pod_spread` /
+  `ch_verify_backups`. Worth back-porting to AWS.
+- **`dns_setup`** runbook (NS delegation records).
+- **`loops_setup`** + `sync_loops_secret`.
+- **CloudSQL inspect** runbooks/actions, `ctl_api_grant_wi`, `workers-scale-down`.
+
+## 4. Cross-cloud coupling
+
+GCP still depends on AWS:
+
+- Images `img_nuon_ctl_api` / `img_nuon_dashboard_ui` pull from **AWS ECR**.
+- GCP inputs `install_stack_template_bucket*` + `secrets_role_arn` reference an **AWS S3 bucket + IAM role** (plus an
+  `aws/s3_bucket` action/runbook on the GCP side).
+
+## Bottom line
+
+Provision paths were already at parity. Of the four day-2/teardown gaps originally identified:
+
+1. **Deprovision safety system** — ✅ done (and now ahead of AWS via the pilot changes).
+2. **Endpoint diagnostics** (`ctl_api_api_health_probe`) — still a GCP gap.
+3. **Nuon Access** — still a GCP gap.
+4. **ClickHouse verification** — still an *AWS* gap (GCP has it).
+
+Natural next targets: #2 (port the probe suite to GKE/WI/cert), or — once the deprovision pilot is proven — back-porting
+the pilot changes to AWS (role-free state_rm, deferred deletes, `sandbox_deprovision` phase).

--- a/byoc-nuon-gcp/inputs/email/loops_api_key.toml
+++ b/byoc-nuon-gcp/inputs/email/loops_api_key.toml
@@ -1,7 +1,0 @@
-name         = "loops_api_key"
-description  = "An API key from your loops account."
-default      = "your-loops-api-key"
-display_name = "Loops API Key"
-group        = "email"
-required     = false
-user_configurable = false

--- a/byoc-nuon-gcp/inputs/email/loops_secret_arn.toml
+++ b/byoc-nuon-gcp/inputs/email/loops_secret_arn.toml
@@ -1,0 +1,8 @@
+name         = "loops_secret_arn"
+description  = "ARN of the AWS Secrets Manager secret in the central account that holds this install's Loops API key (raw string). Read via web identity federation (see secrets_role_arn). Leave empty to keep Loops disabled."
+default      = ""
+display_name = "Loops Secret ARN"
+required     = false
+group        = "email"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/nuon/install_stack_template_bucket.toml
+++ b/byoc-nuon-gcp/inputs/nuon/install_stack_template_bucket.toml
@@ -1,5 +1,5 @@
 name         = "install_stack_template_bucket"
-description  = "The bucket for the install tempaltes used in cloudformation for AWS installs."
+description  = "The bucket for the install templates used in cloudformation for AWS installs."
 default      = ""
 display_name = "Install Stack Template Bucket"
 required     = false

--- a/byoc-nuon-gcp/inputs/nuon/install_stack_template_bucket_region.toml
+++ b/byoc-nuon-gcp/inputs/nuon/install_stack_template_bucket_region.toml
@@ -1,8 +1,8 @@
 name         = "install_stack_template_bucket_region"
-description  = "The region of the bucket for the install tempaltes used in cloudformation for AWS installs."
+description  = "The region of the bucket for the install templates used in cloudformation for AWS installs."
 default      = ""
 display_name = "Install Stack Template Bucket Region"
-required     = true
+required     = false
 group        = "nuon"
 type         = "string"
 

--- a/byoc-nuon-gcp/inputs/nuon/install_stack_template_role_arn.toml
+++ b/byoc-nuon-gcp/inputs/nuon/install_stack_template_role_arn.toml
@@ -1,8 +1,8 @@
 name         = "install_stack_template_bucket_role_arn"
-description  = "The AWS IAM Role with access to the bucket for the install tempaltes used in cloudformation for AWS installs."
+description  = "The AWS IAM Role with access to the bucket for the install templates used in cloudformation for AWS installs."
 default      = ""
 display_name = "Install Stack Template Bucket Role ARN"
-required     = true
+required     = false
 group        = "nuon"
 type         = "string"
 

--- a/byoc-nuon-gcp/permissions/cloudsql_operations.toml
+++ b/byoc-nuon-gcp/permissions/cloudsql_operations.toml
@@ -21,8 +21,11 @@ gcp_permissions = [
 
 # Instance destruction (GCP equivalent of the AWS tag-scoped RDS destruction policy; GCP IAM has
 # no tag-conditional scoping for CloudSQL, so this is limited to the delete verb instead).
+# cloudsql.backups.createBackup is required so the teardown delete can take a FINAL BACKUP
+# (--enable-final-backup) — the only backup that survives instance deletion on GCP.
 [[policies]]
 name            = "{{ .nuon.install.id }}-cloudsql-operations-destruction"
 gcp_permissions = [
   "cloudsql.instances.delete",
+  "cloudsql.backups.createBackup",
 ]

--- a/byoc-nuon-gcp/permissions/cloudsql_operations.toml
+++ b/byoc-nuon-gcp/permissions/cloudsql_operations.toml
@@ -21,11 +21,12 @@ gcp_permissions = [
 
 # Instance destruction (GCP equivalent of the AWS tag-scoped RDS destruction policy; GCP IAM has
 # no tag-conditional scoping for CloudSQL, so this is limited to the delete verb instead).
-# cloudsql.backups.createBackup is required so the teardown delete can take a FINAL BACKUP
-# (--enable-final-backup) — the only backup that survives instance deletion on GCP.
+# Note: the teardown delete takes a FINAL BACKUP (--enable-final-backup). Final-backup creation is
+# covered by cloudsql.backupRuns.create (granted in the backups policy above); the dedicated
+# cloudsql.backups.* permissions are not grantable in custom project roles (GCP rejects them as
+# "not valid"), so they are intentionally omitted here.
 [[policies]]
 name            = "{{ .nuon.install.id }}-cloudsql-operations-destruction"
 gcp_permissions = [
   "cloudsql.instances.delete",
-  "cloudsql.backups.createBackup",
 ]

--- a/byoc-nuon-gcp/permissions/gcs_operations.toml
+++ b/byoc-nuon-gcp/permissions/gcs_operations.toml
@@ -1,0 +1,23 @@
+type           = "custom"
+name           = "{{ .nuon.install.id }}-gcs-operations"
+description    = "GCS bucket teardown operations (empty/delete buckets) for BYOC Nuon"
+display_name   = "gcs-operations"
+cloud_platform = "gcp"
+
+# Custom operational role scoped to tearing down this install's GCS buckets: list
+# and delete every object (including noncurrent/versioned objects), and delete the
+# buckets themselves. GCP equivalent of the AWS s3-operations role — but with no
+# KMS policy, since the buckets use Google-managed encryption (there is no
+# customer key to schedule for deletion). GCP IAM has no tag/label-conditional
+# scoping for storage, so this is scoped by verb; like cloudsql-operations it is
+# disabled by default and must be enabled by the customer before a deprovision
+# can delete these resources.
+[[policies]]
+name            = "{{ .nuon.install.id }}-gcs-operations-destruction"
+gcp_permissions = [
+  "storage.buckets.get",
+  "storage.buckets.delete",
+  "storage.objects.list",
+  "storage.objects.get",
+  "storage.objects.delete",
+]

--- a/byoc-nuon-gcp/runbooks/deprovision.md
+++ b/byoc-nuon-gcp/runbooks/deprovision.md
@@ -1,0 +1,102 @@
+Break-glass steps to deprovision this install by hand.
+
+> [!IMPORTANT] **This runbook is a manual fallback.** During a normal deprovision, each stateful component deletes its
+> own resources automatically via a `pre-teardown-component` hook (`cloudsql_teardown_ctl_api`,
+> `cloudsql_teardown_temporal`, `gcs_teardown`) that runs immediately before that component's Terraform destroy. Those
+> hooks are gated by the `-cloudsql-operations` / `-gcs-operations` roles, which are **disabled by default** — the
+> customer must enable them before a deprovision can delete these resources, so deletion can never happen by accident.
+> Use the steps below only to drive the same actions by hand if a hook fails mid-teardown.
+
+Nuon BYOC on GCP uses Postgres on Cloud SQL for the control-plane (`ctl-api`) and Temporal databases, and GCS buckets
+for blob/clickhouse/template storage. These stateful resources are protected — the `block-destructive-changes` policy
+and `prevent_destroy` deliberately forbid the deploy/teardown job from ever destroying them.
+
+The runbook works in three phases:
+
+1. **Detach from state (steps 1–3).** Detach each critical resource from Terraform state — safe and reversible
+   (**nothing in the cloud is touched**). Once detached, the sandbox deprovision in phase 2 can tear the components down
+   without tripping `block-destructive-changes` / `prevent_destroy`, and the **live cloud resources survive**.
+2. **Deprovision the sandbox (step 4).** Tears down the install — its components and the sandbox (GKE cluster,
+   networking, runner infrastructure). The Cloud SQL instances and GCS buckets were detached from state in phase 1, so
+   they **survive** this.
+3. **Delete (steps 5–7) — OPTIONAL.** Permanently delete the live cloud resources that survived phases 1–2. You may not
+   always want this (e.g. tear everything down but keep the databases/buckets, or delete out-of-band). Cloud SQL deletes
+   take a final backup; GCS deletes are irreversible.
+
+> [!WARNING] **Steps 5–7 are destructive and install-specific.** They permanently delete the `ctl-api` and Temporal
+> databases and the GCS buckets for install `{{ .nuon.install.id }}`. A final backup is taken for each Cloud SQL
+> instance, but the live databases will be gone, and GCS has no snapshot.
+
+> [!NOTE] **GCP backup semantics differ from AWS.** Deleting a Cloud SQL instance also deletes its automated and
+> on-demand backups. A *final backup* (`--enable-final-backup`) is the one artifact that survives the deletion — that is
+> what the delete step takes, and it is the GCP equivalent of an AWS final DB snapshot.
+
+## Phase 1 — Detach from state
+
+### 1. Detach ctl-api Cloud SQL from state
+
+Removes `google_sql_database_instance.nuon` (plus its database and user) from the `cloudsql_nuon` Terraform state via
+the HTTP backend — no destroy. Instance `nuon-{{ .nuon.install.id }}`.
+
+<nuon-action-card name="cloudsql_state_rm_ctl_api"></nuon-action-card>
+
+### 2. Detach Temporal Cloud SQL from state
+
+Removes `google_sql_database_instance.temporal` (plus its database and user) from the `cloudsql_temporal` Terraform
+state via the HTTP backend — no destroy. Instance `temporal-{{ .nuon.install.id }}`.
+
+<nuon-action-card name="cloudsql_state_rm_temporal"></nuon-action-card>
+
+### 3. Detach gcs_buckets from state
+
+Removes the three buckets (`{{ .nuon.install.id }}-byoc-nuon-install-blob`, `{{ .nuon.install.id }}-nuon-clickhouse`,
+`{{ .nuon.install.id }}-byoc-nuon-install-templates`) and the public-read IAM member from the `gcs_buckets` Terraform
+state via the HTTP backend — no destroy.
+
+<nuon-action-card name="gcs_state_rm"></nuon-action-card>
+
+## Phase 2 — Deprovision the sandbox
+
+### 4. Deprovision sandbox
+
+Tears down the install — its components and the sandbox (GKE cluster, networking, runner infrastructure). The Cloud SQL
+instances and GCS buckets were detached from Terraform state in phase 1, so they survive this step and are deleted
+(optionally) in phase 3.
+
+## Phase 3 — Delete (OPTIONAL, destructive)
+
+> [!CAUTION] These steps permanently delete the cloud resources that survived phases 1–2. Run them only when you
+> actually want the resources gone. Each delete derives its instance/bucket names from `install.id`; if a delete fails,
+> the resource is still live in GCP but no longer tracked by Terraform — re-run the delete step to finish.
+
+### 5. Delete ctl-api Cloud SQL
+
+Deletes `nuon-{{ .nuon.install.id }}` via the gcloud API, taking a final backup (default 30-day retention) as part of
+the deletion.
+
+<nuon-action-card name="cloudsql_delete_ctl_api"></nuon-action-card>
+
+### 6. Delete Temporal Cloud SQL
+
+Deletes `temporal-{{ .nuon.install.id }}` via the gcloud API, taking a final backup (default 30-day retention) as part
+of the deletion.
+
+<nuon-action-card name="cloudsql_delete_temporal"></nuon-action-card>
+
+### 7. Delete gcs buckets
+
+Empties and deletes the three buckets via the gcloud API. **Irreversible — GCS has no snapshot.** (No KMS step: the
+buckets use Google-managed encryption.)
+
+<nuon-action-card name="gcs_delete"></nuon-action-card>
+
+> [!NOTE] The detach steps (phase 1) run with the runner's own credentials and need no cloud role — they only talk to
+> the Nuon Terraform HTTP backend. The delete steps (phase 3) run under the `{{ .nuon.install.id }}-cloudsql-operations`
+> / `{{ .nuon.install.id }}-gcs-operations` roles — not the deploy/teardown role — so resource deletion stays an
+> explicit operator action. Both ops roles are disabled by default.
+
+> [!NOTE] The state-detach steps talk to the Nuon Terraform HTTP backend directly using the runner's inherited
+> credentials. This is an interim mechanism until a first-class "terraform state rm" runbook step exists. It acquires
+> the workspace lock, so it is serialized against deploys and drift.
+
+> [!IMPORTANT] Final backups are **retained** for their retention window — they are not deleted by this runbook.

--- a/byoc-nuon-gcp/runbooks/deprovision.toml
+++ b/byoc-nuon-gcp/runbooks/deprovision.toml
@@ -1,0 +1,55 @@
+name        = "deprovision"
+description = "Break-glass deprovision steps that must run explicitly, outside the Terraform teardown. Phase 1: detach each stateful resource (Cloud SQL ctl-api + Temporal, GCS buckets) from Terraform state. Phase 2: deprovision the sandbox. Phase 3 (optional): delete the detached cloud resources via the gcloud API (Cloud SQL with a final backup; GCS irreversibly). Normally the detach+delete run automatically as pre-teardown-component hooks — use this runbook only to drive them by hand if a hook fails mid-teardown."
+readme      = "./runbooks/deprovision.md"
+labels      = { type = "sop" }
+
+# Phase 1 — detach each critical resource from Terraform state. Safe and
+# reversible (nothing in the cloud is touched), so the subsequent sandbox
+# deprovision can tear the components down without tripping
+# block-destructive-changes / prevent_destroy. The live cloud resources survive
+# (they are deleted, optionally, in phase 3).
+
+[[steps]]
+name        = "Detach ctl-api Cloud SQL from state"
+type        = "action"
+action_name = "cloudsql_state_rm_ctl_api"
+
+[[steps]]
+name        = "Detach Temporal Cloud SQL from state"
+type        = "action"
+action_name = "cloudsql_state_rm_temporal"
+
+[[steps]]
+name        = "Detach gcs_buckets from state"
+type        = "action"
+action_name = "gcs_state_rm"
+
+# Phase 2 — deprovision the sandbox. Tears down the install (components + the
+# sandbox: GKE cluster, networking, runner infrastructure). The Cloud SQL
+# instances and GCS buckets were detached from state in phase 1, so they survive
+# this and are deleted in phase 3.
+
+[[steps]]
+name = "Deprovision sandbox"
+type = "sandbox_deprovision"
+
+# Phase 3 — delete the detached cloud resources. OPTIONAL: these permanently
+# destroy the live resources that survived phases 1-2 and may not always be
+# wanted (e.g. tear everything down but keep the databases/buckets, or delete
+# out-of-band). Each delete derives its instance/bucket names from install.id.
+# Cloud SQL deletes take a final backup; GCS deletes are irreversible.
+
+[[steps]]
+name        = "Delete ctl-api Cloud SQL"
+type        = "action"
+action_name = "cloudsql_delete_ctl_api"
+
+[[steps]]
+name        = "Delete Temporal Cloud SQL"
+type        = "action"
+action_name = "cloudsql_delete_temporal"
+
+[[steps]]
+name        = "Delete gcs buckets"
+type        = "action"
+action_name = "gcs_delete"

--- a/byoc-nuon-gcp/runbooks/deprovision.toml
+++ b/byoc-nuon-gcp/runbooks/deprovision.toml
@@ -3,11 +3,9 @@ description = "Break-glass deprovision steps that must run explicitly, outside t
 readme      = "./runbooks/deprovision.md"
 labels      = { type = "sop" }
 
-# Phase 1 — detach each critical resource from Terraform state. Safe and
-# reversible (nothing in the cloud is touched), so the subsequent sandbox
-# deprovision can tear the components down without tripping
-# block-destructive-changes / prevent_destroy. The live cloud resources survive
-# (they are deleted, optionally, in phase 3).
+# Phase 1 — detach each critical resource from Terraform state. This is
+# reversible, nothing in the cloud is touched. The live cloud resources
+# survive, and can be optionally deleted in phase 3).
 
 [[steps]]
 name        = "Detach ctl-api Cloud SQL from state"
@@ -24,20 +22,21 @@ name        = "Detach gcs_buckets from state"
 type        = "action"
 action_name = "gcs_state_rm"
 
-# Phase 2 — deprovision the sandbox. Tears down the install (components + the
-# sandbox: GKE cluster, networking, runner infrastructure). The Cloud SQL
-# instances and GCS buckets were detached from state in phase 1, so they survive
-# this and are deleted in phase 3.
+# Phase 2 — deprovision install components and sandbox.
+
+# Add a `component_tear_down_all` step type, then uncomment this.
+# [[steps]]
+# name = "Tear down components"
+# type = "component_tear_down_all"
 
 [[steps]]
 name = "Deprovision sandbox"
 type = "sandbox_deprovision"
 
 # Phase 3 — delete the detached cloud resources. OPTIONAL: these permanently
-# destroy the live resources that survived phases 1-2 and may not always be
-# wanted (e.g. tear everything down but keep the databases/buckets, or delete
-# out-of-band). Each delete derives its instance/bucket names from install.id.
-# Cloud SQL deletes take a final backup; GCS deletes are irreversible.
+# destroy the RDS and S3 resources. Each delete derives its instance/bucket
+# names from install.id, since the component states have all been deleted
+# by the time these steps run.
 
 [[steps]]
 name        = "Delete ctl-api Cloud SQL"

--- a/byoc-nuon-gcp/runbooks/gateway_fault_debug.md
+++ b/byoc-nuon-gcp/runbooks/gateway_fault_debug.md
@@ -1,0 +1,49 @@
+# Gateway Fault Debug
+
+Diagnose a route returning **`fault filter abort`** — or other gateway/route failures — for install `{{ .nuon.install.id }}`.
+
+`fault filter abort` is the response Envoy returns when an HTTP **fault-injection filter is configured to abort** a
+request, *before* it ever reaches the backend. A common symptom: after login you land on `app.<domain>` and see only the
+text `fault filter abort`. This fault config is **not** part of the `byoc-nuon-gcp` app components — it lives in the
+gateway/mesh layer (the sandbox's gateway, an Istio policy, or something applied out-of-band) — so this runbook is about
+*locating* it so it can be removed there.
+
+Every step is **read-only**. Run the runbook and read each step's output.
+
+## Steps
+
+### 1. Probe public routes
+
+`curl`s each public route (`app`, `api`, `auth`, `runner`) and the internal `admin` route, reporting status code, the
+serving proxy (`server:` header), and whether the body is `fault filter abort`.
+
+- **One route aborts** → the fault is scoped to that route.
+- **All routes abort** → the fault is mesh-wide / on the shared gateway.
+- **DNS/timeout instead of abort** → it's a routing/LB/backend problem, not fault injection — skip to step 3.
+
+### 2. Locate fault injection
+
+Searches the three places an HTTP fault can be configured: an Istio `VirtualService` `http[].fault` stanza, an
+`EnvoyFilter` that inserts a fault filter, or Gateway API `HTTPRoute` filters. It prints any matches with their
+namespace/name and the fault stanza. The fix is to remove the `fault` block (or set its `percentage` to 0) on whatever
+it finds — applied in the gateway/sandbox layer, not in a byoc-nuon-gcp component.
+
+### 3. Route + backend health
+
+Lists the `Gateway`, the `HTTPRoute`s (hostnames, parent gateway, backends), and the `dashboard-ui` (the `app` route) and
+`ctl-api` (api/auth/runner/admin) backend pods. Use this when a route **times out or 5xxs** rather than returning
+`fault filter abort` — a missing/incorrect backend or zero healthy pods explains those, whereas a healthy backend that
+still aborts points back to fault injection (step 2).
+
+## Reading the output
+
+| Symptom | Likely cause | Next |
+| --- | --- | --- |
+| `fault filter abort` on one route | fault scoped to that route | step 2 → remove the fault |
+| `fault filter abort` on all routes | mesh-wide / shared-gateway fault | step 2 → remove the fault |
+| `curl exit 6` (DNS) / `exit 28` (timeout) | route not built or backend down | step 3 → check route + pods |
+| 5xx with a healthy backend | backend erroring | step 3 → then check pod logs |
+
+> [!NOTE]
+> The fixes for fault injection and gateway config live in the install's sandbox / gateway layer, not in the
+> byoc-nuon-gcp app components. This runbook only locates the cause.

--- a/byoc-nuon-gcp/runbooks/gateway_fault_debug.toml
+++ b/byoc-nuon-gcp/runbooks/gateway_fault_debug.toml
@@ -1,0 +1,19 @@
+name        = "gateway_fault_debug"
+description = "Diagnose a route returning Envoy 'fault filter abort' (or other gateway/route failures) for this install. Probes the public routes to confirm the symptom, locates any HTTP fault injection (Istio VirtualService / EnvoyFilter / HTTPRoute filters), and shows route + backend health. Read-only."
+readme      = "./runbooks/gateway_fault_debug.md"
+labels      = { service = "gateway", type = "debug" }
+
+[[steps]]
+name        = "Probe public routes"
+type        = "action"
+action_name = "gateway_probe_routes"
+
+[[steps]]
+name        = "Locate fault injection"
+type        = "action"
+action_name = "gateway_locate_faults"
+
+[[steps]]
+name        = "Route + backend health"
+type        = "action"
+action_name = "gateway_route_health"

--- a/byoc-nuon-gcp/runbooks/inspect_dns.md
+++ b/byoc-nuon-gcp/runbooks/inspect_dns.md
@@ -1,0 +1,62 @@
+{{ $inputs := (default dict (index (default dict .nuon.inputs) "inputs")) }}
+{{ $root_domain := (dig "root_domain" "" $inputs) }}
+{{ $public_domain := (dig "outputs" "nuon_dns" "public_domain" "name" $root_domain .nuon.sandbox) }}
+
+<div style="padding-top:1rem;"></div>
+
+#### Current DNS Configurations
+
+When an install is created, a Route53 zone will be created for each of the domains. When these are ready, you can use
+those details to configure your domain in your registrar to use the AWS nameservers.
+
+{{ if (and .nuon.sandbox.populated .nuon.sandbox.outputs) }}
+
+##### Root Domain
+
+| Attribute   | Value                                                                                          |
+| ----------- | ---------------------------------------------------------------------------------------------- |
+| Domain Name | {{ $public_domain }}                                                                           |
+| Zone ID     | {{ dig "outputs" "nuon_dns" "public_domain" "zone_id" "Z00XXXXXXXXXXXXXXXXXX" .nuon.sandbox }} |
+
+<!-- prettier-ignore-start -->
+| Value     | Record Type | priority |
+| --------- | ----------- | -------- |
+{{ range $i, $ns := dig "nuon_dns" "public_domain" "nameservers" (list) (default dict .nuon.sandbox.outputs) }}| {{ $ns }} | NS          | {{$i}}   |
+{{ end }}
+<!-- prettier-ignore-end -->
+
+{{ else }}
+
+> [!WARNING] Waiting on Sandbox Provision. Once the Sandbox is ready, results will be visible here.
+
+{{ end }}
+
+{{ $dnsZone := dig "dns_zone" dict (default dict (default dict .nuon.components.management).outputs) }}
+{{ if $dnsZone }}
+
+##### Nuon DNS Delegation Domain
+
+| Attribute   | Value                           |
+| ----------- | ------------------------------- |
+| Domain Name | {{ dig "domain" "" $dnsZone }}  |
+| Zone ID     | {{ dig "zone_id" "" $dnsZone }} |
+
+<!-- prettier-ignore-start -->
+| Value     | Record Type | priority |
+| --------- | ----------- | -------- |
+{{ range $i, $ns := dig "nameservers" (list) $dnsZone }}| {{ $ns }} | NS          | {{$i}}   |
+{{ end }}
+<!-- prettier-ignore-end -->
+
+{{ else }}
+
+<!-- prettier-ignore-start -->
+> [!WARNING]
+> Waiting on Sandbox Provision. Once the Sandbox is ready, results will be visible here.
+<!-- prettier-ignore-end -->
+
+{{ end }}
+
+Additional Documentation
+
+- [Creating a subdomain that uses Amazon Route 53 as the DNS service without migrating the parent domain](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingNewSubdomain.html)

--- a/byoc-nuon-gcp/runbooks/inspect_dns.toml
+++ b/byoc-nuon-gcp/runbooks/inspect_dns.toml
@@ -1,0 +1,9 @@
+name        = "inspect_dns"
+description = "Inspect DNS — public root-domain zone and the Nuon DNS delegation domain, with the nameserver (NS) records to configure at the registrar."
+readme      = "./runbooks/inspect_dns.md"
+labels      = { service = "dns", type = "debug" }
+
+[[steps]]
+name        = "Inspect: installs"
+type        = "action"
+action_name = "inspect_installs"

--- a/byoc-nuon-gcp/runbooks/loops_setup.md
+++ b/byoc-nuon-gcp/runbooks/loops_setup.md
@@ -63,7 +63,9 @@ in step 1. Leave it empty to keep Loops disabled.
 loops_secret_arn = '<arn from loops_secret_arns output>'
 ```
 
-`sync_loops_secret` uses the `secrets_role_arn` input to federate into AWS.
+`sync_loops_secret` uses the `secrets_role_arn` input to federate into AWS. The `loops_api_key` value itself is a
+Nuon secret (default `dne` = disabled); the sync step writes the central value into the `ctl-api-loops-api-key` k8s
+secret, which `ctl-api` reads as the `LOOPS_API_KEY` env var.
 
 ### 4. Run the `Loops: Sync loops secret` step {{ if $loopsSynced }}✅ (completed){{ end }}
 

--- a/byoc-nuon-gcp/runbooks/s3_bucket.md
+++ b/byoc-nuon-gcp/runbooks/s3_bucket.md
@@ -1,24 +1,5 @@
 # S3 Bucket
 
-Enable and inspect the AWS S3 install-templates bucket for install `{{ .nuon.install.id }}`.
-
-Nuon deploys installs into AWS using CloudFormation, and CloudFormation can only fetch its templates from S3 — so even
-though this control plane runs on **GCP**, its install-templates bucket must live in **AWS**. This is what lets a GCP
-control plane manage AWS BYOC installs. The three `install_stack_template_bucket*` inputs are optional and left empty at
-provision time (the IAM role's trust policy federates this install's identity, so its ARN can't exist until the install
-does) — the steps below fill them in.
-
-The AWS-side resources are provisioned per-install by the
-[`infra/byoc-s3-buckets`](https://github.com/nuonco/mono/tree/main/infra/byoc-s3-buckets) Terraform workspace in
-`nuonco/mono` (in the `public` AWS account):
-
-- **`{{.nuon.install.id}}-byoc-nuon-install-templates`** — the S3 bucket ctl-api uploads rendered CloudFormation
-  templates to (public read only on the `templates/*` and `stacks/*` prefixes).
-- **`{{.nuon.install.id}}-byoc-nuon-ctl-api-gcp`** — an AWS IAM role ctl-api assumes via **web-identity federation**:
-  ctl-api mints a Google-signed OIDC token from the GKE metadata server and calls `sts:AssumeRoleWithWebIdentity`. The
-  role's trust policy is scoped to `accounts.google.com:sub == <ctl-api SA unique_id>`, which is why that numeric
-  `unique_id` is the key value below.
-
 {{ $ctlApiWi := default dict .nuon.components.ctl_api_wi.outputs }} {{ if not $ctlApiWi }}
 
 <div style="padding-bottom: 1rem;"><nuon-banner theme="warn">The <code>ctl_api_wi</code> component has not been applied yet — its outputs are required before this runbook can reach the bucket. Deploy <code>ctl_api_wi</code> first.</nuon-banner></div>
@@ -27,7 +8,7 @@ The AWS-side resources are provisioned per-install by the
 
 ### 1. `infra/byoc-s3-buckets`
 
-First, add this install to `infra/byoc-s3-buckets` in mono.
+First, add this install to infra/byoc-s3-buckets in mono
 
 {{ if $ctlApiWi }}
 
@@ -42,7 +23,7 @@ installs = {
 }
 ```
 
-Then `terraform apply` there — this creates the bucket and the IAM role.
+This will create the bucket we will need.
 
 {{ else }}
 
@@ -51,41 +32,16 @@ to add to `infra/byoc-s3-buckets`._
 
 {{ end }}
 
-### 2. `installs/byoc/byoc-nuon`
+### 2. installs/byoc/byoc-nuon
 
-Read this install's entry from the workspace outputs and set the three inputs from it:
-
-| `infra/byoc-s3-buckets` output          | install input                            |
-| --------------------------------------- | ---------------------------------------- |
-| `install_template_buckets[<id>].id`     | `install_stack_template_bucket`          |
-| `install_template_buckets[<id>].region` | `install_stack_template_bucket_region`   |
-| `ctl_api_roles[<id>].arn`               | `install_stack_template_bucket_role_arn` |
-
-```bash
-terraform output -json install_template_buckets | jq -r '.["{{.nuon.install.id}}"]'
-terraform output -json ctl_api_roles            | jq -r '.["{{.nuon.install.id}}"].arn'
-```
+Update the inputs with the outputs for this install:
 
 ```toml
-install_stack_template_bucket          = "{{.nuon.install.id}}-byoc-nuon-install-templates"
-install_stack_template_bucket_region   = "us-west-2"
-install_stack_template_bucket_role_arn = "<ctl_api_roles[<id>].arn>"
+install_stack_template_bucket_region   = ""
+install_stack_template_bucket          = ""
+install_stack_template_bucket_role_arn = ""
 ```
 
-These inputs are `user_configurable = false`, so set them via the install's config / API, not the install UI.
+### 3. re-deploy ctl-api
 
-### 3. Re-deploy ctl-api
-
-The three values feed the ctl-api configmap (`AWS_CLOUDFORMATION_STACK_TEMPLATE_BUCKET`, `..._BUCKET_REGION`,
-`..._BASE_URL`, and the role ARN ctl-api assumes). Re-deploy ctl-api so it re-renders the configmap with the new inputs
-— run the `deploy_control_plane` runbook, or deploy the `ctl_api` component directly, if updating the inputs did not
-already redeploy it.
-
-### 4. Verify
-
-Run the **Inspect S3 bucket** step of this runbook. It assumes `install_stack_template_bucket_role_arn` via web identity
-and reads the bucket (name, region, versioning/encryption, and up to 5 objects) — a successful read confirms the role
-trust policy and the inputs are correct.
-
-> [!NOTE] Until these inputs are set, only the AWS-CloudFormation install-management path is degraded — the rest of the
-> control plane runs normally, so this can be enabled any time after provision.
+if the input update did not deploiy `ctl-api` itself.

--- a/byoc-nuon-gcp/runbooks/s3_bucket.md
+++ b/byoc-nuon-gcp/runbooks/s3_bucket.md
@@ -1,5 +1,24 @@
 # S3 Bucket
 
+Enable and inspect the AWS S3 install-templates bucket for install `{{ .nuon.install.id }}`.
+
+Nuon deploys installs into AWS using CloudFormation, and CloudFormation can only fetch its templates from S3 — so even
+though this control plane runs on **GCP**, its install-templates bucket must live in **AWS**. This is what lets a GCP
+control plane manage AWS BYOC installs. The three `install_stack_template_bucket*` inputs are optional and left empty at
+provision time (the IAM role's trust policy federates this install's identity, so its ARN can't exist until the install
+does) — the steps below fill them in.
+
+The AWS-side resources are provisioned per-install by the
+[`infra/byoc-s3-buckets`](https://github.com/nuonco/mono/tree/main/infra/byoc-s3-buckets) Terraform workspace in
+`nuonco/mono` (in the `public` AWS account):
+
+- **`{{.nuon.install.id}}-byoc-nuon-install-templates`** — the S3 bucket ctl-api uploads rendered CloudFormation
+  templates to (public read only on the `templates/*` and `stacks/*` prefixes).
+- **`{{.nuon.install.id}}-byoc-nuon-ctl-api-gcp`** — an AWS IAM role ctl-api assumes via **web-identity federation**:
+  ctl-api mints a Google-signed OIDC token from the GKE metadata server and calls `sts:AssumeRoleWithWebIdentity`. The
+  role's trust policy is scoped to `accounts.google.com:sub == <ctl-api SA unique_id>`, which is why that numeric
+  `unique_id` is the key value below.
+
 {{ $ctlApiWi := default dict .nuon.components.ctl_api_wi.outputs }} {{ if not $ctlApiWi }}
 
 <div style="padding-bottom: 1rem;"><nuon-banner theme="warn">The <code>ctl_api_wi</code> component has not been applied yet — its outputs are required before this runbook can reach the bucket. Deploy <code>ctl_api_wi</code> first.</nuon-banner></div>
@@ -8,7 +27,7 @@
 
 ### 1. `infra/byoc-s3-buckets`
 
-First, add this install to infra/byoc-s3-buckets in mono
+First, add this install to `infra/byoc-s3-buckets` in mono.
 
 {{ if $ctlApiWi }}
 
@@ -23,7 +42,7 @@ installs = {
 }
 ```
 
-This will create the bucket we will need.
+Then `terraform apply` there — this creates the bucket and the IAM role.
 
 {{ else }}
 
@@ -32,16 +51,41 @@ to add to `infra/byoc-s3-buckets`._
 
 {{ end }}
 
-### 2. installs/byoc/byoc-nuon
+### 2. `installs/byoc/byoc-nuon`
 
-Update the inputs with the outputs for this install:
+Read this install's entry from the workspace outputs and set the three inputs from it:
 
-```toml
-install_stack_template_bucket_region   = ""
-install_stack_template_bucket          = ""
-install_stack_template_bucket_role_arn = ""
+| `infra/byoc-s3-buckets` output          | install input                            |
+| --------------------------------------- | ---------------------------------------- |
+| `install_template_buckets[<id>].id`     | `install_stack_template_bucket`          |
+| `install_template_buckets[<id>].region` | `install_stack_template_bucket_region`   |
+| `ctl_api_roles[<id>].arn`               | `install_stack_template_bucket_role_arn` |
+
+```bash
+terraform output -json install_template_buckets | jq -r '.["{{.nuon.install.id}}"]'
+terraform output -json ctl_api_roles            | jq -r '.["{{.nuon.install.id}}"].arn'
 ```
 
-### 3. re-deploy ctl-api
+```toml
+install_stack_template_bucket          = "{{.nuon.install.id}}-byoc-nuon-install-templates"
+install_stack_template_bucket_region   = "us-west-2"
+install_stack_template_bucket_role_arn = "<ctl_api_roles[<id>].arn>"
+```
 
-if the input update did not deploiy `ctl-api` itself.
+These inputs are `user_configurable = false`, so set them via the install's config / API, not the install UI.
+
+### 3. Re-deploy ctl-api
+
+The three values feed the ctl-api configmap (`AWS_CLOUDFORMATION_STACK_TEMPLATE_BUCKET`, `..._BUCKET_REGION`,
+`..._BASE_URL`, and the role ARN ctl-api assumes). Re-deploy ctl-api so it re-renders the configmap with the new inputs
+— run the `deploy_control_plane` runbook, or deploy the `ctl_api` component directly, if updating the inputs did not
+already redeploy it.
+
+### 4. Verify
+
+Run the **Inspect S3 bucket** step of this runbook. It assumes `install_stack_template_bucket_role_arn` via web identity
+and reads the bucket (name, region, versioning/encryption, and up to 5 objects) — a successful read confirms the role
+trust policy and the inputs are correct.
+
+> [!NOTE] Until these inputs are set, only the AWS-CloudFormation install-management path is degraded — the rest of the
+> control plane runs normally, so this can be enabled any time after provision.

--- a/byoc-nuon-gcp/runbooks/s3_bucket.toml
+++ b/byoc-nuon-gcp/runbooks/s3_bucket.toml
@@ -1,5 +1,5 @@
 name        = "s3_bucket"
-description = "Inspects the AWS S3 install-stack template bucket (install_stack_template_bucket): bucket name, region, versioning and default encryption, and lists up to 5 objects."
+description = "Enable and inspect the AWS S3 install-templates bucket integration. The README documents enabling it (add the install to mono's infra/byoc-s3-buckets, set the three install_stack_template_bucket* inputs from its outputs, redeploy ctl-api); the Inspect S3 bucket step then reads the bucket (name, region, versioning/encryption, up to 5 objects) to verify."
 readme      = "./runbooks/s3_bucket.md"
 labels      = { service = "s3", type = "setup" }
 

--- a/byoc-nuon-gcp/runbooks/slack_setup.toml
+++ b/byoc-nuon-gcp/runbooks/slack_setup.toml
@@ -1,7 +1,7 @@
 name        = "slack_setup"
 description = "Set up the Slack integration for this install: create the Slack app, provision and populate the central secret, set the install inputs, then sync the secrets into the ctl-api namespace and verify."
 readme      = "./runbooks/slack_setup.md"
-labels      = { service = "slack", type = "setup" }
+labels      = { service = "slack", type = "feature" }
 
 [[steps]]
 name        = "Slack: Sync slack secrets"

--- a/byoc-nuon-gcp/sandbox.toml
+++ b/byoc-nuon-gcp/sandbox.toml
@@ -1,3 +1,5 @@
+#:schema https://api.nuon.co/v1/general/config-schema?type=sandbox
+
 # sandbox
 terraform_version = "1.11.3"
 
@@ -17,5 +19,4 @@ internal_root_domain = "internal.{{ .nuon.inputs.inputs.root_domain }}"
 gke_node_pool_sa_email = "{{.nuon.install_stack.outputs.gke_node_pool_sa_email}}"
 
 [[var_file]]
-#:schema https://api.nuon.co/v1/general/config-schema?type=sandbox
 contents = "./sandbox.tfvars"

--- a/byoc-nuon-gcp/secrets/email/loops_api_key.toml
+++ b/byoc-nuon-gcp/secrets/email/loops_api_key.toml
@@ -1,0 +1,6 @@
+name         = "loops_api_key"
+display_name = "Loops API Key"
+description  = "API key from your Loops account. Managed out-of-band: the central AWS Secrets Manager entry referenced by loops_secret_arn is the source of truth, and the sync_loops_secret action writes the value into k8s."
+default      = "dne" # "empty" value — disables Loops integration
+
+user_configurable = true

--- a/byoc-nuon-gcp/src/components/ctl_api_wi/main.tf
+++ b/byoc-nuon-gcp/src/components/ctl_api_wi/main.tf
@@ -10,6 +10,16 @@ resource "google_service_account_iam_member" "ctl_api_workload_identity" {
   member             = "serviceAccount:${var.project_id}.svc.id.goog[ctl-api/ctl-api]"
 }
 
+# Let the runner impersonate ctl-api (mint OIDC tokens as ctl-api). The S3
+# install-templates role trust policy is scoped to ctl-api's SA, so the
+# s3_bucket inspect action — which runs on the runner — must present a token
+# minted as ctl-api to verify that federation path.
+resource "google_service_account_iam_member" "runner_impersonate_ctl_api" {
+  service_account_id = google_service_account.ctl_api.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${var.runner_service_account_email}"
+}
+
 resource "google_project_iam_member" "ctl_api_cloudsql_client" {
   project = var.project_id
   role    = "roles/cloudsql.client"

--- a/byoc-nuon-gcp/src/components/ctl_api_wi/variables.tf
+++ b/byoc-nuon-gcp/src/components/ctl_api_wi/variables.tf
@@ -9,3 +9,11 @@ variable "project_id" {
 variable "cloudsql_instance_name" {
   type = string
 }
+
+# The install's runner service account (from the install-stack outputs). Granted
+# token-creator on the ctl-api SA so maintenance actions running on the runner
+# can impersonate ctl-api — e.g. mint an OIDC token with ctl-api's identity to
+# verify the AWS S3 install-templates federation (s3_bucket inspect action).
+variable "runner_service_account_email" {
+  type = string
+}


### PR DESCRIPTION
## Summary

Assorted fixes and improvements that came out of testing Nuon BYOC on GCP. With these changes, you can now reliably:

- Provision to GCP cleanly without manual retries.
- Complete the S3 template bucket, Loops, and DNS configuration using runbooks.
- Enable Slack using a runbook.
- Run the inspect_workflows and other debug runbooks (had to update these to use workload identities.)

This PR also includes some cleanup of the README and existing runbooks, and adds new runbooks:

- Debug gateway fault: for debugging issues with ingress and routing into GKE (GCP-specific)
- Inspect DNS: surface DNS config info
- New deprovision runbook: A new deprovision runbook that simplifies tearding down RDS and S3 components.