### PR TITLE
chore: bump amazon linux alias to v20260625

### DIFF
--- a/byoc-nuon/inputs/karpenter/karpenter_ami_alias.toml
+++ b/byoc-nuon/inputs/karpenter/karpenter_ami_alias.toml
@@ -1,6 +1,6 @@
 name         = "karpenter_ami_alias"
 description  = "The AWS AMI Alias for the Karpenter EC2 Nodeclasses. Set globally."
-default      = "al2023@v20260618"
+default      = "al2023@v20260625"
 display_name = "Runner Image URL"
 group        = "karpenter"
 required     = true


### PR DESCRIPTION
Auto-bump of the Karpenter AL2023 AMI alias to N-1.

- Latest release: `v20260709`
- N-1 (this PR):  `v20260625`
- Previous:       `v20260618`

Source: https://github.com/awslabs/amazon-eks-ami/releases