### PR TITLE
chore: modify the action to restore replicas

### DIFF
--- a/byoc-nuon/actions/clickhouse/ch_replica_status/check_and_restore_replicas.sh
+++ b/byoc-nuon/actions/clickhouse/ch_replica_status/check_and_restore_replicas.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env sh
 
 set -e
-set -u
 set -o pipefail
+set -u
 
-echo "getting a pod"
-pod=`kubectl -n clickhouse get pods | grep installation | cut -d ' ' -f 1 | tail -n 1`
+echo "getting pods"
+pods=$(kubectl -n clickhouse get pods | grep installation | cut -d ' ' -f 1)
+echo "$pods"
+echo "selecting a pod"
+pod=$(echo "$pods" | head -n 1)
+echo " > using pod: $pod"
 
 echo "getting read-only tables"
 # NOTE(fd): we reverse the sort to get the runner_* tables in first.
-tables=`kubectl --namespace=clickhouse exec -i $pod -- clickhouse client -d ctl_api -q "SELECT table FROM system.replicas WHERE database = 'ctl_api' AND is_readonly = 1" | sort -rn`
+tables=$(kubectl --namespace=clickhouse exec -i $pod -- clickhouse client -d ctl_api -q "SELECT table FROM system.replicas WHERE database = 'ctl_api' AND is_readonly = 1" | sort -rn)
 echo $tables
-
 
 # act on replicas w/ a bad status
 for table in $tables; do

--- a/byoc-nuon/actions/karpenter/karpenter_nodepools/nodepools.sh
+++ b/byoc-nuon/actions/karpenter/karpenter_nodepools/nodepools.sh
@@ -5,6 +5,6 @@ set -o pipefail
 set -u
 
 
-kubectl auth whoami | jq -c
+kubectl auth whoami -o json | jq -c
 
 kubectl get --all-namespaces nodepools -o json >> "$NUON_ACTIONS_OUTPUT_FILEPATH"


### PR DESCRIPTION
to select the first, not last, pod

TODO: in a future PR, let's choose based on the status of the pod
TODO: we should have a dedicated deployment for this in case both pods
are down. a single pod with a clickhouse client and connectiond details
should be good enough.
