### PR TITLE
feat: add new policies and security scanner

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,59 @@
+name: Security Scan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  security-scan:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install OPA
+        run: |
+          curl -sL -o /usr/local/bin/opa https://openpolicyagent.org/downloads/v0.68.0/opa_linux_amd64_static
+          chmod +x /usr/local/bin/opa
+          opa version
+
+      # Layer 1: OPA policy tests — validates that all Rego policies (both
+      # existing and new) are correct and haven't regressed. Tests construct
+      # mock Terraform plan / Helm review inputs and assert deny/warn behavior.
+      - name: OPA policy tests (AWS)
+        run: opa test byoc-nuon/policies/ -v
+
+      - name: OPA policy tests (GCP)
+        if: always()
+        run: opa test byoc-nuon-gcp/policies/ -v
+
+      # Layer 2: Config file checks — covers Nuon platform configuration
+      # (TOML permission files, JSON boundary documents) that aren't Terraform
+      # resources and can't be caught by plan-time Rego policies.
+      - name: Config file checks
+        if: always()
+        run: ./scripts/security-scan.sh
+
+      # Layer 3: Trivy IaC scan — broad static analysis of Terraform HCL
+      # for CIS/AWS/GCP misconfigurations. Produces SARIF for inline PR annotations.
+      - name: Trivy IaC scan
+        if: always()
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          trivyignores: .trivyignore
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,7 @@
+# Trivy IaC scan — suppressed findings
+#
+# Add Trivy rule IDs here to suppress known false positives or accepted risks.
+# Format: one rule ID per line, with an optional comment.
+#
+# Example:
+# AVD-AWS-0107  # S3 bucket logging — not required for install-templates bucket

--- a/byoc-nuon-gcp/policies/cloudsql-data-protection_test.rego
+++ b/byoc-nuon-gcp/policies/cloudsql-data-protection_test.rego
@@ -1,0 +1,48 @@
+package nuon
+
+import future.keywords.if
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+mock_cloudsql(deletion_protection, backup_enabled, pitr_enabled) := {"plan": {"resource_changes": [{
+	"type": "google_sql_database_instance",
+	"address": "google_sql_database_instance.nuon",
+	"change": {
+		"actions": ["create"],
+		"after": {
+			"deletion_protection": deletion_protection,
+			"settings": [{
+				"backup_configuration": [{
+					"enabled": backup_enabled,
+					"point_in_time_recovery_enabled": pitr_enabled,
+				}],
+			}],
+		},
+	},
+}]}}
+
+# ── Deny: deletion_protection = false ────────────────────────────────────────
+
+test_deny_no_deletion_protection if {
+	count(deny) > 0 with input as mock_cloudsql(false, true, true)
+}
+
+# ── Deny: backups disabled ───────────────────────────────────────────────────
+
+test_deny_no_backups if {
+	count(deny) > 0 with input as mock_cloudsql(true, false, true)
+}
+
+# ── Warn: PITR disabled ─────────────────────────────────────────────────────
+
+test_warn_no_pitr if {
+	count(warn) > 0 with input as mock_cloudsql(true, true, false)
+}
+
+# ── Pass: fully protected ───────────────────────────────────────────────────
+
+test_pass_fully_protected if {
+	inp := mock_cloudsql(true, true, true)
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
+}

--- a/byoc-nuon-gcp/policies/gke-node-security.rego
+++ b/byoc-nuon-gcp/policies/gke-node-security.rego
@@ -1,0 +1,71 @@
+# GKE Node Security Policy (sandbox)
+#
+# GKE node pool and cluster settings that affect the security posture of every
+# pod running on the cluster. These checks cover the infrastructure baseline
+# that the Nuon control plane inherits from the sandbox.
+#
+# Checks:
+#   - Secure Boot disabled on node pool                  (warn)
+#   - Binary Authorization disabled on cluster           (warn)
+#   - oauth_scopes includes cloud-platform (too broad)   (warn)
+#
+# Input: Terraform JSON plan from the sandbox run
+#        (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Secure Boot prevents rootkit/bootkit attacks at the firmware level. Disabling
+# it is unrelated to NET_ADMIN or any container-level capability.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "google_container_node_pool"
+	rc.change.actions[_] in ["create", "update"]
+	some cfg in object.get(rc.change.after, "node_config", [])
+	some shield in object.get(cfg, "shielded_instance_config", [])
+	shield.enable_secure_boot == false
+	msg := sprintf(
+		"GKE node pool '%s' has Secure Boot disabled. Enable it to prevent persistent kernel-level compromise.",
+		[rc.address],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Binary Authorization enforces that only attested container images can run on
+# the cluster. Disabling it means any image — including malicious ones — can be
+# deployed.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "google_container_cluster"
+	rc.change.actions[_] in ["create", "update"]
+	some ba in object.get(rc.change.after, "binary_authorization", [])
+	ba.evaluation_mode == "DISABLED"
+	msg := sprintf(
+		"GKE cluster '%s' has Binary Authorization disabled. Enable it to enforce image attestation.",
+		[rc.address],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# The cloud-platform OAuth scope grants access to ALL GCP APIs. While Workload
+# Identity should take precedence for annotated pods, any pod that does NOT use
+# WI inherits the node's scope — full API access via the node SA.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "google_container_node_pool"
+	rc.change.actions[_] in ["create", "update"]
+	some cfg in object.get(rc.change.after, "node_config", [])
+	some scope in object.get(cfg, "oauth_scopes", [])
+	scope == "https://www.googleapis.com/auth/cloud-platform"
+	msg := sprintf(
+		"GKE node pool '%s' uses the cloud-platform OAuth scope (full GCP API access). Restrict to logging.write, monitoring, and devstorage.read_only.",
+		[rc.address],
+	)
+}

--- a/byoc-nuon-gcp/policies/gke-node-security.toml
+++ b/byoc-nuon-gcp/policies/gke-node-security.toml
@@ -1,0 +1,4 @@
+# `sandbox` policies evaluate the sandbox run; the `components` field is ignored.
+type     = "sandbox"
+engine   = "opa"
+contents = "./gke-node-security.rego"

--- a/byoc-nuon-gcp/policies/gke-node-security_test.rego
+++ b/byoc-nuon-gcp/policies/gke-node-security_test.rego
@@ -1,0 +1,64 @@
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+mock_node_pool(secure_boot, oauth_scopes) := {"plan": {"resource_changes": [{
+	"type": "google_container_node_pool",
+	"address": "google_container_node_pool.main",
+	"change": {
+		"actions": ["create"],
+		"after": {"node_config": [{"shielded_instance_config": [{"enable_secure_boot": secure_boot}], "oauth_scopes": oauth_scopes}]},
+	},
+}]}}
+
+mock_cluster(eval_mode) := {"plan": {"resource_changes": [{
+	"type": "google_container_cluster",
+	"address": "google_container_cluster.main",
+	"change": {
+		"actions": ["create"],
+		"after": {"binary_authorization": [{"evaluation_mode": eval_mode}]},
+	},
+}]}}
+
+# Helper: check if any warn message matches a substring.
+has_warn_containing(substr) if {
+	some msg in warn
+	contains(msg, substr)
+}
+
+# ── Warn: Secure Boot disabled ────────────────────────────────────────────────
+
+test_warn_secure_boot_disabled if {
+	has_warn_containing("Secure Boot") with input as mock_node_pool(false, [])
+}
+
+test_no_warn_secure_boot_enabled if {
+	not has_warn_containing("Secure Boot") with input as mock_node_pool(true, [])
+}
+
+# ── Warn: Binary Authorization disabled ──────────────────────────────────────
+
+test_warn_binary_auth_disabled if {
+	has_warn_containing("Binary Authorization") with input as mock_cluster("DISABLED")
+}
+
+test_no_warn_binary_auth_enabled if {
+	not has_warn_containing("Binary Authorization") with input as mock_cluster("PROJECT_SINGLETON_POLICY_ENFORCE")
+}
+
+# ── Warn: cloud-platform OAuth scope ────────────────────────────────────────
+
+test_warn_cloud_platform_scope if {
+	has_warn_containing("cloud-platform OAuth scope") with input as mock_node_pool(true, ["https://www.googleapis.com/auth/cloud-platform"])
+}
+
+test_no_warn_restricted_scopes if {
+	not has_warn_containing("cloud-platform OAuth scope") with input as mock_node_pool(true, [
+		"https://www.googleapis.com/auth/logging.write",
+		"https://www.googleapis.com/auth/monitoring",
+	])
+}

--- a/byoc-nuon-gcp/policies/iam-least-privilege_test.rego
+++ b/byoc-nuon-gcp/policies/iam-least-privilege_test.rego
@@ -1,0 +1,56 @@
+package nuon
+
+import future.keywords.if
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+mock_iam_member(role, member) := {"plan": {"resource_changes": [{
+	"type": "google_project_iam_member",
+	"address": "google_project_iam_member.test",
+	"change": {
+		"actions": ["create"],
+		"after": {
+			"role": role,
+			"member": member,
+			"project": "my-project",
+		},
+	},
+}]}}
+
+# ── Warn: broad project-level roles ──────────────────────────────────────────
+
+test_warn_storage_admin if {
+	count(warn) > 0 with input as mock_iam_member("roles/storage.admin", "serviceAccount:sa@proj.iam.gserviceaccount.com")
+}
+
+test_warn_container_admin if {
+	count(warn) > 0 with input as mock_iam_member("roles/container.admin", "serviceAccount:sa@proj.iam.gserviceaccount.com")
+}
+
+test_warn_dns_admin if {
+	count(warn) > 0 with input as mock_iam_member("roles/dns.admin", "serviceAccount:sa@proj.iam.gserviceaccount.com")
+}
+
+# ── Deny: roles/owner ───────────────────────────────────────────────────────
+
+test_deny_owner if {
+	count(deny) > 0 with input as mock_iam_member("roles/owner", "serviceAccount:sa@proj.iam.gserviceaccount.com")
+}
+
+# ── Deny: allUsers at project level ──────────────────────────────────────────
+
+test_deny_all_users if {
+	count(deny) > 0 with input as mock_iam_member("roles/viewer", "allUsers")
+}
+
+test_deny_all_authenticated_users if {
+	count(deny) > 0 with input as mock_iam_member("roles/viewer", "allAuthenticatedUsers")
+}
+
+# ── Allow: narrow roles ──────────────────────────────────────────────────────
+
+test_allow_log_writer if {
+	inp := mock_iam_member("roles/logging.logWriter", "serviceAccount:sa@proj.iam.gserviceaccount.com")
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
+}

--- a/byoc-nuon-gcp/policies/iam-privilege-escalation.rego
+++ b/byoc-nuon-gcp/policies/iam-privilege-escalation.rego
@@ -1,0 +1,76 @@
+# IAM Privilege Escalation Policy (terraform_module)
+#
+# Certain GCP project-level roles on workload service accounts create direct
+# privilege-escalation paths. A compromised pod with projectIamAdmin can bind
+# roles/owner to itself; with serviceAccountTokenCreator it can mint tokens as
+# any other SA. These must never appear on runtime workload identities.
+#
+# Checks:
+#   - projectIamAdmin on a workload SA                         (deny)
+#   - serviceAccountAdmin + serviceAccountUser combo           (warn)
+#   - serviceAccountTokenCreator on a workload SA              (warn)
+#
+# Input: Terraform JSON plan (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+project_iam_resources := {"google_project_iam_member", "google_project_iam_binding"}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# roles/resourcemanager.projectIamAdmin is the single most dangerous role to
+# grant a workload SA. It can modify ANY IAM binding in the project — including
+# binding roles/owner to the SA itself. This is a one-hop escalation to full
+# project ownership from any compromised pod.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in project_iam_resources
+	rc.change.actions[_] in ["create", "update"]
+	rc.change.after.role == "roles/resourcemanager.projectIamAdmin"
+	msg := sprintf(
+		"IAM binding '%s' grants roles/resourcemanager.projectIamAdmin. This allows the SA to modify any IAM binding (including granting itself roles/owner). Use resource-level IAM bindings instead.",
+		[rc.address],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# roles/iam.serviceAccountAdmin lets the SA create new service accounts and
+# manage their keys. Combined with serviceAccountUser (ability to impersonate),
+# this allows creating arbitrary identities.
+#
+# Warned because it's currently required for org runner provisioning.
+# TODO: scope to a name prefix or replace with a custom role.
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in project_iam_resources
+	rc.change.actions[_] in ["create", "update"]
+	rc.change.after.role == "roles/iam.serviceAccountAdmin"
+	msg := sprintf(
+		"IAM binding '%s' grants roles/iam.serviceAccountAdmin at the project level. The SA can create/manage any service account. Scope to a name prefix or use a custom role.",
+		[rc.address],
+	)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# roles/iam.serviceAccountTokenCreator lets the SA mint OAuth/OIDC tokens as
+# ANY service account in the project. Combined with a privileged SA, this is
+# an impersonation escalation path.
+#
+# Warned because it's currently required for GCS signed URL generation.
+# TODO: move to SA-scoped token creator (on the specific SA, not project-level).
+# ──────────────────────────────────────────────────────────────────────────────
+warn contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in project_iam_resources
+	rc.change.actions[_] in ["create", "update"]
+	rc.change.after.role == "roles/iam.serviceAccountTokenCreator"
+	msg := sprintf(
+		"IAM binding '%s' grants roles/iam.serviceAccountTokenCreator at the project level. The SA can mint tokens as any SA. Scope to the specific SA that needs signing.",
+		[rc.address],
+	)
+}

--- a/byoc-nuon-gcp/policies/iam-privilege-escalation.toml
+++ b/byoc-nuon-gcp/policies/iam-privilege-escalation.toml
@@ -1,0 +1,4 @@
+type       = "terraform_module"
+engine     = "opa"
+contents   = "./iam-privilege-escalation.rego"
+components = ["*"]

--- a/byoc-nuon-gcp/policies/iam-privilege-escalation_test.rego
+++ b/byoc-nuon-gcp/policies/iam-privilege-escalation_test.rego
@@ -1,0 +1,37 @@
+package nuon
+
+import future.keywords.if
+
+# Uses mock_iam_member from iam-least-privilege_test.rego (same package, same directory).
+
+# ── Deny: projectIamAdmin ────────────────────────────────────────────────────
+
+test_deny_project_iam_admin if {
+	count(deny) > 0 with input as mock_iam_member("roles/resourcemanager.projectIamAdmin", "serviceAccount:test@project.iam.gserviceaccount.com")
+}
+
+# ── Warn: serviceAccountAdmin ────────────────────────────────────────────────
+
+test_warn_sa_admin if {
+	count(warn) > 0 with input as mock_iam_member("roles/iam.serviceAccountAdmin", "serviceAccount:test@project.iam.gserviceaccount.com")
+}
+
+# ── Warn: serviceAccountTokenCreator ─────────────────────────────────────────
+
+test_warn_token_creator if {
+	count(warn) > 0 with input as mock_iam_member("roles/iam.serviceAccountTokenCreator", "serviceAccount:test@project.iam.gserviceaccount.com")
+}
+
+# ── Allow: safe roles ────────────────────────────────────────────────────────
+
+test_allow_cloudsql_client if {
+	inp := mock_iam_member("roles/cloudsql.client", "serviceAccount:test@project.iam.gserviceaccount.com")
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
+}
+
+test_allow_logging_writer if {
+	inp := mock_iam_member("roles/logging.logWriter", "serviceAccount:test@project.iam.gserviceaccount.com")
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
+}

--- a/byoc-nuon/policies/iam-assume-role-scope.rego
+++ b/byoc-nuon/policies/iam-assume-role-scope.rego
@@ -1,0 +1,62 @@
+# IAM AssumeRole Scope Policy (terraform_module)
+#
+# sts:AssumeRole on Resource:"*" in a permission policy allows a workload to
+# assume ANY role in the customer's account — including provision, deprovision,
+# and break-glass roles. This is the most direct privilege-escalation vector in
+# the control plane: one compromised pod → full account takeover.
+#
+# Checks:
+#   - sts:AssumeRole on Resource "*" in a permission policy   (deny)
+#
+# Input: Terraform JSON plan (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+iam_policy_resources := {"aws_iam_policy", "aws_iam_role_policy", "aws_iam_user_policy"}
+
+assume_role_actions := {"sts:AssumeRole", "sts:*"}
+
+# Helpers ─────────────────────────────────────────────────────────────────────
+parse_policy(s) := json.unmarshal(s)
+
+statements(doc) := s if {
+	is_array(doc.Statement)
+	s := doc.Statement
+} else := [doc.Statement] if {
+	is_object(doc.Statement)
+}
+
+to_set(x) := {x} if {
+	is_string(x)
+}
+
+to_set(x) := {v | some v in x} if {
+	is_array(x)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Deny sts:AssumeRole on Resource "*" in permission policies.
+#
+# Trust policies (aws_iam_role.assume_role_policy) define who can assume a role
+# and are not caught here — they use a different resource type. Permission
+# policies (aws_iam_policy) define what the role can do — sts:AssumeRole on *
+# there means the workload can assume any role in the account.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in iam_policy_resources
+	rc.change.actions[_] in ["create", "update"]
+	some stmt in statements(parse_policy(rc.change.after.policy))
+	stmt.Effect == "Allow"
+	some action in to_set(stmt.Action)
+	action in assume_role_actions
+	"*" in to_set(stmt.Resource)
+	msg := sprintf(
+		"IAM policy '%s' grants '%s' on Resource \"*\". A compromised workload could assume any role in the account (including admin/break-glass). Restrict Resource to specific role ARNs.",
+		[rc.address, action],
+	)
+}

--- a/byoc-nuon/policies/iam-assume-role-scope.toml
+++ b/byoc-nuon/policies/iam-assume-role-scope.toml
@@ -1,0 +1,4 @@
+type       = "terraform_module"
+engine     = "opa"
+contents   = "./iam-assume-role-scope.rego"
+components = ["*"]

--- a/byoc-nuon/policies/iam-assume-role-scope_test.rego
+++ b/byoc-nuon/policies/iam-assume-role-scope_test.rego
@@ -1,0 +1,55 @@
+package nuon
+
+import future.keywords.if
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+mock_plan(policy_json) := {"plan": {"resource_changes": [{
+	"type": "aws_iam_policy",
+	"address": "aws_iam_policy.test",
+	"change": {
+		"actions": ["create"],
+		"after": {"policy": policy_json},
+	},
+}]}}
+
+policy_doc(actions, resources) := json.marshal({
+	"Version": "2012-10-17",
+	"Statement": [{"Effect": "Allow", "Action": actions, "Resource": resources}],
+})
+
+# ── Deny: sts:AssumeRole on * ────────────────────────────────────────────────
+
+test_deny_assume_role_wildcard if {
+	inp := mock_plan(policy_doc(["sts:AssumeRole"], ["*"]))
+	count(deny) > 0 with input as inp
+}
+
+test_deny_sts_star_wildcard if {
+	inp := mock_plan(policy_doc(["sts:*"], ["*"]))
+	count(deny) > 0 with input as inp
+}
+
+# ── Allow: sts:AssumeRole scoped to specific ARN ─────────────────────────────
+
+test_allow_assume_role_scoped if {
+	inp := mock_plan(policy_doc(
+		["sts:AssumeRole"],
+		["arn:aws:iam::123456789012:role/specific-role"],
+	))
+	count(deny) == 0 with input as inp
+}
+
+# ── Allow: non-STS actions on * are not flagged by THIS policy ────────────────
+
+test_allow_s3_wildcard_not_flagged if {
+	inp := mock_plan(policy_doc(["s3:GetObject"], ["*"]))
+	count(deny) == 0 with input as inp
+}
+
+# ── Allow: sts:AssumeRoleWithWebIdentity on * (OIDC federation, always scoped by condition) ──
+
+test_allow_assume_role_web_identity if {
+	inp := mock_plan(policy_doc(["sts:AssumeRoleWithWebIdentity"], ["*"]))
+	count(deny) == 0 with input as inp
+}

--- a/byoc-nuon/policies/iam-least-privilege_test.rego
+++ b/byoc-nuon/policies/iam-least-privilege_test.rego
@@ -1,0 +1,83 @@
+package nuon
+
+import future.keywords.if
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+mock_policy(policy_json) := {"plan": {"resource_changes": [{
+	"type": "aws_iam_policy",
+	"address": "aws_iam_policy.test",
+	"change": {
+		"actions": ["create"],
+		"after": {"policy": policy_json},
+	},
+}]}}
+
+mock_attachment(policy_arn) := {"plan": {"resource_changes": [{
+	"type": "aws_iam_role_policy_attachment",
+	"address": "aws_iam_role_policy_attachment.test",
+	"change": {
+		"actions": ["create"],
+		"after": {"policy_arn": policy_arn},
+	},
+}]}}
+
+policy_doc(actions, resources) := json.marshal({
+	"Version": "2012-10-17",
+	"Statement": [{"Effect": "Allow", "Action": actions, "Resource": resources}],
+})
+
+# ── Warn: service-wide wildcards ──────────────────────────────────────────────
+
+test_warn_s3_star if {
+	inp := mock_policy(policy_doc(["s3:*"], ["*"]))
+	count(warn) > 0 with input as inp
+}
+
+test_warn_iam_star if {
+	inp := mock_policy(policy_doc(["iam:*"], ["*"]))
+	count(warn) > 0 with input as inp
+}
+
+test_warn_kms_star if {
+	inp := mock_policy(policy_doc(["kms:*"], ["*"]))
+	count(warn) > 0 with input as inp
+}
+
+test_warn_full_star if {
+	inp := mock_policy(policy_doc(["*"], ["*"]))
+	count(warn) > 0 with input as inp
+}
+
+# ── No warn: scoped actions ──────────────────────────────────────────────────
+
+test_no_warn_scoped_actions if {
+	inp := mock_policy(policy_doc(["s3:GetObject", "s3:PutObject"], ["arn:aws:s3:::my-bucket/*"]))
+	count(warn) == 0 with input as inp
+}
+
+# ── Warn: write actions on Resource * ────────────────────────────────────────
+
+test_warn_create_on_star if {
+	inp := mock_policy(policy_doc(["s3:CreateBucket"], ["*"]))
+	count(warn) > 0 with input as inp
+}
+
+test_warn_delete_on_star if {
+	inp := mock_policy(policy_doc(["iam:DeleteRole"], ["*"]))
+	count(warn) > 0 with input as inp
+}
+
+# ── Deny: AdministratorAccess attachment ─────────────────────────────────────
+
+test_deny_admin_access_attachment if {
+	inp := mock_attachment("arn:aws:iam::aws:policy/AdministratorAccess")
+	count(deny) > 0 with input as inp
+}
+
+# ── Allow: non-admin attachment ──────────────────────────────────────────────
+
+test_allow_normal_attachment if {
+	inp := mock_attachment("arn:aws:iam::aws:policy/ReadOnlyAccess")
+	count(deny) == 0 with input as inp
+}

--- a/byoc-nuon/policies/rds-data-protection_test.rego
+++ b/byoc-nuon/policies/rds-data-protection_test.rego
@@ -1,0 +1,98 @@
+package nuon
+
+import future.keywords.if
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+mock_rds(fields) := {"plan": {"resource_changes": [{
+	"type": "aws_db_instance",
+	"address": "module.db.aws_db_instance.this",
+	"change": {
+		"actions": ["create"],
+		"after": fields,
+	},
+}]}}
+
+mock_param_group(params) := {"plan": {"resource_changes": [{
+	"type": "aws_db_parameter_group",
+	"address": "module.db.aws_db_parameter_group.this",
+	"change": {
+		"actions": ["create"],
+		"after": {"parameter": params},
+	},
+}]}}
+
+# ── Deny: skip_final_snapshot = true ─────────────────────────────────────────
+
+test_deny_skip_final_snapshot if {
+	inp := mock_rds({
+		"skip_final_snapshot": true,
+		"deletion_protection": true,
+		"storage_encrypted": true,
+		"backup_retention_period": 7,
+	})
+	count(deny) > 0 with input as inp
+}
+
+# ── Deny: storage_encrypted = false ──────────────────────────────────────────
+
+test_deny_unencrypted_storage if {
+	inp := mock_rds({
+		"skip_final_snapshot": false,
+		"deletion_protection": true,
+		"storage_encrypted": false,
+		"backup_retention_period": 7,
+	})
+	count(deny) > 0 with input as inp
+}
+
+# ── Warn: force_ssl = 0 ─────────────────────────────────────────────────────
+
+test_warn_ssl_disabled if {
+	inp := mock_param_group([{"name": "rds.force_ssl", "value": "0"}])
+	count(warn) > 0 with input as inp
+}
+
+# ── No warn: force_ssl = 1 ──────────────────────────────────────────────────
+
+test_no_warn_ssl_enabled if {
+	inp := mock_param_group([{"name": "rds.force_ssl", "value": "1"}])
+	count(warn) == 0 with input as inp
+}
+
+# ── Warn: deletion_protection = false ────────────────────────────────────────
+
+test_warn_no_deletion_protection if {
+	inp := mock_rds({
+		"skip_final_snapshot": false,
+		"deletion_protection": false,
+		"storage_encrypted": true,
+		"backup_retention_period": 7,
+	})
+	count(warn) > 0 with input as inp
+}
+
+# ── Warn: low backup retention ───────────────────────────────────────────────
+
+test_warn_low_backup_retention if {
+	inp := mock_rds({
+		"skip_final_snapshot": false,
+		"deletion_protection": true,
+		"storage_encrypted": true,
+		"backup_retention_period": 3,
+	})
+	count(warn) > 0 with input as inp
+}
+
+# ── Pass: all protections enabled ────────────────────────────────────────────
+
+test_pass_fully_protected if {
+	inp := mock_rds({
+		"skip_final_snapshot": false,
+		"deletion_protection": true,
+		"storage_encrypted": true,
+		"backup_retention_period": 14,
+	})
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
+}

--- a/byoc-nuon/policies/sg-protocol-restriction.rego
+++ b/byoc-nuon/policies/sg-protocol-restriction.rego
@@ -1,0 +1,57 @@
+# Security Group Protocol Restriction Policy (terraform_module)
+#
+# A security group rule with protocol = "-1" (all protocols, all ports) from any
+# source grants unrestricted network access. Even when scoped to a single source
+# SG, this is over-broad — a compromised runner or node can reach every port on
+# every node in the cluster (kubelet 10250, node ports, etcd 2379, etc.).
+#
+# Checks:
+#   - deny security group rules with protocol "-1" (all traffic)   (deny)
+#
+# Input: Terraform JSON plan (input.plan.resource_changes).
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+sg_rule_resources := {
+	"aws_security_group_rule",
+	"aws_vpc_security_group_ingress_rule",
+	"aws_vpc_security_group_egress_rule",
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Deny security group rules that allow all protocols / all ports.
+#
+# protocol = "-1" means all IP protocols (TCP, UDP, ICMP, etc.) on all ports.
+# This is almost never what is intended — it should be scoped to port 443
+# (API server), port 10250 (kubelet), or whatever the workload actually needs.
+# ──────────────────────────────────────────────────────────────────────────────
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type in sg_rule_resources
+	rc.change.actions[_] in ["create", "update"]
+	rc.change.after.protocol == "-1"
+	msg := sprintf(
+		"Security group rule '%s' uses protocol=-1 (all protocols, all ports). Restrict to the specific ports the workload requires (e.g. 443 for API server).",
+		[rc.address],
+	)
+}
+
+# Also catch inline ingress/egress blocks inside aws_security_group resources.
+deny contains msg if {
+	some rc in input.plan.resource_changes
+	rc.type == "aws_security_group"
+	rc.change.actions[_] in ["create", "update"]
+	some rule in array.concat(
+		object.get(rc.change.after, "ingress", []),
+		object.get(rc.change.after, "egress", []),
+	)
+	rule.protocol == "-1"
+	msg := sprintf(
+		"Security group '%s' has an inline rule with protocol=-1 (all protocols, all ports). Restrict to the specific ports the workload requires.",
+		[rc.address],
+	)
+}

--- a/byoc-nuon/policies/sg-protocol-restriction.toml
+++ b/byoc-nuon/policies/sg-protocol-restriction.toml
@@ -1,0 +1,4 @@
+type       = "terraform_module"
+engine     = "opa"
+contents   = "./sg-protocol-restriction.rego"
+components = ["*"]

--- a/byoc-nuon/policies/sg-protocol-restriction_test.rego
+++ b/byoc-nuon/policies/sg-protocol-restriction_test.rego
@@ -1,0 +1,54 @@
+package nuon
+
+import future.keywords.if
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+mock_sg_rule(protocol) := {"plan": {"resource_changes": [{
+	"type": "aws_security_group_rule",
+	"address": "aws_security_group_rule.test",
+	"change": {
+		"actions": ["create"],
+		"after": {"protocol": protocol, "type": "ingress"},
+	},
+}]}}
+
+mock_sg_inline(protocol) := {"plan": {"resource_changes": [{
+	"type": "aws_security_group",
+	"address": "aws_security_group.test",
+	"change": {
+		"actions": ["create"],
+		"after": {
+			"ingress": [{"protocol": protocol, "from_port": 0, "to_port": 65535, "cidr_blocks": ["10.0.0.0/8"]}],
+			"egress": [],
+		},
+	},
+}]}}
+
+# ── Deny: protocol = -1 on standalone rule ────────────────────────────────────
+
+test_deny_all_protocol_rule if {
+	count(deny) > 0 with input as mock_sg_rule("-1")
+}
+
+# ── Allow: specific protocol ──────────────────────────────────────────────────
+
+test_allow_tcp_rule if {
+	count(deny) == 0 with input as mock_sg_rule("tcp")
+}
+
+test_allow_protocol_6 if {
+	count(deny) == 0 with input as mock_sg_rule("6")
+}
+
+# ── Deny: protocol = -1 on inline block ──────────────────────────────────────
+
+test_deny_all_protocol_inline if {
+	count(deny) > 0 with input as mock_sg_inline("-1")
+}
+
+# ── Allow: specific protocol inline ──────────────────────────────────────────
+
+test_allow_tcp_inline if {
+	count(deny) == 0 with input as mock_sg_inline("tcp")
+}

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# security-scan.sh — Static security checks for Nuon BYOC configuration files.
+#
+# This script covers the checks that CANNOT be expressed as Rego policies
+# because they target Nuon platform configuration (TOML permission files, JSON
+# boundary documents) rather than Terraform plan resources.
+#
+# For Terraform-level checks, see the OPA/Rego policies in:
+#   byoc-nuon/policies/       (AWS)
+#   byoc-nuon-gcp/policies/   (GCP)
+#
+# Exit codes:
+#   0 — all checks passed (warnings may be present)
+#   1 — one or more error-level findings detected
+
+set -euo pipefail
+
+ERRORS=0
+WARNINGS=0
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+warn() {
+  local file="$1" line="$2" id="$3" msg="$4"
+  WARNINGS=$((WARNINGS + 1))
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::warning file=${file},line=${line}::${id}: ${msg}"
+  else
+    printf "\033[33mWARN\033[0m  %s:%s  %s: %s\n" "$file" "$line" "$id" "$msg"
+  fi
+}
+
+error() {
+  local file="$1" line="$2" id="$3" msg="$4"
+  ERRORS=$((ERRORS + 1))
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::error file=${file},line=${line}::${id}: ${msg}"
+  else
+    printf "\033[31mERROR\033[0m %s:%s  %s: %s\n" "$file" "$line" "$id" "$msg"
+  fi
+}
+
+# ─── SEC-001: AdministratorAccess or roles/owner in lifecycle roles ───────────
+#
+# These are Nuon platform configs (.toml), not Terraform resources, so they
+# can't be caught by plan-time Rego policies.
+check_lifecycle_admin() {
+  local id="SEC-001"
+  local msg="Lifecycle role uses AdministratorAccess or roles/owner. Replace with least-privilege policy derived from audit logs."
+
+  for dir in byoc-nuon/permissions byoc-nuon-gcp/permissions; do
+    [[ -d "$dir" ]] || continue
+    for f in "$dir"/provision.toml "$dir"/deprovision.toml "$dir"/maintenance.toml; do
+      [[ -f "$f" ]] || continue
+      local results
+      results=$(grep -n -E '(AdministratorAccess|roles/owner)' "$f" 2>/dev/null || true)
+      while IFS= read -r match; do
+        [[ -z "$match" ]] && continue
+        local line
+        line=$(echo "$match" | cut -d: -f1)
+        warn "$f" "$line" "$id" "$msg"
+      done <<< "$results"
+    done
+  done
+}
+
+# ─── SEC-002: Boundary policy with Action:* + Resource:* ─────────────────────
+#
+# Permissions boundary JSON files are Nuon platform configs referenced by
+# permission .toml files. A boundary that allows everything provides no
+# effective guardrail.
+check_wildcard_boundaries() {
+  local id="SEC-002"
+  local msg="Permissions boundary grants Action:* Resource:* — provides no effective constraint."
+
+  for dir in byoc-nuon/permissions/boundaries byoc-nuon-gcp/permissions/boundaries; do
+    [[ -d "$dir" ]] || continue
+    for f in "$dir"/*.json; do
+      [[ -f "$f" ]] || continue
+      local has_wildcard
+      has_wildcard=$(jq -r '
+        .Statement[]?
+        | select(
+            (.Action == "*" or .Action == ["*"]) and
+            (.Resource == "*" or .Resource == ["*"])
+          )
+        | "found"
+      ' "$f" 2>/dev/null || true)
+
+      if [[ "$has_wildcard" == *"found"* ]]; then
+        local line
+        line=$(grep -n '"Action"' "$f" 2>/dev/null | head -1 | cut -d: -f1)
+        line=${line:-1}
+        error "$f" "$line" "$id" "$msg"
+      fi
+    done
+  done
+}
+
+# ─── SEC-003: Service-wide wildcards in boundary/policy JSON ──────────────────
+#
+# The boundary and base-policy JSON files define the ceiling for what lifecycle
+# roles can do. Service-wide wildcards here (iam:*, s3:*, etc.) are too broad.
+check_wildcard_actions_json() {
+  local id="SEC-003"
+  local msg="Policy/boundary JSON contains service-wide wildcard action. Scope to specific actions."
+
+  for dir in byoc-nuon/permissions/policies byoc-nuon/permissions/boundaries \
+             byoc-nuon-gcp/permissions/policies byoc-nuon-gcp/permissions/boundaries; do
+    [[ -d "$dir" ]] || continue
+    for f in "$dir"/*.json; do
+      [[ -f "$f" ]] || continue
+      local results
+      results=$(grep -n -E '"(s3|iam|kms|ecr|sts|route53|ec2|rds|ecr-public):\*"' "$f" 2>/dev/null || true)
+      while IFS= read -r match; do
+        [[ -z "$match" ]] && continue
+        local line
+        line=$(echo "$match" | cut -d: -f1)
+        warn "$f" "$line" "$id" "$msg"
+      done <<< "$results"
+    done
+  done
+}
+
+# ─── SEC-004: Missing boundary reference ─────────────────────────────────────
+#
+# Every lifecycle permission .toml should reference a boundary file. An empty
+# permissions_boundary means the role is unconstrained.
+check_missing_boundary() {
+  local id="SEC-004"
+  local msg="Permission role has no permissions_boundary. Add one to constrain the role's effective permissions."
+
+  for dir in byoc-nuon/permissions byoc-nuon-gcp/permissions; do
+    [[ -d "$dir" ]] || continue
+    for f in "$dir"/provision.toml "$dir"/deprovision.toml "$dir"/maintenance.toml; do
+      [[ -f "$f" ]] || continue
+      # Check if permissions_boundary is missing or empty
+      if ! grep -q 'permissions_boundary' "$f" 2>/dev/null; then
+        warn "$f" "1" "$id" "$msg"
+      elif grep -q 'permissions_boundary\s*=\s*""' "$f" 2>/dev/null; then
+        local line
+        line=$(grep -n 'permissions_boundary' "$f" | head -1 | cut -d: -f1)
+        warn "$f" "$line" "$id" "$msg"
+      fi
+    done
+  done
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  echo "============================================"
+  echo "  Nuon BYOC Config Scanner"
+  echo "  (Nuon platform config checks)"
+  echo "============================================"
+  echo ""
+
+  check_lifecycle_admin
+  check_wildcard_boundaries
+  check_wildcard_actions_json
+  check_missing_boundary
+
+  echo ""
+  echo "============================================"
+  echo "  Results: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+  echo "============================================"
+
+  if [[ $ERRORS -gt 0 ]]; then
+    echo ""
+    echo "Config scan FAILED — ${ERRORS} error-level finding(s) must be resolved."
+    exit 1
+  fi
+
+  if [[ $WARNINGS -gt 0 ]]; then
+    echo ""
+    echo "Config scan PASSED with ${WARNINGS} warning(s) — review before merging."
+    exit 0
+  fi
+
+  echo ""
+  echo "Config scan PASSED — no findings."
+  exit 0
+}
+
+main "$@"


### PR DESCRIPTION
This PR is a spike on adding some automated security testing in the repo here. Some things it includes:

1. [Trivy](https://trivy.dev/) spike, to include scans on PRs.
1. Manual, `security-scan.sh` script to check for common things such as permissions in the nuon app.
1. Some improved policies for the nuon app config.

Nuon currently does not have a way to measure app policies, and instead defers those to the customers. Thus, it's easy 
to "request" admin permissions. This scanner should be a stop gap until we enable policies for those in the platform.
