### PR TITLE
fix: allow 50% more clt-api-runner workers

### DIFF
--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -236,7 +236,7 @@ worker:
           value: "50"
     - namespace: runners
       minReplicas: 4
-      maxReplicas: 4
+      maxReplicas: 6
       command: ["/bin/service", "worker", "--namespace=runners"]
       resources:
         requests:


### PR DESCRIPTION
## Summary

Seeing ctl-api-runner workers hit ceiling at the current max of 4. Increasing to 6.