### PR TITLE
gcp: hide vendor secrets (slack, loops) from install config

### DIFF
--- a/byoc-nuon-gcp/actions/email/ensure_loops_secret/ensure-loops-secret.sh
+++ b/byoc-nuon-gcp/actions/email/ensure_loops_secret/ensure-loops-secret.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# ensure-loops-secret (GCP)
+#
+# ctl-api's LOOPS_API_KEY config is required at boot (services/ctl-api
+# validates it as non-empty), but Loops is no longer an app secret with a
+# Terraform-managed "dne" default — sync_loops_secret writes the real value
+# directly to k8s, out-of-band. This pre-deploy-component hook guarantees the
+# ctl-api-loops-api-key secret exists (with a "dne" placeholder) the first
+# time ctl_api deploys, and is a no-op on every redeploy after that, so a
+# real, previously-synced value is never clobbered.
+#
+# Required env:
+#   NAMESPACE - k8s namespace for ctl-api (default ctl-api).
+set -euo pipefail
+set -o errtrace
+
+: "${NAMESPACE:=ctl-api}"
+
+# pre-deploy-component hooks can run moments after the cluster reports ready,
+# before the API server's networking has fully settled — poll instead of
+# failing on the first transient timeout.
+wait_for_apiserver() {
+  attempts=24
+  i=1
+  while true; do
+    if kubectl get --raw='/healthz' --request-timeout=10s >/dev/null 2>&1; then
+      echo "[ensure_loops_secret] API server reachable (attempt ${i})."
+      return 0
+    fi
+    if [ "$i" -ge "$attempts" ]; then
+      echo "[ensure_loops_secret] ERROR: API server not reachable after ${attempts} attempts (~4m)." >&2
+      kubectl get --raw='/healthz' --request-timeout=10s || true
+      return 1
+    fi
+    i=$((i + 1))
+    sleep 10
+  done
+}
+wait_for_apiserver
+
+if kubectl get secret ctl-api-loops-api-key -n "$NAMESPACE" >/dev/null 2>&1; then
+  echo "ctl-api-loops-api-key already exists in $NAMESPACE; nothing to do."
+  exit 0
+fi
+
+echo "ctl-api-loops-api-key not found in $NAMESPACE; creating placeholder."
+kubectl create secret generic ctl-api-loops-api-key \
+  -n "$NAMESPACE" \
+  --from-literal=value=dne
+
+echo "done"

--- a/byoc-nuon-gcp/actions/email/ensure_loops_secret/ensure_loops_secret.toml
+++ b/byoc-nuon-gcp/actions/email/ensure_loops_secret/ensure_loops_secret.toml
@@ -1,0 +1,26 @@
+# action
+# description: Ensures the ctl-api-loops-api-key k8s secret exists before
+# ctl_api deploys. ctl-api's LOOPS_API_KEY config is required at boot, but
+# Loops is no longer modeled as an app secret (it used to ship a "dne"
+# placeholder default via Terraform) — the central value is only ever wired in
+# out-of-band by sync_loops_secret. This step creates a "dne" placeholder on
+# first deploy only; it never overwrites an existing secret, so a
+# previously-synced real value survives every redeploy.
+name    = "ensure_loops_secret"
+labels  = { service = "email", type = "sop" }
+label   = "email"
+timeout = "2m"
+
+[[triggers]]
+type           = "pre-deploy-component"
+component_name = "ctl_api"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "ensure-placeholder"
+inline_contents = "./email/ensure_loops_secret/ensure-loops-secret.sh"
+
+[steps.env_vars]
+NAMESPACE = "ctl-api"

--- a/byoc-nuon-gcp/runbooks/loops_setup.md
+++ b/byoc-nuon-gcp/runbooks/loops_setup.md
@@ -63,9 +63,11 @@ in step 1. Leave it empty to keep Loops disabled.
 loops_secret_arn = '<arn from loops_secret_arns output>'
 ```
 
-`sync_loops_secret` uses the `secrets_role_arn` input to federate into AWS. The `loops_api_key` value itself is a
-Nuon secret (default `dne` = disabled); the sync step writes the central value into the `ctl-api-loops-api-key` k8s
-secret, which `ctl-api` reads as the `LOOPS_API_KEY` env var.
+`sync_loops_secret` uses the `secrets_role_arn` input to federate into AWS. The `ctl-api-loops-api-key` k8s secret
+(which `ctl-api` reads as the `LOOPS_API_KEY` env var) is no longer an app-level Nuon secret — the `ensure_loops_secret`
+pre-deploy-component step seeds it with a `dne` placeholder (= disabled) the first time `ctl_api` deploys, and this
+sync step overwrites it with the real central value out-of-band. Neither step ever runs Loops config through
+Terraform, so it never appears in a customer-downloadable tfvars file.
 
 ### 4. Run the `Loops: Sync loops secret` step {{ if $loopsSynced }}✅ (completed){{ end }}
 

--- a/byoc-nuon-gcp/secrets/email/loops_api_key.toml
+++ b/byoc-nuon-gcp/secrets/email/loops_api_key.toml
@@ -1,6 +1,0 @@
-name         = "loops_api_key"
-display_name = "Loops API Key"
-description  = "API key from your Loops account. Managed out-of-band: the central AWS Secrets Manager entry referenced by loops_secret_arn is the source of truth, and the sync_loops_secret action writes the value into k8s."
-default      = "dne" # "empty" value — disables Loops integration
-
-user_configurable = false

--- a/byoc-nuon-gcp/secrets/slack/client_secret.toml
+++ b/byoc-nuon-gcp/secrets/slack/client_secret.toml
@@ -1,6 +1,0 @@
-name         = "slack_client_secret"
-display_name = "Slack Client Secret"
-description  = "Client Secret from your Slack app's Basic Information page. Managed out-of-band: the central AWS Secrets Manager entry referenced by slack_secrets_arn is the source of truth, and the sync_slack_secrets action writes the value into k8s."
-default      = "dne" # "empty" value — disables Slack integration
-
-user_configurable = false

--- a/byoc-nuon-gcp/secrets/slack/signing_secret.toml
+++ b/byoc-nuon-gcp/secrets/slack/signing_secret.toml
@@ -1,6 +1,0 @@
-name         = "slack_signing_secret"
-display_name = "Slack Signing Secret"
-description  = "Signing Secret from your Slack app's Basic Information page. Used to verify signed Slack webhook requests (events, slash commands, interactions). Managed out-of-band: the central AWS Secrets Manager entry referenced by slack_secrets_arn is the source of truth, and the sync_slack_secrets action writes the value into k8s."
-default      = "dne" # "empty" value — disables Slack integration
-
-user_configurable = false


### PR DESCRIPTION
## Summary
- Removes slack_client_secret, slack_signing_secret, and loops_api_key from byoc-nuon-gcp's app config. These were only ever placeholders ("dne") consumed via `secrets_tfvars` — the real values are synced directly into k8s by sync_slack_secrets/sync_loops_secret, bypassing Terraform entirely. Keeping them as app secrets meant they showed up in secrets.auto.tfvars downloads, the dashboard's stack-detail view, and got materialized as orphan placeholder secrets in the customer's GCP project.
- Slack secrets are optional in ctl-api's config, so they're just gone now — no replacement needed.
- loops_api_key is required at ctl-api boot (`validate:"required"`), so this adds a new `ensure_loops_secret` action (`pre-deploy-component` trigger on `ctl_api`, same mechanism `ctl_api_init_db` already uses) that creates the `ctl-api-loops-api-key` k8s secret with a `dne` placeholder only if it doesn't already exist — idempotent, never clobbers a real synced value.
- Updates loops_setup.md to describe the new mechanism.

## Test plan
- [ ] Apply to a fresh GCP install and confirm ctl-api boots with LOOPS_API_KEY=dne before sync_loops_secret runs
- [ ] Run sync_loops_secret and sync_slack_secrets runbooks, confirm they still work unchanged
- [ ] Confirm no google_secret_manager_secret resources are created for slack_client_secret/slack_signing_secret/loops_api_key