### PR TITLE
feat(byoc-nuon-gcp): port nuon access login flow from aws

### DIFF
--- a/byoc-nuon-gcp/actions/_nuon_access/enable/action.sh
+++ b/byoc-nuon-gcp/actions/_nuon_access/enable/action.sh
@@ -31,9 +31,11 @@ export AWS_PAGER=""
 : "${NAMESPACE:=ctl-api}"
 : "${NUON_ACCESS_AUDIENCE:=sts.amazonaws.com}"
 
-# admin api + auth
+# admin api. the identity-provider endpoints are plain internal routes: the
+# X-Nuon-Admin-Email header is optional audit-only and must be omitted here --
+# a fresh control plane has no nuon.co accounts yet, and a header that fails to
+# resolve is a 403.
 admin_api_url="$ADMIN_API_URL"
-admin_email="fred@nuon.co"
 nuon_access_secret_arn="$NUON_ACCESS_SECRET_ARN"
 
 # default outputs (emitted on every exit path)
@@ -126,7 +128,6 @@ url="$admin_api_url/v1/auth/identity-providers"
 echo "[nuon-access] listing existing identity providers"
 identity_providers=$(curl -sS -f \
   -H 'accept: application/json' \
-  -H "X-Nuon-Admin-Email: $admin_email" \
   "$url")
 
 existing_id=$(echo "$identity_providers" | jq -r \
@@ -144,7 +145,6 @@ if [[ -n "$existing_id" ]]; then
   response=$(curl -sS -f -X PATCH \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
-    -H "X-Nuon-Admin-Email: $admin_email" \
     -d "$body" \
     "$url/$existing_id")
   created=false
@@ -154,7 +154,6 @@ else
   response=$(curl -sS -f -X POST \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
-    -H "X-Nuon-Admin-Email: $admin_email" \
     -d "$body" \
     "$url")
   created=true

--- a/byoc-nuon-gcp/actions/_nuon_access/enable/action.sh
+++ b/byoc-nuon-gcp/actions/_nuon_access/enable/action.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# nuon_access_enable (GCP)
+#
+# Reads the central Nuon Access secret (an identity provider payload) from the
+# central AWS Secrets Manager (byoc-infra-prod), upserts an enabled identity
+# provider on the Auth service via the admin API, then appends nuon.co to the
+# ctl-api configmap's NUON_AUTH_ALLOWED_DOMAINS and restarts ctl-api-auth.
+#
+# Unlike the AWS install (whose maintenance IAM role is granted on the secret
+# directly), a GCP install has no AWS identity. Instead it federates: the
+# runner mints a Google-signed OIDC token for its GCP identity via the GCE/GKE
+# metadata server and exchanges it for temporary AWS credentials via
+# sts:AssumeRoleWithWebIdentity against a per-install reader role in
+# byoc-infra-prod (same flow as sync_slack_secrets).
+#
+# Required env:
+#   ADMIN_API_URL           - internal admin API base URL.
+#   NUON_ACCESS_SECRET_ARN  - full ARN of the central secret. Empty => skip (no-op).
+#   NUON_ACCESS_ROLE_ARN    - AWS IAM role to assume via web identity.
+#   NUON_ACCESS_AUDIENCE    - OIDC audience the role's trust policy expects.
+#   NAMESPACE               - k8s namespace for ctl-api (default ctl-api).
+#   INSTALL_ID              - used for the STS role session name.
+
+set -e
+set -o pipefail
+set -u
+
+export AWS_PAGER=""
+
+: "${NAMESPACE:=ctl-api}"
+: "${NUON_ACCESS_AUDIENCE:=sts.amazonaws.com}"
+
+# admin api + auth
+admin_api_url="$ADMIN_API_URL"
+admin_email="fred@nuon.co"
+nuon_access_secret_arn="$NUON_ACCESS_SECRET_ARN"
+
+# default outputs (emitted on every exit path)
+created=false
+id=""
+enabled=false
+
+write_outputs() {
+  jq -cn \
+    --argjson created "$created" \
+    --arg id "$id" \
+    --argjson enabled "$enabled" \
+    --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
+    '{created: $created, id: $id, enabled: $enabled, updated_at: $updated_at}' \
+    >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+}
+trap write_outputs EXIT
+
+# if NUON_ACCESS_SECRET_ARN is an empty string, nuon access is not configured: exit early
+if [[ -z "$nuon_access_secret_arn" ]]; then
+  echo "[nuon-access] no secret arn configured, skipping"
+  exit 0
+fi
+
+if [[ -z "${NUON_ACCESS_ROLE_ARN:-}" ]]; then
+  echo >&2 "[nuon-access] NUON_ACCESS_ROLE_ARN is empty; cannot federate into AWS to read the secret"
+  exit 1
+fi
+
+# the region is embedded in the secret arn: arn:aws:secretsmanager:<region>:<acct>:secret:<name>
+region=$(echo "$nuon_access_secret_arn" | cut -d: -f4)
+region="${region:-us-west-2}"
+
+# mint a Google-signed OIDC identity token for this runner's GCP identity and
+# exchange it for temporary AWS credentials (no pre-existing AWS creds needed).
+echo "[nuon-access] minting GCP identity token (audience: $NUON_ACCESS_AUDIENCE)"
+web_identity_token=$(curl -sf -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${NUON_ACCESS_AUDIENCE}&format=full")
+if [[ -z "$web_identity_token" ]]; then
+  echo >&2 "[nuon-access] failed to mint GCP identity token from the metadata server"
+  exit 1
+fi
+
+echo "[nuon-access] assuming AWS role via web identity"
+echo "  role:   $NUON_ACCESS_ROLE_ARN"
+echo "  region: $region"
+creds=$(aws --region "$region" sts assume-role-with-web-identity \
+  --role-arn "$NUON_ACCESS_ROLE_ARN" \
+  --role-session-name "nuon-access-${INSTALL_ID:-nuon}" \
+  --web-identity-token "$web_identity_token" \
+  --query 'Credentials' --output json)
+
+export AWS_ACCESS_KEY_ID=$(echo "$creds" | jq -er '.AccessKeyId')
+export AWS_SECRET_ACCESS_KEY=$(echo "$creds" | jq -er '.SecretAccessKey')
+export AWS_SESSION_TOKEN=$(echo "$creds" | jq -er '.SessionToken')
+
+# pull the secret. the secret string is a json payload shaped like the create request body:
+#   { "provider_type": "github|google|oidc", "<provider>_config": { "client_id": ..., ... } }
+echo "[nuon-access] reading secret from $region"
+payload=$(aws --region "$region" secretsmanager get-secret-value \
+  --secret-id "$nuon_access_secret_arn" \
+  --query SecretString --output text)
+
+# determine the provider type and its config key. prefer an explicit provider_type, otherwise
+# infer it from whichever *_config key is present in the secret.
+provider_type=$(echo "$payload" | jq -r '
+  .provider_type //
+  (if has("openid_config") then "oidc"
+   elif has("google_config") then "google"
+   elif has("github_config") then "github"
+   else "" end)')
+
+case "$provider_type" in
+  oidc)   config_key="openid_config" ;;
+  google) config_key="google_config" ;;
+  github) config_key="github_config" ;;
+  *)
+    echo >&2 "[nuon-access] error: could not determine provider type from secret"
+    exit 1
+    ;;
+esac
+
+# pull the client_id out of the config block so we can match against existing providers
+client_id=$(echo "$payload" | jq -r --arg ck "$config_key" '.[$ck].client_id // ""')
+echo "[nuon-access] provider_type=$provider_type client_id=$client_id"
+
+# this action must be idempotent: a global provider is unique per provider_type, so we look up
+# any existing provider of the same type to decide between create and update.
+url="$admin_api_url/v1/auth/identity-providers"
+echo "[nuon-access] listing existing identity providers"
+identity_providers=$(curl -sS -f \
+  -H 'accept: application/json' \
+  -H "X-Nuon-Admin-Email: $admin_email" \
+  "$url")
+
+existing_id=$(echo "$identity_providers" | jq -r \
+  --arg pt "$provider_type" \
+  'map(select(.provider_type == $pt)) | (.[0].id // "")')
+
+# the request body is the full secret payload with enabled forced to true. this way updating
+# the secret (e.g. the redirect url) propagates to the db on the next run, and we only ever
+# override the enabled flag.
+body=$(echo "$payload" | jq -c '.enabled = true')
+
+if [[ -n "$existing_id" ]]; then
+  # provider exists: PATCH it by id with the secret payload, enabling it
+  echo "[nuon-access] provider exists (id=$existing_id), updating and enabling"
+  response=$(curl -sS -f -X PATCH \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -H "X-Nuon-Admin-Email: $admin_email" \
+    -d "$body" \
+    "$url/$existing_id")
+  created=false
+else
+  # provider does not exist: POST the secret payload, always forcing enabled=true
+  echo "[nuon-access] provider does not exist, creating"
+  response=$(curl -sS -f -X POST \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -H "X-Nuon-Admin-Email: $admin_email" \
+    -d "$body" \
+    "$url")
+  created=true
+fi
+
+id=$(echo "$response" | jq -r '.id // ""')
+enabled=$(echo "$response" | jq -r '.enabled // false')
+echo "[nuon-access] provider: created=$created id=$id enabled=$enabled"
+
+# ensure nuon.co is an allowed sign-in domain: append it to the comma-delimited
+# NUON_AUTH_ALLOWED_DOMAINS key in the ctl-api configmap (idempotent).
+cm_key="NUON_AUTH_ALLOWED_DOMAINS"
+required_domain="nuon.co"
+
+current_domains=$(kubectl get -n "$NAMESPACE" configmap "ctl-api" \
+  -o jsonpath="{.data.$cm_key}")
+
+if echo ",$current_domains," | grep -q ",$required_domain,"; then
+  echo "[nuon-access] $required_domain already in $cm_key, leaving configmap unchanged"
+else
+  if [[ -z "$current_domains" ]]; then
+    updated_domains="$required_domain"
+  else
+    updated_domains="$current_domains,$required_domain"
+  fi
+  echo "[nuon-access] adding $required_domain to $cm_key"
+  kubectl patch -n "$NAMESPACE" configmap "ctl-api" \
+    --type merge \
+    -p "{\"data\":{\"$cm_key\":\"$updated_domains\"}}"
+
+  # the configmap is consumed via envFrom across the split ctl-api deployments
+  # (ctl-api-auth, -public, -admin, ...); env changes only take effect on restart,
+  # so roll the auth deployment to pick up the new value.
+  echo "[nuon-access] restarting ctl-api-auth deployment"
+  kubectl rollout restart -n "$NAMESPACE" deployment/ctl-api-auth
+fi
+
+echo "[nuon-access] done"

--- a/byoc-nuon-gcp/actions/_nuon_access/enable/action.toml
+++ b/byoc-nuon-gcp/actions/_nuon_access/enable/action.toml
@@ -1,0 +1,25 @@
+# action
+# description: Reads the central Nuon Access secret (identity provider payload)
+# from the central AWS Secrets Manager entry referenced by
+# NUON_ACCESS_SECRET_ARN — federating this GCP install's identity into AWS via
+# web identity (NUON_ACCESS_ROLE_ARN) — then upserts an enabled identity
+# provider on the Auth service and adds nuon.co to the allowed sign-in domains.
+# Skips cleanly when NUON_ACCESS_SECRET_ARN is empty.
+name    = "nuon_access_enable"
+labels  = { service = "auth", type = "break-glass" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "exec"
+inline_contents = "./_nuon_access/enable/action.sh"
+
+[steps.env_vars]
+ADMIN_API_URL          = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+NUON_ACCESS_SECRET_ARN = "{{ or .nuon.inputs.inputs.nuon_access_secret_arn \"\" }}"
+NUON_ACCESS_ROLE_ARN   = "{{ or .nuon.inputs.inputs.secrets_role_arn \"\" }}"
+NUON_ACCESS_AUDIENCE   = "sts.amazonaws.com"
+NAMESPACE              = "ctl-api"
+INSTALL_ID             = "{{ .nuon.install.id }}"

--- a/byoc-nuon-gcp/actions/runners/runner_sa_unique_id/runner-sa-unique-id.sh
+++ b/byoc-nuon-gcp/actions/runners/runner_sa_unique_id/runner-sa-unique-id.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# runner_sa_unique_id (GCP)
+#
+# Emits the runner's GCP service account email and numeric unique id (the OIDC
+# "sub" claim). The unique id is what central byoc-secrets Terraform needs in
+# its gcp_installs map to bind this install's secret-reader role trust policy
+# (see mono/infra/byoc-secrets/installs.auto.tfvars).
+#
+# The id is read by minting an identity token from the metadata server and
+# decoding its payload — the same token the install presents to AWS when it
+# federates, so what we print here is exactly what STS will see as :sub.
+set -euo pipefail
+
+metadata_base="http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
+
+email=$(curl -sf -H "Metadata-Flavor: Google" "$metadata_base/email")
+
+token=$(curl -sf -H "Metadata-Flavor: Google" \
+  "$metadata_base/identity?audience=sts.amazonaws.com&format=full")
+
+# decode the JWT payload (2nd segment); re-pad base64url before decoding
+payload=$(echo "$token" | cut -d. -f2 | tr '_-' '/+')
+case $(( ${#payload} % 4 )) in
+  2) payload="${payload}==" ;;
+  3) payload="${payload}=" ;;
+esac
+unique_id=$(echo "$payload" | base64 -d | jq -er '.sub')
+
+echo "runner service account email:     $email"
+echo "runner service account unique id: $unique_id"
+
+jq -cn \
+  --arg email "$email" \
+  --arg unique_id "$unique_id" \
+  '{email: $email, unique_id: $unique_id}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/runners/runner_sa_unique_id/runner_sa_unique_id.toml
+++ b/byoc-nuon-gcp/actions/runners/runner_sa_unique_id/runner_sa_unique_id.toml
@@ -1,0 +1,14 @@
+# action
+# description: Prints the runner's GCP service account email and numeric unique
+# id (OIDC "sub"). Central byoc-secrets Terraform needs the unique id in its
+# gcp_installs map to grant this install read access to its central secrets.
+name    = "runner_sa_unique_id"
+labels  = { service = "runner", type = "sop" }
+timeout = "1m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "exec"
+inline_contents = "./runners/runner_sa_unique_id/runner-sa-unique-id.sh"

--- a/byoc-nuon-gcp/components/images/nuon_ctl_api.toml
+++ b/byoc-nuon-gcp/components/images/nuon_ctl_api.toml
@@ -3,6 +3,6 @@ type = "container_image"
 
 [aws_ecr]
 image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/ctl-api"
-tag          = "0.19.1049"
+tag          = "0.19.1052"
 region       = "us-west-2"
 iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"

--- a/byoc-nuon-gcp/components/images/nuon_dashboard_ui.toml
+++ b/byoc-nuon-gcp/components/images/nuon_dashboard_ui.toml
@@ -3,6 +3,6 @@ type = "container_image"
 
 [aws_ecr]
 image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/dashboard-ui"
-tag          = "0.19.1049"
+tag          = "0.19.1052"
 region       = "us-west-2"
 iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"

--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -32,7 +32,10 @@ env:
   NUON_AUTH_CLIENT_ID: '{{ or .nuon.inputs.inputs.nuon_auth_client_id "nuon_auth_client_id" }}'
   NUON_AUTH_ISSUER_URL: '{{ or .nuon.inputs.inputs.nuon_auth_issuer_url "nuon_auth_issuer_url" }}'
   NUON_AUTH_REDIRECT_URL: "https://auth.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}/auth"
-  NUON_AUTH_ALLOWED_DOMAINS: '{{ or .nuon.inputs.inputs.nuon_auth_allowed_domains "" }}'
+  # nuon_access_enabled appends nuon.co declaratively so it survives re-renders
+  # (the nuon_access_enable runbook's configmap patch alone is reverted by any
+  # input sync) and turns off cleanly when the input is set back to false.
+  NUON_AUTH_ALLOWED_DOMAINS: '{{ or .nuon.inputs.inputs.nuon_auth_allowed_domains "" }}{{ if eq (or .nuon.inputs.inputs.nuon_access_enabled "false") "true" }},nuon.co{{ end }}'
   NUON_AUTH_ALLOW_ALL_USERS: '{{ or .nuon.inputs.inputs.nuon_auth_allow_all_users "false" }}'
 
   EVALUATION_JOURNEY_ENABLED: "false"

--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -50,7 +50,7 @@ env:
   INTERNAL_HTTP_PORT: !!string 8082
   RUNNER_HTTP_PORT: !!string 8083
   GRACEFUL_SHUTDOWN_TIMEOUT: 10s
-  RUNNER_CONTAINER_IMAGE_TAG: "0.19.1049"
+  RUNNER_CONTAINER_IMAGE_TAG: "0.19.1052"
   RUNNER_CONTAINER_IMAGE_URL: "public.ecr.aws/p7e3r5y0/runner"
 
   GITHUB_APP_ID: !!string {{ .nuon.inputs.inputs.github_app_id }}

--- a/byoc-nuon-gcp/docs/aws-gcp-config-deltas.md
+++ b/byoc-nuon-gcp/docs/aws-gcp-config-deltas.md
@@ -33,8 +33,10 @@ Policy coverage tracks these well: `rds-data-protection` / `s3-data-protection` 
     install.id-derived resource names.
 - **Still open — ctl-api endpoint diagnostic suite.** GCP has only `api_status`; no equivalent of
   `ctl_api_api_health_probe` + the 8 ALB/IRSA/ACM/per-endpoint probe actions.
-- **Still open — Nuon Access login flow.** No `_nuon_access/enable` action, no `nuon_access_enable` runbook, no
-  `nuon_access_enabled` / `nuon_access_secret_arn` inputs on GCP.
+- **✅ Nuon Access login flow — NOW CLOSED.** GCP has the `_nuon_access/enable` action, `nuon_access_enable` runbook,
+  and `nuon_access_enabled` / `nuon_access_secret_arn` inputs. Unlike AWS (direct maintenance-role read), the action
+  federates into AWS via web identity using the shared `secrets_role_arn` input — the same flow as
+  `sync_slack_secrets`. A `runner_sa_unique_id` action emits the value byoc-secrets Terraform needs in `gcp_installs`.
 - **Still open — node autoscaling tooling.** AWS has `karpenter-nodepools` + 4 karpenter actions + nodepool kubectl
   actions; GCP relies on native GKE autoscaling (defensible) but has no node-rotation/inspection actions.
 - **Still open — other AWS-only:** RDS Performance-Insights runbooks (`rds_inspect_ctl_api/temporal`), `acm_operations`

--- a/byoc-nuon-gcp/input_groups/nuon.toml
+++ b/byoc-nuon-gcp/input_groups/nuon.toml
@@ -1,0 +1,3 @@
+name         = "nuon"
+description  = "Configure your Nuon install."
+display_name = "Nuon configuration"

--- a/byoc-nuon-gcp/inputs/nuon/nuon_access_enabled.toml
+++ b/byoc-nuon-gcp/inputs/nuon/nuon_access_enabled.toml
@@ -1,0 +1,9 @@
+name         = "nuon_access_enabled"
+description  = "Allow Nuon to have access to the the install's public services. When true, `nuon.co` is added to the `ALLOWED_DOMAINS` and an identity provider is added."
+default      = "false"
+display_name = "Nuon Access Enabled"
+required     = false
+group        = "nuon"
+type         = "bool"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/nuon/nuon_access_secret_arn.toml
+++ b/byoc-nuon-gcp/inputs/nuon/nuon_access_secret_arn.toml
@@ -1,0 +1,8 @@
+name         = "nuon_access_secret_arn"
+description  = "ARN of the AWS Secrets Manager secret in the central account that holds an identity provider configuration for Nuon Access."
+default      = ""
+display_name = "Nuon Access Secrets ARN"
+required     = false
+group        = "nuon"
+
+user_configurable = false

--- a/byoc-nuon-gcp/runbooks/nuon_access_enable.md
+++ b/byoc-nuon-gcp/runbooks/nuon_access_enable.md
@@ -1,0 +1,29 @@
+# Nuon Access Enable
+
+Adds or enables the Nuon Access identity provider on the Auth service.
+
+{{ $action := default dict (index (default dict .nuon.actions.workflows) "nuon_access_enable") }}
+{{ $outputs := default dict (dig "outputs" dict $action) }} {{ $actionID := dig "id" "" $action }}
+
+<div style="padding-top:1rem;"></div>
+
+<nuon-group gap="2" align="center" justify="start">{{ if dig "enabled" false $outputs }}<nuon-status status="active" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}{{ with dig "updated_at" "" $outputs }}<span style="margin-left:auto;font-size:0.85em;">Last
+updated by
+<a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/actions/{{ $actionID }}">nuon_access_enable</a>
+<nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</nuon-group>
+
+<div style="padding-bottom:1rem;"></div>
+
+{{ if dig "id" "" $outputs }}
+
+| Field   | Value                              |
+| ------- | ---------------------------------- |
+| created | {{ dig "created" false $outputs }} |
+| enabled | {{ dig "enabled" false $outputs }} |
+| id      | `{{ dig "id" "—" $outputs }}`      |
+
+{{ else }}
+
+<nuon-banner theme="warn">Waiting on the nuon_access_enable action. Run it to populate this runbook.</nuon-banner>
+
+{{ end }}

--- a/byoc-nuon-gcp/runbooks/nuon_access_enable.toml
+++ b/byoc-nuon-gcp/runbooks/nuon_access_enable.toml
@@ -1,0 +1,9 @@
+name        = "nuon_access_enable"
+description = "Enables Nuon Access by adding or enabling an Identity Provider Configuration to the Nuon Auth service."
+readme      = "./runbooks/nuon_access_enable.md"
+labels      = { service = "auth", type = "break-glass" }
+
+[[steps]]
+name        = "nuon_access_enable"
+type        = "action"
+action_name = "nuon_access_enable"

--- a/byoc-nuon/actions/_nuon_access/enable/action.sh
+++ b/byoc-nuon/actions/_nuon_access/enable/action.sh
@@ -6,9 +6,11 @@ set -u
 
 export AWS_PAGER=""
 
-# admin api + auth
+# admin api. the identity-provider endpoints are plain internal routes: the
+# X-Nuon-Admin-Email header is optional audit-only and must be omitted here --
+# a fresh control plane has no nuon.co accounts yet, and a header that fails to
+# resolve is a 403.
 admin_api_url="$ADMIN_API_URL"
-admin_email="fred@nuon.co"
 nuon_access_secret_arn="$NUON_ACCESS_SECRET_ARN"
 
 # default outputs (emitted on every exit path)
@@ -73,7 +75,6 @@ url="$admin_api_url/v1/auth/identity-providers"
 echo "[nuon-access] listing existing identity providers"
 identity_providers=$(curl -sS -f \
   -H 'accept: application/json' \
-  -H "X-Nuon-Admin-Email: $admin_email" \
   "$url")
 
 existing_id=$(echo "$identity_providers" | jq -r \
@@ -91,7 +92,6 @@ if [[ -n "$existing_id" ]]; then
   response=$(curl -sS -f -X PATCH \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
-    -H "X-Nuon-Admin-Email: $admin_email" \
     -d "$body" \
     "$url/$existing_id")
   created=false
@@ -101,7 +101,6 @@ else
   response=$(curl -sS -f -X POST \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
-    -H "X-Nuon-Admin-Email: $admin_email" \
     -d "$body" \
     "$url")
   created=true

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -38,7 +38,10 @@ env:
   NUON_AUTH_CLIENT_ID: '{{ or .nuon.inputs.inputs.nuon_auth_client_id "nuon_auth_client_id" }}'
   NUON_AUTH_ISSUER_URL: '{{ or .nuon.inputs.inputs.nuon_auth_issuer_url "nuon_auth_issuer_url" }}'
   NUON_AUTH_REDIRECT_URL: "https://auth.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}/auth"
-  NUON_AUTH_ALLOWED_DOMAINS: '{{ or .nuon.inputs.inputs.nuon_auth_allowed_domains "" }}'
+  # nuon_access_enabled appends nuon.co declaratively so it survives re-renders
+  # (the nuon_access_enable runbook's configmap patch alone is reverted by any
+  # input sync) and turns off cleanly when the input is set back to false.
+  NUON_AUTH_ALLOWED_DOMAINS: '{{ or .nuon.inputs.inputs.nuon_auth_allowed_domains "" }}{{ if eq (or .nuon.inputs.inputs.nuon_access_enabled "false") "true" }},nuon.co{{ end }}'
   NUON_AUTH_ALLOW_ALL_USERS: '{{ or .nuon.inputs.inputs.nuon_auth_allow_all_users "false" }}'
 
   EVALUATION_JOURNEY_ENABLED: "false"


### PR DESCRIPTION
Ports the nuon_access_enable action, runbook, and nuon_access inputs to the GCP config. Same idempotent flow as AWS (idp upsert via admin API, append nuon.co to allowed domains, roll ctl-api-auth), except the central secret is read by federating into AWS with the shared secrets_role_arn — the sync_slack_secrets pattern. Also adds a runner_sa_unique_id action that prints the value byoc-secrets terraform needs in its gcp_installs map.