### PR TITLE
feat: update the gcp app config to use  blob bucket support

### DIFF
--- a/byoc-nuon-gcp/components/images/nuon_ctl_api.toml
+++ b/byoc-nuon-gcp/components/images/nuon_ctl_api.toml
@@ -1,1 +1,8 @@
-../../../shared/components/images/nuon_ctl_api.toml
+name = "img_nuon_ctl_api"
+type = "container_image"
+
+[aws_ecr]
+image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/ctl-api"
+tag          = "0.19.1041"
+region       = "us-west-2"
+iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"

--- a/byoc-nuon-gcp/components/images/nuon_dashboard_ui.toml
+++ b/byoc-nuon-gcp/components/images/nuon_dashboard_ui.toml
@@ -1,1 +1,8 @@
-../../../shared/components/images/nuon_dashboard_ui.toml
+name = "img_nuon_dashboard_ui"
+type = "container_image"
+
+[aws_ecr]
+image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/dashboard-ui"
+tag          = "0.19.1041"
+region       = "us-west-2"
+iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"

--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -47,7 +47,7 @@ env:
   INTERNAL_HTTP_PORT: !!string 8082
   RUNNER_HTTP_PORT: !!string 8083
   GRACEFUL_SHUTDOWN_TIMEOUT: 10s
-  RUNNER_CONTAINER_IMAGE_TAG: "0.19.999"
+  RUNNER_CONTAINER_IMAGE_TAG: "0.19.1041"
   RUNNER_CONTAINER_IMAGE_URL: "public.ecr.aws/p7e3r5y0/runner"
 
   GITHUB_APP_ID: !!string {{ .nuon.inputs.inputs.github_app_id }}


### PR DESCRIPTION
## Summary

This PR updates the gcp app config to use the new gcp blob bucket support in ctl-api version 0.19.1041.