### PR TITLE
fix: route admin dashboard + temporal ui through the app proxy

### DIFF
--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -86,7 +86,8 @@ env:
   TEMPORAL_HOST: temporal-frontend-headless.temporal.svc.cluster.local:7233
   TEMPORAL_MAX_CONCURRENT_ACTIVITIES: !!string 3500
   TEMPORAL_STICKY_WORKFLOW_CACHE_SIZE: !!string 10000
-  TEMPORAL_UI_URL: http://temporal-ui.temporal.svc.cluster.local:8080
+  # served via the dashboard-ui proxy; a cluster-internal URL breaks the browser link
+  TEMPORAL_UI_URL: https://app.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}/admin/temporal
   SANDBOX_MODE_SLEEP: 1s
 
   BLOB_STORAGE_BUCKET: "{{ .nuon.components.gcs_buckets.outputs.blob_bucket.name }}"
@@ -305,6 +306,8 @@ api:
     port: 8087
     domain: "admin.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}"
       # domain_certificate: ""
+    alb:
+      enabled: {{ or .nuon.inputs.inputs.admin_dashboard_alb_enabled "false" }}
     autoscaling:
       minReplicas: 2
       maxReplicas: 4

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -86,7 +86,8 @@ env:
   TEMPORAL_HOST: temporal-frontend-headless.temporal.svc.cluster.local:7233
   TEMPORAL_MAX_CONCURRENT_ACTIVITIES: !!string 3500
   TEMPORAL_STICKY_WORKFLOW_CACHE_SIZE: !!string 10000
-  TEMPORAL_UI_URL: http://temporal-ui.{{ .nuon.install_stack.outputs.region }}.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}:8080
+  # served via the dashboard-ui proxy; a cluster-internal URL breaks the browser link
+  TEMPORAL_UI_URL: https://app.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}/admin/temporal
   SANDBOX_MODE_SLEEP: 1s
 
   BLOB_STORAGE_BUCKET: "{{ .nuon.components.s3_buckets.outputs.blob_bucket.id }}"


### PR DESCRIPTION
## What

Two BYOC `ctl-api` config fixes so the admin dashboard and its Temporal links are served through the dashboard-ui app proxy (`app.<root_domain>`), same-origin and behind nuon auth:

1. **`TEMPORAL_UI_URL`** (GCP + AWS) → `https://app.<root_domain>/admin/temporal`.
2. **GCP `dashboard_admin.alb.enabled`** wiring (from `admin_dashboard_alb_enabled`).

## Why

The dashboard-ui server already reverse-proxies `/admin/dashboard/*` (→ `ctl-api-dashboard-admin`) and `/admin/temporal/*` (→ in-cluster `temporal-web`), both gated to `@nuon.co` users. The BYOC configs were defeating it:

- The admin dashboard builds "View in Temporal" as a raw href `${TEMPORAL_UI_URL}/namespaces/...`. On GCP this was `http://temporal-ui.temporal.svc.cluster.local:8080` (cluster-internal, unreachable from a browser); AWS pointed at the internal domain. Now both point at the app proxy path (matches mono's own `values.{prod,stage}.tmpl`).
- On GCP the standalone admin ingress was created regardless of the alb flag; adding `dashboard_admin.alb.enabled` lets the companion charts gate honor it, so `alb=false` serves the dashboard only via `app.<root_domain>/admin/dashboard`.

## Depends on / related

- **Merge after** nuonco/charts#33 (gates the GCP ingress on `dashboard_admin.alb.enabled`). The GCP `ctl_api` component pins charts to `branch = main`.
- Related: nuonco/mono lovable install flips `admin_dashboard_alb_enabled` to `false`.

## Notes

`TEMPORAL_UI_URL` (`validate:"required"` in ctl-api) stays non-empty. The dashboard-ui `NUON_TEMPORAL_UI_URL` upstream (`temporal-web.temporal.svc.cluster.local:8080`) is unchanged and correct.