### PR TITLE
feat: dedicated node pool for clickhouse

### DIFF
--- a/byoc-nuon-gcp/components/89-tf-clickhouse_nodepools.toml
+++ b/byoc-nuon-gcp/components/89-tf-clickhouse_nodepools.toml
@@ -6,7 +6,7 @@ terraform_version = "1.11.3"
 [public_repo]
 repo      = "nuonco/byoc"
 directory = "byoc-nuon-gcp/src/components/clickhouse_nodepools"
-branch    = "main"
+branch    = "ja/gke-standard"
 
 [vars]
 install_id       = "{{ .nuon.install.id }}"
@@ -14,3 +14,5 @@ project_id       = "{{ .nuon.install_stack.outputs.project_id }}"
 region           = "{{ .nuon.install_stack.outputs.region }}"
 cluster_name     = "{{ .nuon.sandbox.outputs.cluster.name }}"
 cluster_location = "{{ .nuon.sandbox.outputs.cluster.location }}"
+
+keeper_node_count = "{{ .nuon.inputs.inputs.ch_keeper_node_count }}"

--- a/byoc-nuon-gcp/components/89-tf-clickhouse_nodepools.toml
+++ b/byoc-nuon-gcp/components/89-tf-clickhouse_nodepools.toml
@@ -1,0 +1,16 @@
+#:schema https://api.nuon.co/v1/general/config-schema?type=terraform
+name              = "clickhouse_nodepools"
+type              = "terraform_module"
+terraform_version = "1.11.3"
+
+[public_repo]
+repo      = "nuonco/byoc"
+directory = "byoc-nuon-gcp/src/components/clickhouse_nodepools"
+branch    = "main"
+
+[vars]
+install_id       = "{{ .nuon.install.id }}"
+project_id       = "{{ .nuon.install_stack.outputs.project_id }}"
+region           = "{{ .nuon.install_stack.outputs.region }}"
+cluster_name     = "{{ .nuon.sandbox.outputs.cluster.name }}"
+cluster_location = "{{ .nuon.sandbox.outputs.cluster.location }}"

--- a/byoc-nuon-gcp/components/90-tf-clickhouse_cluster.toml
+++ b/byoc-nuon-gcp/components/90-tf-clickhouse_cluster.toml
@@ -3,7 +3,7 @@ name              = "clickhouse_cluster"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 
-dependencies = ["crd_clickhouse_operator", "gcs_buckets"]
+dependencies = ["crd_clickhouse_operator", "gcs_buckets", "clickhouse_nodepools"]
 
 [public_repo]
 repo      = "nuonco/byoc"

--- a/byoc-nuon-gcp/inputs/clickhouse/keeper_node_count.toml
+++ b/byoc-nuon-gcp/inputs/clickhouse/keeper_node_count.toml
@@ -1,0 +1,7 @@
+name         = "ch_keeper_node_count"
+description  = "Per-zone node count for the clickhouse-keeper node pool (1 => 3 nodes on a regional cluster)."
+default      = "1"
+display_name = "Keeper node count"
+group        = "clickhouse"
+
+user_configurable = false

--- a/byoc-nuon-gcp/src/components/clickhouse_cluster/keeper.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_cluster/keeper.tf
@@ -63,10 +63,21 @@ resource "kubectl_manifest" "clickhouse_keeper_installation" {
                 "runAsUser" = 101
               }
               # spread the 3 keeper replicas onto distinct nodes so a single node failure
-              # cannot take out the raft quorum. the regional pool has >=1 node per zone
-              # (3 zones), so DoNotSchedule/minDomains=3 is satisfiable and naturally
-              # spreads the quorum across zones. label is applied automatically by the CRD.
-              # NOTE: no nodeSelector/tolerations on GCP (single autoscaling pool, no taints).
+              # cannot take out the raft quorum. the dedicated clickhouse-keeper pool runs
+              # exactly 3 nodes (one per zone), so DoNotSchedule/minDomains=3 is satisfiable
+              # and naturally spreads the quorum across zones. label is applied automatically
+              # by the CRD.
+              # pin onto the dedicated clickhouse-keeper node pool (created by the
+              # clickhouse_nodepools component) via its pool.nuon.co taint/label, mirroring AWS.
+              "nodeSelector" = {
+                "pool.nuon.co" = "clickhouse-keeper"
+              }
+              "tolerations" = [{
+                "key"      = "pool.nuon.co"
+                "operator" = "Equal"
+                "value"    = "clickhouse-keeper"
+                "effect"   = "NoSchedule"
+              }]
               "topologySpreadConstraints" = [
                 # hard: the 3 keeper replicas must land on distinct nodes.
                 {

--- a/byoc-nuon-gcp/src/components/clickhouse_cluster/main.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_cluster/main.tf
@@ -93,8 +93,17 @@ resource "kubectl_manifest" "clickhouse_installation" {
             spec = {
               # never co-locate the two replicas on the same node, and best-effort
               # spread them across zones. the label is applied automatically by the CRD.
-              # NOTE: unlike the AWS install there is no dedicated tainted node pool on GCP
-              # (single autoscaling regional pool "main"), so we set no nodeSelector/tolerations.
+              # pin onto the dedicated clickhouse-installation node pool (created by the
+              # clickhouse_nodepools component) via its pool.nuon.co taint/label, mirroring AWS.
+              nodeSelector = {
+                "pool.nuon.co" = "clickhouse-installation"
+              }
+              tolerations = [{
+                key      = "pool.nuon.co"
+                operator = "Equal"
+                value    = "clickhouse-installation"
+                effect   = "NoSchedule"
+              }]
               affinity = {
                 podAntiAffinity = {
                   requiredDuringSchedulingIgnoredDuringExecution = [

--- a/byoc-nuon-gcp/src/components/clickhouse_nodepools/main.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_nodepools/main.tf
@@ -91,7 +91,7 @@ resource "google_container_node_pool" "clickhouse_keeper" {
   location = var.cluster_location
   cluster  = var.cluster_name
 
-  node_count = 1
+  node_count = var.keeper_node_count
 
   management {
     auto_repair  = true

--- a/byoc-nuon-gcp/src/components/clickhouse_nodepools/main.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_nodepools/main.tf
@@ -76,16 +76,22 @@ resource "google_container_node_pool" "clickhouse_installation" {
 
 # clickhouse-keeper pool: exactly 3 replicas, one per zone, to keep the raft
 # quorum spread across zones (matches the keeper topologySpreadConstraints).
+#
+# STATIC pool (node_count, no autoscaling): the keeper podTemplate uses a
+# minDomains=3 / DoNotSchedule topology spread. The cluster autoscaler bootstraps
+# a pool from 0 by simulating a single new node and checking the pod would then
+# schedule -- but one node gives 1 domain < minDomains=3, so the predicate fails
+# and the autoscaler refuses to ever add the first node (deadlock: pool stuck at
+# 0, keeper pods Pending forever). A static pool sidesteps the autoscaler
+# entirely and comes up with all 3 nodes at create time. node_count is per-zone
+# on a regional cluster, so 1 => 3 nodes, one per zone.
 resource "google_container_node_pool" "clickhouse_keeper" {
   name     = "clickhouse-keeper"
   project  = var.project_id
   location = var.cluster_location
   cluster  = var.cluster_name
 
-  autoscaling {
-    total_min_node_count = 3
-    total_max_node_count = 3
-  }
+  node_count = 1
 
   management {
     auto_repair  = true

--- a/byoc-nuon-gcp/src/components/clickhouse_nodepools/main.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_nodepools/main.tf
@@ -1,0 +1,116 @@
+locals {
+  # taint/label key mirrors the AWS install's `pool.nuon.co` convention so the
+  # ClickHouse CRD podTemplates can pin onto these pools via nodeSelector +
+  # tolerations. Values match the AWS nodepool names.
+  pool_key         = "pool.nuon.co"
+  installation_val = "clickhouse-installation"
+  keeper_val       = "clickhouse-keeper"
+}
+
+# Dedicated least-privilege service account for ClickHouse nodes. Required by
+# policies/gke-node-pool-service-account.rego — omitting it defaults to the
+# Compute Engine SA (Editor role) and fails the policy.
+resource "google_service_account" "clickhouse_nodes" {
+  project      = var.project_id
+  account_id   = "ch-nodes-${substr(var.install_id, 0, 12)}"
+  display_name = "ClickHouse GKE nodes for ${var.install_id}"
+}
+
+# Minimal roles a GKE node needs to log, export metrics, and pull images.
+resource "google_project_iam_member" "clickhouse_nodes_roles" {
+  for_each = toset([
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+    "roles/stackdriver.resourceMetadata.writer",
+    "roles/artifactregistry.reader",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.clickhouse_nodes.email}"
+}
+
+# clickhouse-installation (server) pool: 2 replicas with hard anti-affinity, so
+# we need >=2 nodes. Regional pool, so node_locations is inherited from the
+# cluster (one node per zone up to the counts below).
+resource "google_container_node_pool" "clickhouse_installation" {
+  name     = "clickhouse-installation"
+  project  = var.project_id
+  location = var.cluster_location
+  cluster  = var.cluster_name
+
+  # total counts span all zones of the regional cluster.
+  autoscaling {
+    total_min_node_count = 2
+    total_max_node_count = 4
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  node_config {
+    machine_type    = var.installation_machine_type
+    disk_size_gb    = var.installation_disk_size_gb
+    disk_type       = "pd-balanced"
+    service_account = google_service_account.clickhouse_nodes.email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    labels = {
+      (local.pool_key) = local.installation_val
+    }
+
+    taint {
+      key    = local.pool_key
+      value  = local.installation_val
+      effect = "NO_SCHEDULE"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [node_config[0].labels, node_config[0].taint]
+  }
+}
+
+# clickhouse-keeper pool: exactly 3 replicas, one per zone, to keep the raft
+# quorum spread across zones (matches the keeper topologySpreadConstraints).
+resource "google_container_node_pool" "clickhouse_keeper" {
+  name     = "clickhouse-keeper"
+  project  = var.project_id
+  location = var.cluster_location
+  cluster  = var.cluster_name
+
+  autoscaling {
+    total_min_node_count = 3
+    total_max_node_count = 3
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  node_config {
+    machine_type    = var.keeper_machine_type
+    disk_size_gb    = var.keeper_disk_size_gb
+    disk_type       = "pd-balanced"
+    service_account = google_service_account.clickhouse_nodes.email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    labels = {
+      (local.pool_key) = local.keeper_val
+    }
+
+    taint {
+      key    = local.pool_key
+      value  = local.keeper_val
+      effect = "NO_SCHEDULE"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [node_config[0].labels, node_config[0].taint]
+  }
+}

--- a/byoc-nuon-gcp/src/components/clickhouse_nodepools/outputs.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_nodepools/outputs.tf
@@ -1,0 +1,16 @@
+output "node_service_account_email" {
+  value = google_service_account.clickhouse_nodes.email
+}
+
+output "installation_pool_name" {
+  value = google_container_node_pool.clickhouse_installation.name
+}
+
+output "keeper_pool_name" {
+  value = google_container_node_pool.clickhouse_keeper.name
+}
+
+# The nodeSelector/toleration key the ClickHouse CRD podTemplates pin against.
+output "pool_key" {
+  value = local.pool_key
+}

--- a/byoc-nuon-gcp/src/components/clickhouse_nodepools/providers.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_nodepools/providers.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/byoc-nuon-gcp/src/components/clickhouse_nodepools/variables.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_nodepools/variables.tf
@@ -28,9 +28,14 @@ variable "installation_machine_type" {
 }
 
 variable "keeper_machine_type" {
-  type        = string
-  description = "Machine type for the clickhouse-keeper node pool. ~AWS t3a.medium/c5.medium."
-  default     = "e2-medium"
+  type = string
+  # AWS keeper runs on t3a.medium/c5.medium = 2 vCPU. The keeper pod requests
+  # cpu:1 (1000m), which does NOT fit an e2-medium: it's a shared-core type with
+  # only ~940m allocatable CPU after GKE system reservations, so the pod stays
+  # Pending with "Insufficient cpu". e2-standard-2 gives 2 dedicated vCPU
+  # (~1930m allocatable), matching the AWS 2-vCPU keeper node.
+  description = "Machine type for the clickhouse-keeper node pool. ~AWS t3a.medium/c5.medium (2 vCPU)."
+  default     = "e2-standard-2"
 }
 
 variable "installation_disk_size_gb" {

--- a/byoc-nuon-gcp/src/components/clickhouse_nodepools/variables.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_nodepools/variables.tf
@@ -47,3 +47,12 @@ variable "keeper_disk_size_gb" {
   type    = number
   default = 50
 }
+
+variable "keeper_node_count" {
+  type = number
+  # Per-zone count on the regional cluster, so 1 => 3 nodes (one per zone),
+  # matching the keeper's minDomains=3 topology spread. See the static-pool
+  # note on google_container_node_pool.clickhouse_keeper in main.tf.
+  description = "Per-zone node count for the clickhouse-keeper node pool."
+  default     = 1
+}

--- a/byoc-nuon-gcp/src/components/clickhouse_nodepools/variables.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_nodepools/variables.tf
@@ -1,0 +1,44 @@
+variable "install_id" {
+  type = string
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+# The GKE cluster the node pools attach to. For a regional cluster this is the
+# region (e.g. us-central1); the node pools inherit the cluster's node_locations
+# so they span every zone the cluster runs in.
+variable "cluster_name" {
+  type = string
+}
+
+variable "cluster_location" {
+  type = string
+}
+
+variable "installation_machine_type" {
+  type        = string
+  description = "Machine type for the clickhouse-installation (server) node pool. ~AWS t3a.large/c5.large."
+  default     = "e2-standard-2"
+}
+
+variable "keeper_machine_type" {
+  type        = string
+  description = "Machine type for the clickhouse-keeper node pool. ~AWS t3a.medium/c5.medium."
+  default     = "e2-medium"
+}
+
+variable "installation_disk_size_gb" {
+  type    = number
+  default = 100
+}
+
+variable "keeper_disk_size_gb" {
+  type    = number
+  default = 50
+}

--- a/byoc-nuon-gcp/src/components/clickhouse_nodepools/versions.tf
+++ b/byoc-nuon-gcp/src/components/clickhouse_nodepools/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The GCP app config was missing a dedicated node pool for clickhouse, like the AWS config has. This is not strictly required for clickhouse to run -- we've been dogfooding GCP internally and clickhouse has been working fine -- but will cause issues in the long run as a BYOC install accrues data over time.