### PR TITLE
Ja/cloudsql pitr runbook

### DIFF
--- a/byoc-nuon-gcp/actions/gcp/cloudsql_pitr_restore/cloudsql_pitr_restore.sh
+++ b/byoc-nuon-gcp/actions/gcp/cloudsql_pitr_restore/cloudsql_pitr_restore.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+# Restores a Cloud SQL instance to a point in time using point-in-time recovery
+# (PITR), which must be enabled on the source instance (it is: see the
+# backup_configuration block in the cloudsql_* components).
+#
+# GCP note: PITR restore is NOT in-place. `gcloud sql instances clone` replays
+# the source instance's archived transaction logs up to the requested timestamp
+# into a BRAND NEW target instance, leaving the source untouched. Recovery is
+# therefore a two-part operation: (1) this action creates the recovered instance;
+# (2) repointing the application at it (or promoting/renaming) is a separate,
+# deliberate step. We never mutate the live instance here.
+#
+# The point in time must fall within the transaction-log retention window
+# (transaction_log_retention_days on the source, default 7) and cannot be in the
+# future. Timestamps are RFC 3339 UTC, e.g. 2026-07-06T14:30:00Z.
+#
+# Required env:
+#   SOURCE_INSTANCE_NAME  the Cloud SQL instance to recover from
+#   POINT_IN_TIME         RFC 3339 UTC timestamp to restore to (e.g. 2026-07-06T14:30:00Z)
+#   PROJECT_ID            the GCP project id
+# Optional env:
+#   TARGET_INSTANCE_NAME  name of the new recovered instance
+#                         (defaults to "<source>-pitr-<YYYYmmdd-HHMMSS>")
+#   DB_LABEL              human-friendly label used in log output (defaults to "database")
+#   OVERRIDE_INPUT_NAME   the install input to set to the recovered address when
+#                         repointing (defaults to "db_host_override"; temporal
+#                         uses "temporal_db_host_override")
+
+source_instance_name="$SOURCE_INSTANCE_NAME"
+point_in_time="$POINT_IN_TIME"
+project_id="$PROJECT_ID"
+db_label="${DB_LABEL:-database}"
+override_input_name="${OVERRIDE_INPUT_NAME:-db_host_override}"
+
+stamp=$(date -u +%Y%m%d-%H%M%S)
+target_instance_name="${TARGET_INSTANCE_NAME:-${source_instance_name}-pitr-${stamp}}"
+
+echo "==================================================================="
+echo " Cloud SQL PITR restore: ${db_label}"
+echo "   source: ${source_instance_name}"
+echo "   target: ${target_instance_name}  (new instance)"
+echo "   point in time: ${point_in_time}"
+echo "==================================================================="
+
+# ── source must exist and have PITR enabled ──────────────────────────────────
+if ! pitr_enabled=$(gcloud sql instances describe "$source_instance_name" \
+  --project "$project_id" \
+  --format='value(settings.backupConfiguration.pointInTimeRecoveryEnabled)' 2>/dev/null); then
+  echo "ERROR: source instance ${source_instance_name} not found." >&2
+  exit 1
+fi
+
+if [ "$pitr_enabled" != "True" ] && [ "$pitr_enabled" != "true" ]; then
+  echo "ERROR: point-in-time recovery is not enabled on ${source_instance_name}." >&2
+  echo "       PITR restore is impossible without archived transaction logs." >&2
+  exit 1
+fi
+
+# ── refuse to clobber an existing target ─────────────────────────────────────
+if gcloud sql instances describe "$target_instance_name" \
+  --project "$project_id" --format='value(name)' >/dev/null 2>&1; then
+  echo "ERROR: target instance ${target_instance_name} already exists." >&2
+  echo "       Choose a different TARGET_INSTANCE_NAME or delete the existing one first." >&2
+  exit 1
+fi
+
+echo ""
+echo "Cloning ${source_instance_name} -> ${target_instance_name} at ${point_in_time}..."
+gcloud sql instances clone "$source_instance_name" "$target_instance_name" \
+  --project "$project_id" \
+  --point-in-time "$point_in_time"
+
+# Private IP of the recovered instance — this is what ctl-api's db_host_override
+# input must be set to in order to repoint the app (see the PITR restore runbook).
+recovered_address=$(gcloud sql instances describe "$target_instance_name" \
+  --project "$project_id" \
+  --format='value(ipAddresses[0].ipAddress)' 2>/dev/null || true)
+
+echo ""
+echo "Recovered instance ${target_instance_name} created from ${source_instance_name} at ${point_in_time}."
+echo "  private address: ${recovered_address:-<unknown>}"
+echo "NOTE: this is a NEW instance. The live instance ${source_instance_name} was not modified."
+echo ""
+echo "To repoint ${db_label} at the recovered instance:"
+echo "  1. set the install input  ${override_input_name} = ${recovered_address:-<recovered address>}"
+echo "  2. run the runbook's repoint step (redeploys the target component)."
+echo "Clear the ${override_input_name} input and redeploy to revert to the Terraform-managed instance."
+
+# Surface the recovered instance to downstream steps / the action output.
+if [ -n "${NUON_ACTIONS_OUTPUT_FILEPATH:-}" ]; then
+  echo "CLOUDSQL_PITR_TARGET_INSTANCE=${target_instance_name}" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  echo "CLOUDSQL_PITR_TARGET_ADDRESS=${recovered_address}" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+fi

--- a/byoc-nuon-gcp/actions/gcp/cloudsql_pitr_restore/cloudsql_pitr_restore.toml
+++ b/byoc-nuon-gcp/actions/gcp/cloudsql_pitr_restore/cloudsql_pitr_restore.toml
@@ -1,0 +1,38 @@
+# action
+# description: restores a control-plane Cloud SQL instance (ctl-api/nuon or
+# temporal, selected by the target_component runbook input) to a point in time
+# using point-in-time recovery. PITR restore is NOT in-place — it clones the
+# source's archived transaction logs up to the requested timestamp into a BRAND
+# NEW instance, leaving the live instance untouched. Repointing the application
+# at the recovered instance is a separate, deliberate step (the runbook's
+# repoint step, driven by the same target_component input).
+#
+# Designed to run from the cloudsql_pitr_restore runbook, which supplies the
+# runbook inputs referenced below. target_component selects which instance:
+#   "ctl_api"  -> cloudsql_nuon      (repoint via db_host_override)
+#   "temporal" -> cloudsql_temporal  (repoint via temporal_db_host_override)
+#
+# Gated by the -cloudsql-operations role, which is disabled by default: creating
+# a recovered instance is a deliberate, customer-enabled action, not a routine
+# debug read.
+name    = "cloudsql_pitr_restore"
+labels  = { service = "cloudsql", type = "step" }
+label   = "gcp"
+timeout = "60m"
+role    = "{{.nuon.install.id}}-cloudsql-operations"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "PITR restore Cloud SQL"
+inline_contents = "./gcp/cloudsql_pitr_restore/cloudsql_pitr_restore.sh"
+
+[steps.env_vars]
+# Source instance + labels are selected from the target_component runbook input.
+SOURCE_INSTANCE_NAME = "{{ if eq .runbook_inputs.target_component \"temporal\" }}{{ .nuon.components.cloudsql_temporal.outputs.db_instance_name }}{{ else }}{{ .nuon.components.cloudsql_nuon.outputs.db_instance_name }}{{ end }}"
+DB_LABEL             = "{{ if eq .runbook_inputs.target_component \"temporal\" }}temporal{{ else }}ctl-api (nuon){{ end }}"
+OVERRIDE_INPUT_NAME  = "{{ if eq .runbook_inputs.target_component \"temporal\" }}temporal_db_host_override{{ else }}db_host_override{{ end }}"
+PROJECT_ID           = "{{ .nuon.install_stack.outputs.project_id }}"
+POINT_IN_TIME        = "{{ .runbook_inputs.point_in_time }}"
+TARGET_INSTANCE_NAME = "{{ or .runbook_inputs.pitr_target_instance_name \"\" }}"

--- a/byoc-nuon-gcp/components/5-tf-temporal.toml
+++ b/byoc-nuon-gcp/components/5-tf-temporal.toml
@@ -19,7 +19,11 @@ cluster_certificate_authority_data = "{{ .nuon.install.sandbox.outputs.cluster.c
 codec_endpoint = "https://app.{{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.name }}/admin/temporal-codec"
 ctl_api_host   = "api.{{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.name }}"
 
-db_instance_address    = "{{ .nuon.components.cloudsql_temporal.outputs.address }}"
+# temporal_db_host_override repoints temporal at a recovered Cloud SQL instance
+# (e.g. a PITR clone) without TF state surgery: set the install input to the
+# recovered instance's private IP and redeploy. Clear it to revert. Mirrors
+# ctl-api's db_host_override. See the cloudsql_pitr_restore runbook.
+db_instance_address    = "{{ or .nuon.inputs.inputs.temporal_db_host_override .nuon.components.cloudsql_temporal.outputs.address }}"
 db_instance_port       = "{{ .nuon.components.cloudsql_temporal.outputs.db_instance_port }}"
 temporal_web_image_repository = "{{ .nuon.components.img_temporal_ui.outputs.image.repository }}"
 temporal_web_image_tag        = "{{ .nuon.components.img_temporal_ui.outputs.image.tag }}"

--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -7,8 +7,12 @@ env:
   INTERNAL_MIDDLEWARES: tracer,internal_metrics,error,size,public,log,global,config,admin,offset_pagination,cors,config,patcher,panicker
   GIN_MODE: "release"
 
-  DB_REPLICA_HOST: "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
-  DB_HOST: "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
+  # db_host_override lets an operator repoint ctl-api at a recovered Cloud SQL
+  # instance (e.g. a PITR clone) without TF state surgery: set the install input
+  # to the recovered instance's private IP and redeploy. Clear it to revert to
+  # the Terraform-managed instance. See the cloudsql_pitr_restore_ctl_api runbook.
+  DB_REPLICA_HOST: "{{ or .nuon.inputs.inputs.db_host_override .nuon.components.cloudsql_nuon.outputs.address }}"
+  DB_HOST: "{{ or .nuon.inputs.inputs.db_host_override .nuon.components.cloudsql_nuon.outputs.address }}"
   DB_NAME: "ctl_api"
   DB_USER: "{{ .nuon.components.ctl_api_wi.outputs.db_user }}"
   DB_USE_SSL: "true"

--- a/byoc-nuon-gcp/runbooks/cloudsql_pitr_restore.md
+++ b/byoc-nuon-gcp/runbooks/cloudsql_pitr_restore.md
@@ -1,0 +1,71 @@
+# Cloud SQL PITR restore
+
+Recover **one** control-plane Cloud SQL instance to a point in time and repoint its app at the recovered instance. The
+`target_component` input selects which instance the runbook operates on:
+
+| `target_component` | Source Cloud SQL instance | Redeployed component | Override input             |
+| ------------------ | ------------------------- | -------------------- | -------------------------- |
+| `ctl_api`          | `cloudsql_nuon`           | `ctl_api`            | `db_host_override`         |
+| `temporal`         | `cloudsql_temporal`       | `temporal`           | `temporal_db_host_override`|
+
+Point-in-time recovery (PITR) is enabled on both instances, so their transaction logs are archived continuously and you
+can restore to any moment within the `transaction_log_retention_days` window (default 7 days).
+
+> **PITR is not in-place.** GCP implements PITR as a *clone*: it replays the source instance's transaction logs up to the
+> chosen timestamp into a **brand-new** instance and never touches the live one. Recovery is clone → repoint, not an
+> in-place rollback.
+
+<div style="padding-bottom: 1rem;"><nuon-banner theme="warn">This runbook has a manual operator step between step 1 (clone) and step 2 (repoint). Step 1 creates the recovered instance and reports its private IP; you must set the override input to that IP before step 2 takes effect. If the runbook runs straight through, set the input and re-run step 2.</nuon-banner></div>
+
+## Inputs
+
+- `target_component` — `ctl_api` or `temporal` (see table above). Drives both the clone and the repoint.
+- `point_in_time` — RFC 3339 UTC timestamp, e.g. `2026-07-06T14:30:00Z`. Must be within the retention window and not in
+  the future.
+- `pitr_target_instance_name` *(optional)* — name for the recovered instance. Defaults to `<source>-pitr-<timestamp>`.
+
+## Step 1 — PITR clone
+
+Clones the selected source instance into the new instance and prints the recovered instance's **name** and **private IP**
+(also surfaced as the `CLOUDSQL_PITR_TARGET_INSTANCE` / `CLOUDSQL_PITR_TARGET_ADDRESS` action outputs). The live instance
+is not modified.
+
+## Operator step — set the override
+
+Using the address reported by step 1, set the matching install input (see the table):
+
+```toml
+# target_component = ctl_api
+db_host_override = "<recovered instance private IP>"
+
+# target_component = temporal
+temporal_db_host_override = "<recovered instance private IP>"
+```
+
+`ctl-api.yaml` resolves `DB_HOST` / `DB_REPLICA_HOST` from `db_host_override`, and the `temporal` component resolves
+`db_instance_address` from `temporal_db_host_override`, each falling back to the Terraform-managed instance when unset.
+The recovered instance is a full clone, so its database, users (including IAM auth), and credentials all carry over — no
+credential changes are needed.
+
+## Step 2 — repoint (redeploy)
+
+Redeploys the selected component (`component_name` is templated from `target_component`) so its DB host re-renders to the
+override address. The app is now serving from the recovered instance.
+
+## Reverting
+
+Clear the override input and redeploy the component. The DB host falls back to the Terraform-managed instance.
+
+## Caveats
+
+- The recovered instance is **not** managed by Terraform. It will not receive future config changes from the
+  `cloudsql_*` component and will not be torn down by a normal deprovision. Once you have confirmed recovery, either
+  promote it into Terraform (a state swap — out of scope here) or migrate the data back into the managed instance and
+  delete the recovered one.
+- Both instances run and are billed separately until you delete one.
+- This runbook does not delete the original instance. It stays intact so you can revert.
+- For `temporal`, `temporal_init_db` (schema setup) does not need re-running — the recovered clone already contains the
+  schema.
+- **Platform note:** step 2 relies on `component_deploy.component_name` accepting the `{{ .runbook_inputs.target_component }}`
+  template. This is the first runbook here to template a step field — verify it resolves on the first run; if the engine
+  does not template `component_name`, split step 2 into two role/condition-guarded deploy steps or repoint manually.

--- a/byoc-nuon-gcp/runbooks/cloudsql_pitr_restore.toml
+++ b/byoc-nuon-gcp/runbooks/cloudsql_pitr_restore.toml
@@ -1,0 +1,46 @@
+name        = "cloudsql_pitr_restore"
+description = "Recover ONE control-plane Cloud SQL instance (ctl-api/nuon OR temporal, chosen by the target_component input) to a point in time and repoint its app at the recovered instance. Step 1 clones the source's transaction logs up to the chosen timestamp into a BRAND NEW instance (PITR is not in-place; the live instance is untouched). The operator then sets the override input to the recovered private IP (reported by step 1). Step 2 redeploys the chosen component, which picks up the override. Clear the input and redeploy to revert."
+readme      = "./runbooks/cloudsql_pitr_restore.md"
+labels      = { service = "cloudsql", type = "sop" }
+
+[[input]]
+name         = "target_component"
+display_name = "Target component"
+description  = "Which control-plane database to restore. Use \"ctl_api\" for the ctl-api (nuon) instance, or \"temporal\" for the temporal instance. This selects both the source instance cloned in step 1 and the component redeployed in step 2."
+required     = true
+type         = "string"
+
+[[input]]
+name         = "point_in_time"
+display_name = "Point in time"
+description  = "RFC 3339 UTC timestamp to restore to, e.g. 2026-07-06T14:30:00Z. Must fall within the source's transaction_log_retention_days window (default 7 days) and not be in the future."
+required     = true
+type         = "string"
+
+[[input]]
+name         = "pitr_target_instance_name"
+display_name = "Recovered instance name (optional)"
+description  = "Name for the new recovered instance. Leave blank to default to \"<source>-pitr-<timestamp>\"."
+required     = false
+type         = "string"
+
+# Step 1 — clone the selected instance to a point in time (creates a new instance).
+[[steps]]
+name        = "PITR clone Cloud SQL"
+type        = "action"
+action_name = "cloudsql_pitr_restore"
+
+# ── operator step (between step 1 and step 2, see README) ────────────────────
+# Using the address reported by step 1, set the install input:
+#   target_component = ctl_api  -> db_host_override          = <recovered IP>
+#   target_component = temporal -> temporal_db_host_override = <recovered IP>
+# Then run step 2 (or re-run it if the runbook ran straight through before the
+# input was set).
+
+# Step 2 — repoint: redeploy the selected component so its DB host resolves to
+# the override (the recovered instance). component_name is templated from the
+# same target_component input that drove the clone.
+[[steps]]
+name           = "Repoint app at recovered instance"
+type           = "component_deploy"
+component_name = "{{ .runbook_inputs.target_component }}"

--- a/byoc-nuon-gcp/src/components/cloudsql_nuon/main.tf
+++ b/byoc-nuon-gcp/src/components/cloudsql_nuon/main.tf
@@ -30,6 +30,12 @@ resource "google_sql_database_instance" "nuon" {
       enabled                        = true
       point_in_time_recovery_enabled = true
       start_time                     = "03:00"
+      transaction_log_retention_days = 7
+
+      backup_retention_settings {
+        retained_backups = 7
+        retention_unit   = "COUNT"
+      }
     }
 
     database_flags {

--- a/byoc-nuon-gcp/src/components/cloudsql_temporal/main.tf
+++ b/byoc-nuon-gcp/src/components/cloudsql_temporal/main.tf
@@ -22,6 +22,12 @@ resource "google_sql_database_instance" "temporal" {
       enabled                        = true
       point_in_time_recovery_enabled = true
       start_time                     = "03:00"
+      transaction_log_retention_days = 7
+
+      backup_retention_settings {
+        retained_backups = 7
+        retention_unit   = "COUNT"
+      }
     }
 
     user_labels = {


### PR DESCRIPTION
## Summary

This PR adds a runbook for performing CloudSQL Point-in-Time-Restores. These allow us to restore a CloudSQL database to any point-in-time in the last 7 days. Because PITRs are created as copies of the database, I put together a runbook to handle creating the PITR and then pointing the app at the new instance.