### PR TITLE
drop public binding on install templates bucket, enforce pap

### DIFF
--- a/byoc-nuon-gcp/actions/gcp/gcs_delete/gcs_delete.sh
+++ b/byoc-nuon-gcp/actions/gcp/gcs_delete/gcs_delete.sh
@@ -19,13 +19,11 @@ set -u
 # Required env (set in the action from the gcs_buckets component outputs):
 #   BLOB_BUCKET        blob bucket name (blob_bucket.name output)
 #   CLICKHOUSE_BUCKET  clickhouse bucket name (clickhouse_bucket.name output)
-#   TEMPLATES_BUCKET   install-templates bucket name (install_template_bucket.name output)
 # Optional env:
 #   PROJECT_ID         the GCP project id (for explicit --project on bucket ops)
 
 : "${BLOB_BUCKET:?BLOB_BUCKET is required}"
 : "${CLICKHOUSE_BUCKET:?CLICKHOUSE_BUCKET is required}"
-: "${TEMPLATES_BUCKET:?TEMPLATES_BUCKET is required}"
 project_id="${PROJECT_ID:-}"
 
 # gcloud storage accepts a --project flag; only pass it when we have one.
@@ -67,7 +65,7 @@ empty_and_delete_bucket() {
   echo "  deleted ${b}"
 }
 
-for b in "$BLOB_BUCKET" "$CLICKHOUSE_BUCKET" "$TEMPLATES_BUCKET"; do
+for b in "$BLOB_BUCKET" "$CLICKHOUSE_BUCKET"; do
   echo ""
   echo "Bucket: ${b}"
   empty_and_delete_bucket "$b"

--- a/byoc-nuon-gcp/actions/gcp/gcs_delete/gcs_delete.toml
+++ b/byoc-nuon-gcp/actions/gcp/gcs_delete/gcs_delete.toml
@@ -22,5 +22,4 @@ inline_contents = "./gcp/gcs_delete/gcs_delete.sh"
 # component outputs — so these still resolve after the component is torn down.
 BLOB_BUCKET       = "{{ .nuon.install.id }}-byoc-nuon-install-blob"
 CLICKHOUSE_BUCKET = "{{ .nuon.install.id }}-nuon-clickhouse"
-TEMPLATES_BUCKET  = "{{ .nuon.install.id }}-byoc-nuon-install-templates"
 PROJECT_ID        = "{{ .nuon.install_stack.outputs.project_id }}"

--- a/byoc-nuon-gcp/actions/gcp/gcs_state_rm/gcs_state_rm.toml
+++ b/byoc-nuon-gcp/actions/gcp/gcs_state_rm/gcs_state_rm.toml
@@ -22,6 +22,6 @@ inline_contents = "./tf/state_rm/state_rm.sh"
 
 [steps.env_vars]
 INSTALL_COMPONENT_ID = "{{ .nuon.components.gcs_buckets.install_component_id }}"
-STATE_ADDRESSES      = "google_storage_bucket.clickhouse,google_storage_bucket.install_templates,google_storage_bucket_iam_member.install_templates_public_read,google_storage_bucket.blob"
+STATE_ADDRESSES      = "google_storage_bucket.clickhouse,google_storage_bucket.blob"
 TF_VERSION           = "1.11.3"
 LABEL                = "gcs_buckets"

--- a/byoc-nuon-gcp/actions/gcp/gcs_teardown/gcs_teardown.toml
+++ b/byoc-nuon-gcp/actions/gcp/gcs_teardown/gcs_teardown.toml
@@ -32,7 +32,7 @@ inline_contents = "./tf/state_rm/state_rm.sh"
 
 [steps.env_vars]
 INSTALL_COMPONENT_ID = "{{ .nuon.components.gcs_buckets.install_component_id }}"
-STATE_ADDRESSES      = "google_storage_bucket.clickhouse,google_storage_bucket.install_templates,google_storage_bucket_iam_member.install_templates_public_read,google_storage_bucket.blob"
+STATE_ADDRESSES      = "google_storage_bucket.clickhouse,google_storage_bucket.blob"
 TF_VERSION           = "1.11.3"
 LABEL                = "gcs_buckets"
 
@@ -45,5 +45,4 @@ inline_contents = "./gcp/gcs_delete/gcs_delete.sh"
 # outputs — robust even if the outputs are unavailable at teardown time.
 BLOB_BUCKET       = "{{ .nuon.install.id }}-byoc-nuon-install-blob"
 CLICKHOUSE_BUCKET = "{{ .nuon.install.id }}-nuon-clickhouse"
-TEMPLATES_BUCKET  = "{{ .nuon.install.id }}-byoc-nuon-install-templates"
 PROJECT_ID        = "{{ .nuon.install_stack.outputs.project_id }}"

--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -67,7 +67,6 @@ env:
 
   # GCP: install templates bucket
   # NOTE: keeping this for a few cycles but we must, ultimately, remove it
-  GCS_INSTALL_TEMPLATE_BUCKET: "{{ .nuon.components.gcs_buckets.outputs.install_template_bucket.name }}"
 
   # Bucket
   # This bucket will be used for the install templates and the custom cloudformation stacks

--- a/byoc-nuon-gcp/policies/gcs-data-protection.rego
+++ b/byoc-nuon-gcp/policies/gcs-data-protection.rego
@@ -23,7 +23,7 @@ public_members := {"allUsers", "allAuthenticatedUsers"}
 # Buckets that are intentionally public: the install-templates bucket serves
 # install templates that the customer's GCP project fetches over public HTTPS,
 # so its allUsers objectViewer grant is deliberate.
-intentionally_public_buckets := {"install_templates"}
+intentionally_public_buckets := set()
 
 # Buckets that hold immutable backup objects and do not require versioning.
 unversioned_ok_buckets := {"clickhouse"}

--- a/byoc-nuon-gcp/policies/gcs-data-protection_test.rego
+++ b/byoc-nuon-gcp/policies/gcs-data-protection_test.rego
@@ -28,12 +28,8 @@ test_deny_pap_unset if {
 	count(deny) > 0 with input as mock_bucket("google_storage_bucket.blob", "")
 }
 
-# ── Pass: enforced, or intentionally public bucket ───────────────────────────
+# ── Pass: enforced ───────────────────────────────────────────────────────────
 
 test_pass_pap_enforced if {
 	count(deny) == 0 with input as mock_bucket("google_storage_bucket.blob", "enforced")
-}
-
-test_pass_pap_exempt_install_templates if {
-	count(deny) == 0 with input as mock_bucket("google_storage_bucket.install_templates", "inherited")
 }

--- a/byoc-nuon-gcp/src/components/gcs_buckets/main.tf
+++ b/byoc-nuon-gcp/src/components/gcs_buckets/main.tf
@@ -17,25 +17,6 @@ resource "google_storage_bucket" "clickhouse" {
   }
 }
 
-resource "google_storage_bucket" "install_templates" {
-  project  = var.project_id
-  name     = "${var.install_id}-byoc-nuon-install-templates"
-  location = var.region
-
-  uniform_bucket_level_access = true
-  public_access_prevention    = "enforced"
-  force_destroy               = false
-
-  versioning {
-    enabled = true
-  }
-
-  labels = {
-    "install-nuon-co-id"     = var.install_id
-    "component-nuon-co-name" = "install-templates"
-  }
-}
-
 resource "google_storage_bucket" "blob" {
   project  = var.project_id
   name     = "${var.install_id}-byoc-nuon-install-blob"

--- a/byoc-nuon-gcp/src/components/gcs_buckets/main.tf
+++ b/byoc-nuon-gcp/src/components/gcs_buckets/main.tf
@@ -23,6 +23,7 @@ resource "google_storage_bucket" "install_templates" {
   location = var.region
 
   uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
   force_destroy               = false
 
   versioning {
@@ -33,12 +34,6 @@ resource "google_storage_bucket" "install_templates" {
     "install-nuon-co-id"     = var.install_id
     "component-nuon-co-name" = "install-templates"
   }
-}
-
-resource "google_storage_bucket_iam_member" "install_templates_public_read" {
-  bucket = google_storage_bucket.install_templates.name
-  role   = "roles/storage.objectViewer"
-  member = "allUsers"
 }
 
 resource "google_storage_bucket" "blob" {

--- a/byoc-nuon-gcp/src/components/gcs_buckets/outputs.tf
+++ b/byoc-nuon-gcp/src/components/gcs_buckets/outputs.tf
@@ -13,10 +13,3 @@ output "blob_bucket" {
   }
 }
 
-output "install_template_bucket" {
-  value = {
-    name     = google_storage_bucket.install_templates.name
-    url      = google_storage_bucket.install_templates.url
-    base_url = "https://storage.googleapis.com/${google_storage_bucket.install_templates.name}/"
-  }
-}


### PR DESCRIPTION
bucket is vestigial (templates serve from central s3 via federation); fixes 412 at orgs enforcing publicAccessPrevention