### PR TITLE
Ja/gcp input cleanup

### DIFF
--- a/byoc-nuon-gcp/input_groups/admin_dashboard.toml
+++ b/byoc-nuon-gcp/input_groups/admin_dashboard.toml
@@ -1,0 +1,3 @@
+name         = "admin_dashboard"
+description  = "Configure the Nuon admin dashboard for this install."
+display_name = "Admin dashboard"

--- a/byoc-nuon-gcp/input_groups/auth.toml
+++ b/byoc-nuon-gcp/input_groups/auth.toml
@@ -1,3 +1,3 @@
 name         = "auth"
 description  = "Auth0 authentication configuration"
-display_name = "Auth0 Authentication"
+display_name = "Auth0 authentication"

--- a/byoc-nuon-gcp/input_groups/clickhouse.toml
+++ b/byoc-nuon-gcp/input_groups/clickhouse.toml
@@ -1,3 +1,3 @@
 name         = "clickhouse"
 description  = "Configuration for the ClickHouse cluster for the Nuon control plane."
-display_name = "ClickHouse Cluster"
+display_name = "ClickHouse cluster"

--- a/byoc-nuon-gcp/input_groups/email.toml
+++ b/byoc-nuon-gcp/input_groups/email.toml
@@ -1,4 +1,4 @@
 #:schema https://api.nuon.co/v1/general/config-schema?type=inputs
 name         = "email"
-description  = "Configure email settings."
+description  = "Configure email settings. Set after provisioning via the loops_setup runbook, which populates the central Loops secret and syncs it into the install."
 display_name = "Email"

--- a/byoc-nuon-gcp/input_groups/github.toml
+++ b/byoc-nuon-gcp/input_groups/github.toml
@@ -1,3 +1,3 @@
 name         = "github"
 description  = "Configure the GitHub Application for this BYOC Nuon install."
-display_name = "Github configuration"
+display_name = "GitHub configuration"

--- a/byoc-nuon-gcp/input_groups/install_stack_template_bucket.toml
+++ b/byoc-nuon-gcp/input_groups/install_stack_template_bucket.toml
@@ -1,0 +1,3 @@
+name         = "install_stack_template_bucket"
+description  = "Configure the AWS S3 bucket this install reads install stack templates from. Set after provisioning via the s3_bucket runbook."
+display_name = "Install stack template bucket"

--- a/byoc-nuon-gcp/input_groups/nuon.toml
+++ b/byoc-nuon-gcp/input_groups/nuon.toml
@@ -1,3 +1,0 @@
-name         = "nuon"
-description  = "Configure your Nuon install."
-display_name = "Nuon configuration"

--- a/byoc-nuon-gcp/input_groups/oidc.toml
+++ b/byoc-nuon-gcp/input_groups/oidc.toml
@@ -1,3 +1,3 @@
 name         = "oidc"
 description  = "OIDC authentication configuration (Google OAuth, etc.)"
-display_name = "OIDC Authentication"
+display_name = "OIDC authentication"

--- a/byoc-nuon-gcp/input_groups/secrets.toml
+++ b/byoc-nuon-gcp/input_groups/secrets.toml
@@ -1,3 +1,3 @@
 name         = "secrets"
-description  = "Federation settings this install uses to read its credentials from the central, vendor-owned AWS Secrets Manager store. Shared by all integrations that source secrets from that store."
-display_name = "Central secrets"
+description  = "Federation settings this install can use to read secrets from the central, vendor-owned AWS Secrets Manager store. Set after provisioning via the slack_setup and loops_setup runbooks."
+display_name = "Vendor secrets"

--- a/byoc-nuon-gcp/input_groups/slack.toml
+++ b/byoc-nuon-gcp/input_groups/slack.toml
@@ -1,3 +1,3 @@
 name         = "slack"
-description  = "Configure the Slack App for this BYOC Nuon install. Optional — only required if you plan to enable the Slack integration."
+description  = "Configure the Slack App for this BYOC Nuon install. Set after provisioning via the slack_setup runbook."
 display_name = "Slack configuration"

--- a/byoc-nuon-gcp/inputs/admin_dashboard/admin_dashboard_alb_enabled.toml
+++ b/byoc-nuon-gcp/inputs/admin_dashboard/admin_dashboard_alb_enabled.toml
@@ -1,9 +1,9 @@
 name         = "admin_dashboard_alb_enabled"
 description  = "Enable the public ingress for the Nuon admin dashboard. When true, the admin dashboard service will be deployed with a GCP ingress on admin.<root_domain>."
 default      = "false"
-display_name = "Admin Dashboard Ingress Enabled"
+display_name = "Admin dashboard ingress enabled"
 required     = false
-group        = "nuon"
+group        = "admin_dashboard"
 type         = "bool"
 
 user_configurable = false

--- a/byoc-nuon-gcp/inputs/admin_dashboard/admin_dashboard_enabled.toml
+++ b/byoc-nuon-gcp/inputs/admin_dashboard/admin_dashboard_enabled.toml
@@ -1,9 +1,9 @@
 name         = "admin_dashboard_enabled"
 description  = "Enable the Nuon admin dashboard. When true, the admin dashboard service will be deployed."
 default      = "false"
-display_name = "Admin Dashboard Enabled"
+display_name = "Admin dashboard enabled"
 required     = false
-group        = "nuon"
+group        = "admin_dashboard"
 type         = "bool"
 
 user_configurable = false

--- a/byoc-nuon-gcp/inputs/clickhouse/instance_type_cluster.toml
+++ b/byoc-nuon-gcp/inputs/clickhouse/instance_type_cluster.toml
@@ -1,7 +1,7 @@
 name         = "ch_instance_type_cluster"
 description  = "What GCE machine type should each clickhouse cluster node deploy on?"
 default      = "e2-standard-2"
-display_name = "Cluster Instance Type"
+display_name = "Cluster instance type"
 group        = "clickhouse"
 
 user_configurable = false

--- a/byoc-nuon-gcp/inputs/clickhouse/instance_type_keeper.toml
+++ b/byoc-nuon-gcp/inputs/clickhouse/instance_type_keeper.toml
@@ -1,7 +1,7 @@
 name         = "ch_instance_type_keeper"
 description  = "What GCE machine type should each clickhouse cluster node deploy on?"
 default      = "e2-medium"
-display_name = "Keeper Instance Type"
+display_name = "Keeper instance type"
 group        = "clickhouse"
 
 user_configurable = false

--- a/byoc-nuon-gcp/inputs/cloudsql-temporal/instance_tier.toml
+++ b/byoc-nuon-gcp/inputs/cloudsql-temporal/instance_tier.toml
@@ -1,6 +1,6 @@
 name         = "temporal_db_instance_tier"
 description  = "Cloud SQL machine tier for the Temporal database (e.g. db-custom-2-8192)."
-display_name = "Temporal DB Instance Tier"
+display_name = "Temporal DB instance tier"
 default      = "db-custom-2-8192"
 group        = "cloudsql_temporal"
 

--- a/byoc-nuon-gcp/inputs/cloudsql/instance_tier.toml
+++ b/byoc-nuon-gcp/inputs/cloudsql/instance_tier.toml
@@ -1,6 +1,6 @@
 name         = "nuon_db_instance_tier"
 description  = "Cloud SQL machine tier for the Nuon database (e.g. db-custom-2-8192)."
-display_name = "Nuon DB Instance Tier"
+display_name = "Nuon DB instance tier"
 default      = "db-custom-2-8192"
 group        = "cloudsql"
 

--- a/byoc-nuon-gcp/inputs/datadog/datadog_api_key.toml
+++ b/byoc-nuon-gcp/inputs/datadog/datadog_api_key.toml
@@ -1,5 +1,5 @@
 name         = "datadog_api_key"
 description  = "Datadog API Key"
 default      = ""
-display_name = "Datadog API Key"
+display_name = "Datadog API key"
 group        = "datadog"

--- a/byoc-nuon-gcp/inputs/datadog/datadog_app_key.toml
+++ b/byoc-nuon-gcp/inputs/datadog/datadog_app_key.toml
@@ -1,5 +1,5 @@
 name         = "datadog_app_key"
 description  = "Datadog App Key"
 default      = ""
-display_name = "Datadog App Key"
+display_name = "Datadog app key"
 group        = "datadog"

--- a/byoc-nuon-gcp/inputs/dns/nuon_dns.toml
+++ b/byoc-nuon-gcp/inputs/dns/nuon_dns.toml
@@ -1,6 +1,6 @@
 name         = "nuon_dns_domain"
 description  = "The domain under which Cloud DNS zones will be provisioned for installs, when using the nuon_dns feature."
-display_name = "Install DNS Delegation Domain"
+display_name = "Install DNS delegation domain"
 required     = true
 group        = "dns"
 

--- a/byoc-nuon-gcp/inputs/dns/root_domain.toml
+++ b/byoc-nuon-gcp/inputs/dns/root_domain.toml
@@ -1,6 +1,6 @@
 name         = "root_domain"
 description  = "The root domain. Services will be made available at subdomains of this root domain."
-display_name = "Root Domain"
+display_name = "Root domain"
 required     = true
 group        = "dns"
 

--- a/byoc-nuon-gcp/inputs/email/loops_secret_arn.toml
+++ b/byoc-nuon-gcp/inputs/email/loops_secret_arn.toml
@@ -1,7 +1,7 @@
 name         = "loops_secret_arn"
-description  = "ARN of the AWS Secrets Manager secret in the central account that holds this install's Loops API key (raw string). Read via web identity federation (see secrets_role_arn). Leave empty to keep Loops disabled."
+description  = "ARN of the vendor secret that holds this install's Loops API key. Read via web identity federation (see secrets_role_arn)."
 default      = ""
-display_name = "Loops Secret ARN"
+display_name = "Loops API key ARN"
 required     = false
 group        = "email"
 

--- a/byoc-nuon-gcp/inputs/github/github_app_client.toml
+++ b/byoc-nuon-gcp/inputs/github/github_app_client.toml
@@ -1,7 +1,7 @@
 name         = "github_app_client_id"
 description  = "The github app client id."
 default      = "please-provide-a-value"
-display_name = "GitHub App Client ID"
+display_name = "GitHub app client ID"
 group        = "github"
 required     = true
 

--- a/byoc-nuon-gcp/inputs/github/github_app_id.toml
+++ b/byoc-nuon-gcp/inputs/github/github_app_id.toml
@@ -1,7 +1,7 @@
 name         = "github_app_id"
 description  = "The github app id."
 default      = "please-provide-a-value"
-display_name = "GitHub App ID"
+display_name = "GitHub app ID"
 group        = "github"
 required     = true
 

--- a/byoc-nuon-gcp/inputs/github/github_app_name.toml
+++ b/byoc-nuon-gcp/inputs/github/github_app_name.toml
@@ -1,7 +1,7 @@
 name         = "github_app_name"
 description  = "The name of the GitHub app to use for VCS connections."
 default      = "please-provide-a-value"
-display_name = "GitHub App Name"
+display_name = "GitHub app name"
 group        = "github"
 required     = true
 

--- a/byoc-nuon-gcp/inputs/install_stack_template_bucket/install_stack_template_bucket.toml
+++ b/byoc-nuon-gcp/inputs/install_stack_template_bucket/install_stack_template_bucket.toml
@@ -1,0 +1,9 @@
+name         = "install_stack_template_bucket"
+description  = "The S3 bucket used to store install stack templates for AWS and Azure installs. Required to create Cloudformation quickcreate links."
+default      = ""
+display_name = "Install stack template bucket"
+required     = false
+group        = "install_stack_template_bucket"
+type         = "string"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/install_stack_template_bucket/install_stack_template_bucket_region.toml
+++ b/byoc-nuon-gcp/inputs/install_stack_template_bucket/install_stack_template_bucket_region.toml
@@ -1,0 +1,9 @@
+name         = "install_stack_template_bucket_region"
+description  = "The region the install stack template bucket is in."
+default      = ""
+display_name = "Install stack template bucket region"
+required     = false
+group        = "install_stack_template_bucket"
+type         = "string"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/install_stack_template_bucket/install_stack_template_role_arn.toml
+++ b/byoc-nuon-gcp/inputs/install_stack_template_bucket/install_stack_template_role_arn.toml
@@ -1,0 +1,9 @@
+name         = "install_stack_template_bucket_role_arn"
+description  = "The AWS IAM Role used to access the install stack template bucket."
+default      = ""
+display_name = "Install stack template bucket role ARN"
+required     = false
+group        = "install_stack_template_bucket"
+type         = "string"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/nuon/install_stack_template_bucket.toml
+++ b/byoc-nuon-gcp/inputs/nuon/install_stack_template_bucket.toml
@@ -1,9 +1,0 @@
-name         = "install_stack_template_bucket"
-description  = "The bucket for the install templates used in cloudformation for AWS installs."
-default      = ""
-display_name = "Install Stack Template Bucket"
-required     = false
-group        = "nuon"
-type         = "string"
-
-user_configurable = false

--- a/byoc-nuon-gcp/inputs/nuon/install_stack_template_bucket_region.toml
+++ b/byoc-nuon-gcp/inputs/nuon/install_stack_template_bucket_region.toml
@@ -1,9 +1,0 @@
-name         = "install_stack_template_bucket_region"
-description  = "The region of the bucket for the install templates used in cloudformation for AWS installs."
-default      = ""
-display_name = "Install Stack Template Bucket Region"
-required     = false
-group        = "nuon"
-type         = "string"
-
-user_configurable = false

--- a/byoc-nuon-gcp/inputs/nuon/install_stack_template_role_arn.toml
+++ b/byoc-nuon-gcp/inputs/nuon/install_stack_template_role_arn.toml
@@ -1,9 +1,0 @@
-name         = "install_stack_template_bucket_role_arn"
-description  = "The AWS IAM Role with access to the bucket for the install templates used in cloudformation for AWS installs."
-default      = ""
-display_name = "Install Stack Template Bucket Role ARN"
-required     = false
-group        = "nuon"
-type         = "string"
-
-user_configurable = false

--- a/byoc-nuon-gcp/inputs/nuon/slack_enabled.toml
+++ b/byoc-nuon-gcp/inputs/nuon/slack_enabled.toml
@@ -1,9 +1,0 @@
-name         = "slack_enabled"
-description  = "Enable the Nuon Slack integration. When true, the slack service is deployed and exposed on slack.<root_domain>."
-default      = "false"
-display_name = "Slack Enabled"
-required     = false
-group        = "nuon"
-type         = "bool"
-
-user_configurable = false

--- a/byoc-nuon-gcp/inputs/oidc/allow_all_users.toml
+++ b/byoc-nuon-gcp/inputs/oidc/allow_all_users.toml
@@ -1,7 +1,7 @@
 name         = "nuon_auth_allow_all_users"
 description  = "If this is set to true, any user with an email in one of the allowed_domains will be able to register."
 default      = "please-provide-a-value"
-display_name = "Allow All Users"
+display_name = "Allow all users"
 required     = true
 group        = "oidc"
 type         = "bool"

--- a/byoc-nuon-gcp/inputs/oidc/allowed_domains.toml
+++ b/byoc-nuon-gcp/inputs/oidc/allowed_domains.toml
@@ -1,7 +1,7 @@
 name         = "nuon_auth_allowed_domains"
 description  = "A comma delimited lists of domains from which user are allowed to register. Usually your org's email domain."
 default      = "please-provide-a-value"
-display_name = "Allowed Domains"
+display_name = "Allowed domains"
 required     = true
 group        = "oidc"
 type         = "string"

--- a/byoc-nuon-gcp/inputs/oidc/client_id.toml
+++ b/byoc-nuon-gcp/inputs/oidc/client_id.toml
@@ -1,7 +1,7 @@
 name         = "nuon_auth_client_id"
 description  = "OIDC Client ID from your identity provider."
 default      = "please-provide-a-value"
-display_name = "Auth Client ID"
+display_name = "Auth client ID"
 required     = false
 group        = "oidc"
 

--- a/byoc-nuon-gcp/inputs/oidc/issuer_url.toml
+++ b/byoc-nuon-gcp/inputs/oidc/issuer_url.toml
@@ -1,7 +1,7 @@
 name         = "nuon_auth_issuer_url"
 description  = "OIDC Issuer URL. Not required for Google OAuth - leave empty. Required for generic OIDC providers."
 default      = "please-provide-a-value"
-display_name = "Auth Issuer URL"
+display_name = "Auth issuer URL"
 required     = false
 group        = "oidc"
 

--- a/byoc-nuon-gcp/inputs/oidc/provider_type.toml
+++ b/byoc-nuon-gcp/inputs/oidc/provider_type.toml
@@ -1,7 +1,7 @@
 name         = "nuon_auth_provider_type"
 description  = "Identity provider type. Currently only 'google' is supported."
 default      = "please-provide-a-value"
-display_name = "Auth Provider Type"
+display_name = "Auth provider type"
 required     = false
 group        = "oidc"
 

--- a/byoc-nuon-gcp/inputs/secrets/secrets_role_arn.toml
+++ b/byoc-nuon-gcp/inputs/secrets/secrets_role_arn.toml
@@ -1,7 +1,7 @@
 name         = "secrets_role_arn"
-description  = "ARN of the AWS IAM role this GCP install assumes (via sts:AssumeRoleWithWebIdentity) to read its secrets from the central AWS Secrets Manager store. The role's trust policy is bound to this install's maintenance GCP service account, and the role is granted read on this install's secrets + CMK. Leave empty to keep central-secret sync disabled."
+description  = "ARN of the AWS IAM role this GCP install assumes to read vendor secrets from AWS Secrets Manager."
 default      = ""
-display_name = "Central Secrets Role ARN"
+display_name = "Vendor secret store role ARN"
 required     = false
 group        = "secrets"
 

--- a/byoc-nuon-gcp/inputs/slack/slack_client_id.toml
+++ b/byoc-nuon-gcp/inputs/slack/slack_client_id.toml
@@ -1,7 +1,7 @@
 name         = "slack_client_id"
-description  = "The Slack app's OAuth Client ID. Found on the Slack app's Basic Information page. Leave empty to disable the Slack integration."
+description  = "The Slack app's OAuth Client ID. Found on the Slack app's Basic Information page."
 default      = ""
-display_name = "Slack Client ID"
+display_name = "Slack client ID"
 required     = false
 group        = "slack"
 

--- a/byoc-nuon-gcp/inputs/slack/slack_enabled.toml
+++ b/byoc-nuon-gcp/inputs/slack/slack_enabled.toml
@@ -1,0 +1,9 @@
+name         = "slack_enabled"
+description  = "Enable the Nuon Slack integration."
+default      = "false"
+display_name = "Slack enabled"
+required     = false
+group        = "slack"
+type         = "bool"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/slack/slack_secrets_arn.toml
+++ b/byoc-nuon-gcp/inputs/slack/slack_secrets_arn.toml
@@ -1,7 +1,7 @@
 name         = "slack_secrets_arn"
-description  = "ARN of the AWS Secrets Manager secret in the central account that holds this install's Slack app credentials. JSON value with keys client_secret and signing_secret. Read via web identity federation (see secrets_role_arn). Leave empty to keep Slack disabled."
+description  = "ARN of the vendor secret that holds this install's Slack app credentials. JSON value with the keys \"client_secret\" and \"signing_secret\"."
 default      = ""
-display_name = "Slack Secrets ARN"
+display_name = "Slack secrets ARN"
 required     = false
 group        = "slack"
 

--- a/byoc-nuon-gcp/runbooks/slack_setup.md
+++ b/byoc-nuon-gcp/runbooks/slack_setup.md
@@ -150,17 +150,14 @@ Set the install's Slack inputs in the install config file. The relevant inputs:
 | `slack_secrets_arn` | the ARN from the `slack_secret_arns` output in step 2             |
 | `secrets_role_arn`  | the ARN from the `secret_reader_role_arns` output in step 2       |
 
-Set these in the install config file. `slack_enabled` lives in the `nuon` input group; `slack_client_id` and
+Set these in the install config file. `slack_enabled`, `slack_client_id`, and
 `slack_secrets_arn` live in the `slack` input group; `secrets_role_arn` lives in the `secrets` input group (it is the
 shared central-secrets federation role, not Slack-specific). Fill in the Client ID from step 1 and the ARNs from step 2:
 
 ```toml
-# input.group: nuon
-[[inputs]]
-slack_enabled = 'true'
-
 # input.group: slack
 [[inputs]]
+slack_enabled     = 'true'
 slack_client_id   = '<slack client id>'
 slack_secrets_arn = '<arn from slack_secret_arns output>'
 

--- a/byoc-nuon-gcp/secrets/email/loops_api_key.toml
+++ b/byoc-nuon-gcp/secrets/email/loops_api_key.toml
@@ -3,4 +3,4 @@ display_name = "Loops API Key"
 description  = "API key from your Loops account. Managed out-of-band: the central AWS Secrets Manager entry referenced by loops_secret_arn is the source of truth, and the sync_loops_secret action writes the value into k8s."
 default      = "dne" # "empty" value — disables Loops integration
 
-user_configurable = true
+user_configurable = false

--- a/byoc-nuon-gcp/secrets/slack/client_secret.toml
+++ b/byoc-nuon-gcp/secrets/slack/client_secret.toml
@@ -3,4 +3,4 @@ display_name = "Slack Client Secret"
 description  = "Client Secret from your Slack app's Basic Information page. Managed out-of-band: the central AWS Secrets Manager entry referenced by slack_secrets_arn is the source of truth, and the sync_slack_secrets action writes the value into k8s."
 default      = "dne" # "empty" value — disables Slack integration
 
-user_configurable = true
+user_configurable = false

--- a/byoc-nuon-gcp/secrets/slack/signing_secret.toml
+++ b/byoc-nuon-gcp/secrets/slack/signing_secret.toml
@@ -3,4 +3,4 @@ display_name = "Slack Signing Secret"
 description  = "Signing Secret from your Slack app's Basic Information page. Used to verify signed Slack webhook requests (events, slash commands, interactions). Managed out-of-band: the central AWS Secrets Manager entry referenced by slack_secrets_arn is the source of truth, and the sync_slack_secrets action writes the value into k8s."
 default      = "dne" # "empty" value — disables Slack integration
 
-user_configurable = true
+user_configurable = false

--- a/byoc-nuon-gcp/secrets/slack/state_jwt_secret.toml
+++ b/byoc-nuon-gcp/secrets/slack/state_jwt_secret.toml
@@ -7,4 +7,4 @@ kubernetes_sync             = true
 kubernetes_secret_namespace = "ctl-api"
 kubernetes_secret_name      = "ctl-api-slack-state-jwt-secret"
 
-user_configurable = true
+user_configurable = false


### PR DESCRIPTION
## Summary

Cleaned up the GCP inputs.

- Consistent sentence-casing of display names.
- Shorter, more clear descriptions.
- Broke up the nuon input group.
- Configured `user_configurable = false` on vendor secrets.