### PR TITLE
fix(byoc-nuon): keep ClickHouse Keeper state on PVCs

### DIFF
--- a/byoc-nuon/components/clickhouse_cluster/keeper.tf
+++ b/byoc-nuon/components/clickhouse_cluster/keeper.tf
@@ -13,7 +13,8 @@ resource "kubectl_manifest" "clickhouse_keeper_installation" {
     "spec" = {
       "defaults" = {
         "templates" = {
-          "podTemplate" = "default"
+          "dataVolumeClaimTemplate" = "default"
+          "podTemplate"             = "default"
         }
       }
       "configuration" = {


### PR DESCRIPTION
## Summary

ClickHouse Keeper now stores coordination and Raft state on its existing persistent volume claim template. Keeper metadata survives pod replacement instead of living on ephemeral container storage.

## Mechanics worth flagging for review

This selects the volume claim template that was already defined but unused. Existing installs need a controlled, quorum-safe rollout because adopting the claim replaces Keeper pods, and state currently held only in ephemeral storage is not migrated automatically.

