### PR TITLE
gcp: fix cfn base url rendering non-empty when bucket is unset

### DIFF
--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -72,7 +72,7 @@ env:
   # Bucket
   # This bucket will be used for the install templates and the custom cloudformation stacks
   AWS_CLOUDFORMATION_STACK_TEMPLATE_BUCKET: "{{ .nuon.inputs.inputs.install_stack_template_bucket }}"
-  AWS_CLOUDFORMATION_STACK_TEMPLATE_BASE_URL: "https://{{ .nuon.inputs.inputs.install_stack_template_bucket }}.s3.{{ .nuon.inputs.inputs.install_stack_template_bucket_region }}.amazonaws.com"
+  AWS_CLOUDFORMATION_STACK_TEMPLATE_BASE_URL: "{{ if .nuon.inputs.inputs.install_stack_template_bucket }}https://{{ .nuon.inputs.inputs.install_stack_template_bucket }}.s3.{{ .nuon.inputs.inputs.install_stack_template_bucket_region }}.amazonaws.com{{ end }}"
   AWS_CLOUDFORMATION_STACK_TEMPLATE_BUCKET_REGION: "{{ .nuon.inputs.inputs.install_stack_template_bucket_region }}"
   AWS_CLOUDFORMATION_STACK_TEMPLATE_ROLE_ARN: "{{.nuon.inputs.inputs.install_stack_template_bucket_role_arn}}"
 


### PR DESCRIPTION
## Summary
AWS_CLOUDFORMATION_STACK_TEMPLATE_BASE_URL wraps install_stack_template_bucket in a literal "https://...s3....amazonaws.com" string, so it rendered non-empty ("https://.s3..amazonaws.com") even with the bucket unset — while AWS_CLOUDFORMATION_STACK_TEMPLATE_BUCKET correctly rendered empty. ctl-api's stack-generation code only checked BaseURL to decide the bucket was configured, so it proceeded to upload and failed on the genuinely-empty Bucket field ("Field validation for 'Bucket' failed on the 'required' tag").

Gates BASE_URL behind the same bucket check so it renders truly empty too. Companion fix in nuonco/nuon (checks the Bucket field directly instead of BaseURL) is in nuonco/nuon#1821.

## Test plan
- [ ] GCP install with install_stack_template_bucket unset: confirm ctl-api configmap shows AWS_CLOUDFORMATION_STACK_TEMPLATE_BASE_URL empty, and the "Generate install stack" workflow step no longer fails