### PR TITLE
feat: add runbook to resize the clickhouse pvc

### DIFF
--- a/byoc-nuon/actions/clickhouse/ch_pvc_expand/ch_pvc_expand.toml
+++ b/byoc-nuon/actions/clickhouse/ch_pvc_expand/ch_pvc_expand.toml
@@ -1,0 +1,24 @@
+# action
+# description: MUTATING. Grows the ClickHouse data PVCs online. Runs a preflight
+# first (prints state; aborts if no CSI resizer, or if any CH StatefulSet has
+# whenDeleted=Delete which would drop the PVC on a later STS recreate), then
+# enables allowVolumeExpansion on the StorageClass (mutable false->true) and
+# patches each data PVC to TARGET_SIZE, waiting for the resize to complete. Never
+# shrinks (skips any PVC already >= TARGET_SIZE). Online grow — no pod restart, no
+# data rewrite.
+name    = "ch_pvc_expand"
+labels  = { service = "clickhouse" }
+timeout = "8m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "expand"
+inline_contents = "./clickhouse/ch_pvc_expand/expand.sh"
+
+[steps.env_vars]
+NAMESPACE       = "clickhouse"
+STORAGE_CLASS   = "ebi"
+DATA_PVC_PREFIX = "data-volume-template-"
+TARGET_SIZE     = "100Gi"

--- a/byoc-nuon/actions/clickhouse/ch_pvc_expand/expand.sh
+++ b/byoc-nuon/actions/clickhouse/ch_pvc_expand/expand.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Grow the ClickHouse data PVCs online. Self-contained: preflight -> enable SC
+# expansion -> patch PVCs -> wait for resize -> verify. Additive only (never
+# shrinks), and refuses to run if no CSI resizer is present (a resize without one
+# hangs indefinitely). Online grow: no pod restart, no data rewrite.
+#
+# Env:
+#   NAMESPACE        clickhouse namespace (default: clickhouse)
+#   STORAGE_CLASS    StorageClass backing the data PVCs (default: ebi)
+#   DATA_PVC_PREFIX  name prefix of the data PVCs (default: data-volume-template-)
+#   TARGET_SIZE      target size, e.g. 100Gi (default: 100Gi)
+
+set -uo pipefail
+
+NS="${NAMESPACE:-clickhouse}"
+SC="${STORAGE_CLASS:-ebi}"
+PREFIX="${DATA_PVC_PREFIX:-data-volume-template-}"
+TARGET="${TARGET_SIZE:-100Gi}"
+
+# k8s quantity (e.g. 20Gi, 100Gi, 1Ti) -> bytes, for never-shrink comparison.
+to_bytes() {
+  awk -v s="$1" 'BEGIN {
+    if (s ~ /Gi$/)      { sub(/Gi$/,"",s); print s*1073741824 }
+    else if (s ~ /Mi$/) { sub(/Mi$/,"",s); print s*1048576 }
+    else if (s ~ /Ti$/) { sub(/Ti$/,"",s); print s*1099511627776 }
+    else                { print s+0 }
+  }'
+}
+target_b=$(to_bytes "$TARGET")
+
+##############################################################################
+# 0. PREFLIGHT (read-only) — print state, gate on the CSI resizer.
+##############################################################################
+echo "=== ch_pvc_expand -> $TARGET  ($(date -u +%Y-%m-%dT%H:%M:%SZ)) ==="
+echo
+echo "--- preflight: data PVCs ---"
+kubectl get pvc -n "$NS" -o custom-columns=\
+'NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage,SC:.spec.storageClassName,PHASE:.status.phase'
+
+echo
+echo "--- preflight: StorageClass '$SC' ---"
+expand=$(kubectl get storageclass "$SC" -o jsonpath='{.allowVolumeExpansion}' 2>/dev/null)
+echo "allowVolumeExpansion=${expand:-<unset>}"
+
+echo
+echo "--- preflight: CSI resizer (required; a resize without it hangs) ---"
+resizer=$(kubectl get pods -A \
+  -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.name}{"\n"}{end}{end}' 2>/dev/null \
+  | grep -c 'csi-resizer')
+echo "csi-resizer containers: ${resizer:-0}"
+if [ "${resizer:-0}" -lt 1 ]; then
+  echo "!! no csi-resizer present — refusing to patch (resize would hang). ABORT."
+  exit 1
+fi
+
+echo
+echo "--- preflight: PVC retention policy on StatefulSets (must not be Delete) ---"
+# The clickhouse_cluster redeploy makes the operator recreate the STS to apply
+# the new volumeClaimTemplates size. If a STS has whenDeleted=Delete, that
+# recreation would DROP the data PVC. Unset defaults to Retain (safe); only an
+# explicit Delete is dangerous. Abort if any CH StatefulSet is set to Delete.
+retain_bad=0
+stss=$(kubectl get sts -n "$NS" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.persistentVolumeClaimRetentionPolicy.whenDeleted}{"\n"}{end}' 2>/dev/null)
+while IFS=' ' read -r name whenDeleted; do
+  [ -z "$name" ] && continue
+  echo "  ${name}: whenDeleted=${whenDeleted:-Retain (default)}"
+  [ "$whenDeleted" = "Delete" ] && retain_bad=$((retain_bad + 1))
+done <<EOF
+$stss
+EOF
+if [ "$retain_bad" -gt 0 ]; then
+  echo "  !! a StatefulSet has whenDeleted=Delete — the clickhouse_cluster redeploy"
+  echo "     recreates the STS and would DROP the data PVC. Refusing to proceed. ABORT."
+  exit 1
+fi
+
+echo
+echo "--- preflight OK ---"
+echo
+
+##############################################################################
+# 1. Enable expansion on the StorageClass (mutable false->true, non-destructive).
+##############################################################################
+echo "--- 1. enable expansion on StorageClass '$SC' ---"
+if [ "$expand" != "true" ]; then
+  kubectl patch storageclass "$SC" --type merge -p '{"allowVolumeExpansion":true}' \
+    || { echo "!! failed to patch StorageClass"; exit 1; }
+fi
+kubectl get storageclass "$SC" -o jsonpath='allowVolumeExpansion={.allowVolumeExpansion}{"\n"}'
+echo
+
+##############################################################################
+# 2. Grow the data PVCs to TARGET (never shrink).
+##############################################################################
+echo "--- 2. grow data PVCs to $TARGET ---"
+pvcs=$(kubectl get pvc -n "$NS" -o name 2>/dev/null | sed 's|persistentvolumeclaim/||' | grep "^${PREFIX}")
+if [ -z "$pvcs" ]; then
+  echo "!! no data PVCs matched prefix '$PREFIX' in namespace '$NS'"; exit 1
+fi
+for pvc in $pvcs; do
+  cur=$(kubectl get pvc -n "$NS" "$pvc" -o jsonpath='{.spec.resources.requests.storage}')
+  cur_b=$(to_bytes "$cur")
+  if [ "$target_b" -le "$cur_b" ]; then
+    echo "  ${pvc}: current ${cur} >= target ${TARGET} — skip (never shrink)"
+    continue
+  fi
+  echo "  ${pvc}: ${cur} -> ${TARGET}"
+  kubectl patch pvc -n "$NS" "$pvc" --type merge \
+    -p "{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"${TARGET}\"}}}}" \
+    || { echo "  !! patch failed for ${pvc}"; exit 1; }
+done
+echo
+
+##############################################################################
+# 3. Wait for the resize to reach capacity (up to ~4m).
+##############################################################################
+echo "--- 3. waiting for resize to complete ---"
+for i in $(seq 1 24); do
+  pending=0
+  for pvc in $pvcs; do
+    cap=$(kubectl get pvc -n "$NS" "$pvc" -o jsonpath='{.status.capacity.storage}')
+    [ "$(to_bytes "${cap:-0}")" -lt "$target_b" ] && pending=$((pending + 1))
+  done
+  [ "$pending" -eq 0 ] && { echo "  all PVCs at ${TARGET}"; break; }
+  echo "  waiting... (${pending} pending) [${i}/24]"
+  sleep 10
+done
+echo
+
+##############################################################################
+# 4. Final state.
+##############################################################################
+echo "--- 4. final state ---"
+kubectl get pvc -n "$NS" -o custom-columns=\
+'NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage,PHASE:.status.phase'
+echo "=== done ==="

--- a/byoc-nuon/components/clickhouse_cluster/cluster.tf
+++ b/byoc-nuon/components/clickhouse_cluster/cluster.tf
@@ -263,7 +263,7 @@ resource "kubectl_manifest" "clickhouse_installation" {
               ]
               "resources" = {
                 "requests" = {
-                  "storage" = "20Gi"
+                  "storage" = "100Gi"
                 }
               }
             }

--- a/byoc-nuon/components/storage_classes/templates/ebi.tpl
+++ b/byoc-nuon/components/storage_classes/templates/ebi.tpl
@@ -2,6 +2,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: ebi
+allowVolumeExpansion: true
 parameters:
   fsType: ext4
   type: gp2

--- a/byoc-nuon/runbooks/clickhouse_pvc_expand.md
+++ b/byoc-nuon/runbooks/clickhouse_pvc_expand.md
@@ -1,0 +1,114 @@
+<div style="padding-top:1rem;"></div>
+
+<nuon-banner theme="warn">Mutating, on a live database. Step 1 grows the data
+PVCs in place (additive — no restart, no data rewrite). Step 3 redeploys
+<code>clickhouse_cluster</code>, which makes the operator recreate the
+StatefulSet and <strong>may briefly restart the ClickHouse pods</strong>. Data is
+preserved throughout (PVCs are <code>Retain</code> and Kubernetes cannot shrink a
+PVC). Read this first.</nuon-banner>
+
+<div style="padding-top:1rem;"></div>
+
+## What this runbook does
+
+Grows the ClickHouse **data** PVCs online, then reconciles source so it sticks.
+Three steps, run in this order — the order is enforced by the runbook, and it
+matters (see step 3):
+
+1. **`ch_pvc_expand`** (action) — grows the live PVCs.
+   - **Preflights** — prints PVC size/capacity + the SC `allowVolumeExpansion`
+     flag; **aborts if no `csi-resizer` is present** (a resize without one hangs
+     indefinitely); and **aborts if any CH StatefulSet has
+     `persistentVolumeClaimRetentionPolicy.whenDeleted: Delete`** — because step 3
+     recreates the STS, and `Delete` would drop the data PVC (unset defaults to
+     `Retain`, which is safe).
+   - **Enables expansion** — patches `allowVolumeExpansion: true` on `ebi`
+     (mutable false→true, non-destructive).
+   - **Grows the PVCs** — patches each data PVC (by `DATA_PVC_PREFIX`) to
+     `TARGET_SIZE`; **never shrinks** (skips any PVC already ≥ target).
+   - **Waits & verifies** — polls until `.status.capacity` reaches the target
+     (EBS volume then ext4 filesystem grow, both online), prints final state.
+2. **`storage_classes: Deploy`** — persists `allowVolumeExpansion: true` in
+   source (no-op against the live SC that step 1 already patched).
+3. **`clickhouse_cluster: Deploy`** — persists the larger `volumeClaimTemplates`
+   size in the CHI. Because a StatefulSet's `volumeClaimTemplates` is
+   **immutable**, the operator **recreates the STS** to apply the new size:
+   it deletes the STS orphan-style (pods keep running / are re-adopted) and the
+   PVCs — already at the target from step 1 and marked `Retain` — are re-adopted
+   by name with **no resize and no data copy**. This step **may briefly restart
+   the CH pods**; 2 replicas + ctl-api retries make it a blip, not an outage.
+
+**Why step 1 must run before step 3:** with the PVCs already at target, the
+recreated STS adopts volumes that already match — nothing to reconcile. If you
+deployed first (PVCs still small), the operator would have to recreate the STS
+*and* drive the resize at once — more churn, more room to get stuck. The runbook
+enforces this order, so just run it top to bottom.
+
+## What happens to the StatefulSet
+
+**After step 1 (the expand action) alone: the STS is NOT recreated, and nothing
+restarts.** The action patches the **PVC objects** directly — it never touches
+the StatefulSet. The PVC is a separate object from the STS. So after it runs:
+
+- **PVCs:** at the target size, live, grown online by the CSI resizer.
+- **Running pods:** keep using those same grown PVCs — no restart.
+- **STS `volumeClaimTemplates`:** still shows the old size — stale, but harmless.
+  That template is only ever read when the STS needs to create a **new** PVC (a
+  new replica ordinal, or a pod whose PVC was deleted). Existing PVCs are already
+  bound and grown, so the cluster runs fine with a stale template.
+
+So a low-disk **incident is fully resolved after step 1**. The STS recreation
+only enters the picture at the source-reconcile step.
+
+**When the STS gets recreated — step 3, the `clickhouse_cluster` redeploy.** A
+StatefulSet's `volumeClaimTemplates` is **immutable** — you cannot edit the size
+in place. So when `clickhouse_cluster` is deployed with the CHI now requesting the
+larger size, the Altinity operator sees: desired vct = new size, live STS vct =
+old size, can't patch it → **it deletes and recreates the STS.**
+
+That recreation is safe here **only because the PVCs survive it**: the STS
+`persistentVolumeClaimRetentionPolicy` is `Retain` (the preflight aborts if it's
+`Delete`), so the PVCs are not garbage-collected when the STS is deleted; the
+recreated STS re-adopts them by name; and Kubernetes cannot shrink a PVC, so the
+grown volumes can't be reverted. The only visible effect is a possible brief pod
+restart.
+
+## After running — confirm healthy
+
+- StatefulSets show the new `volumeClaimTemplates` size.
+- All data PVCs are `Bound` at the target.
+- All ClickHouse pods are `Ready`.
+
+## Why online expansion works here
+
+The data PVCs bind to the `ebi` StorageClass (in-tree `kubernetes.io/aws-ebs`
+provisioner, CSI-migrated to `ebs.csi.aws.com` on EKS ≥ 1.23). The EBS CSI
+controller runs with the `csi-resizer` sidecar, so a change to the PVC's
+requested size is applied to the live volume without detaching or restarting the
+pod. The preflight confirms the resizer is present before touching anything.
+
+## Parameters (`ch_pvc_expand` step env)
+
+| Var | Default | Notes |
+|---|---|---|
+| `TARGET_SIZE` | `100Gi` | Target size. **Never shrinks.** EBS enforces a ~6h cooldown between resizes of the same volume, so size generously and resize once. |
+| `STORAGE_CLASS` | `ebi` | StorageClass to enable expansion on. |
+| `DATA_PVC_PREFIX` | `data-volume-template-` | Prefix identifying the data PVCs. |
+| `NAMESPACE` | `clickhouse` | |
+
+## When to use
+
+The ClickHouse data disk is running low (e.g. an `inspect_clickhouse` snapshot or
+a disk alert shows the data PVC filling). Table data lives in
+`/var/lib/clickhouse/store`; this grows the volume it sits on.
+
+## If a resize stalls
+
+`.status.capacity` may briefly lag behind `.spec…requests` with a
+`FileSystemResizePending` condition, then catch up within a minute or two. If it
+is still stuck after the wait loop, inspect the PVC and the resizer:
+
+```
+kubectl describe pvc <name> -n clickhouse
+kubectl logs -n <ebs-csi ns> deploy/ebs-csi-controller -c csi-resizer
+```

--- a/byoc-nuon/runbooks/clickhouse_pvc_expand.toml
+++ b/byoc-nuon/runbooks/clickhouse_pvc_expand.toml
@@ -1,0 +1,23 @@
+name        = "clickhouse_pvc_expand"
+description = "Grow the ClickHouse data PVCs online, then reconcile source. Step 1 enables StorageClass expansion and resizes each data PVC to TARGET_SIZE (preflight-gated on the CSI resizer; additive only; no restart). Steps 2-3 redeploy storage_classes + clickhouse_cluster so source matches — the clickhouse_cluster deploy makes the operator recreate the StatefulSet (orphan-style, PVCs retained), which may briefly restart the CH pods."
+readme      = "./runbooks/clickhouse_pvc_expand.md"
+labels      = { service = "clickhouse" }
+
+# 1. Grow the live PVCs FIRST. Fully resolves a low-disk incident on its own.
+[[steps]]
+name        = "Expand ClickHouse data PVCs"
+type        = "action"
+action_name = "ch_pvc_expand"
+
+# 2. Persist allowVolumeExpansion in source (ebi StorageClass).
+[[steps]]
+name           = "storage_classes: Deploy"
+type           = "component_deploy"
+component_name = "storage_classes"
+
+# 3. Persist the larger vct in source. Operator recreates the STS to apply it
+#    (PVCs already at target from step 1 -> re-adopted, no resize; may restart pods).
+[[steps]]
+name           = "clickhouse_cluster: Deploy"
+type           = "component_deploy"
+component_name = "clickhouse_cluster"

--- a/byoc-nuon/runbooks/clickhouse_pvc_expand.toml
+++ b/byoc-nuon/runbooks/clickhouse_pvc_expand.toml
@@ -1,5 +1,5 @@
 name        = "clickhouse_pvc_expand"
-description = "Grow the ClickHouse data PVCs online, then reconcile source. Step 1 enables StorageClass expansion and resizes each data PVC to TARGET_SIZE (preflight-gated on the CSI resizer; additive only; no restart). Steps 2-3 redeploy storage_classes + clickhouse_cluster so source matches — the clickhouse_cluster deploy makes the operator recreate the StatefulSet (orphan-style, PVCs retained), which may briefly restart the CH pods."
+description = "Expands the ClickHouse data PVC."
 readme      = "./runbooks/clickhouse_pvc_expand.md"
 labels      = { service = "clickhouse" }
 


### PR DESCRIPTION
Adds a clickhouse_pvc_expand runbook to grow the ClickHouse data PVCs online:

- Enables allowVolumeExpansion on the ebi StorageClass
- Resizes each data PVC to TARGET_SIZE (new default 100Gi) — online

- Preflight-gated: aborts 
  * If the CSI csi-resizer isn't present
  * Any CH StatefulSet has whenDeleted: Delete (would drop the PVC)

- Sets ebi.tpl `allowVolumeExpansion: true`
- cluster.tf data PVC bumped 20Gi → 100Gi

- Redeploys storage_classes + clickhouse_cluster
  - clickhouse_cluster deploy recreates the STS (immutable volumeClaimTemplates)
  - PVCs are Retain + re-adopted by name, so data is preserved (may briefly restart CH pods).