### PR TITLE
feat: opt-in migration window for ctl-api post deploy startup

### DIFF
--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy_startup/ctl_api_post_deploy_startup.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy_startup/ctl_api_post_deploy_startup.toml
@@ -1,7 +1,7 @@
 # action
 name    = "ctl_api_post_deploy_startup"
 labels  = { service = "ctl-api", type = "step" }
-timeout = "1m30s"
+timeout = "20m"
 
 [[triggers]]
 type           = "post-deploy-component"
@@ -18,3 +18,7 @@ inline_contents = "./ctl_api/ctl_api_post_deploy_startup/startup.sh"
 [steps.env_vars]
 DB_ADDR = "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
 DB_PORT = "5432"
+
+# off by default: scaling to 0 takes the whole control plane down for the migration.
+# flip to "true" for a deploy with a heavy index migration that live writes would block.
+SCALE_DOWN = "false"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy_startup/startup.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_post_deploy_startup/startup.sh
@@ -4,16 +4,169 @@ set -e
 set -o pipefail
 set -u
 
-db_addr="$DB_ADDR"
-db_port="$DB_PORT"
 log_level="${LOG_LEVEL:-info}"
 db_log_queries="${DB_LOG_QUERIES:-false}"
 
 # internal
+namespace="ctl-api"
 deployment_name="ctl-api-startup"
+state_configmap="ctl-api-startup-scale-state"
+
+# ctl-api-startup runs the migration; ctl-api-init is the psql jump box.
+keep_deployments="ctl-api-startup ctl-api-init"
+
+drain_timeout="${DRAIN_TIMEOUT:-240}"
+
+# scaling ctl-api to 0 takes the whole control plane down, so it is opt-in: the
+# post-deploy action sets it, the manual action does not. leftover state from an aborted
+# run is still restored either way.
+scale_down_enabled="${SCALE_DOWN:-false}"
+
+state_exists() {
+  kubectl get configmap -n "$namespace" "$state_configmap" >/dev/null 2>&1
+}
+
+state_get() {
+  kubectl get configmap -n "$namespace" "$state_configmap" -o json | jq -r --arg key "$1" '.data[$key]'
+}
+
+# save_state is write-once on purpose. a run that dies after scaling down leaves the
+# configmap behind holding the real replica counts; re-saving here would record the
+# scaled-down values (0) as the originals and lose them for good.
+save_state() {
+  if state_exists; then
+    echo "[ctl_api startup] reusing scale state from a previous run"
+    state_get deployments.json | jq -r '.[] | "  \(.name): \(.replicas)"'
+    return 0
+  fi
+
+  local deployments hpas
+  deployments=$(kubectl get deploy -n "$namespace" -o json | jq -c --arg keep "$keep_deployments" '
+    ($keep | split(" ")) as $keep
+    | [ .items[]
+        | .metadata.name as $name
+        | select(($keep | index($name)) | not)
+        | { name: $name, replicas: (.spec.replicas // 0) } ]')
+
+  # strip server-managed fields so the manifest re-applies cleanly, but keep the rest of
+  # the annotations: helm ownership metadata lives there, and re-applying without it makes
+  # the next chart deploy fail on invalid ownership. matches ctl_api_pause_worker_hpas.
+  hpas=$(kubectl get hpa -n "$namespace" -o json | jq -c '
+    { apiVersion: "v1", kind: "List",
+      items: [ .items[]
+        | del(.status, .metadata.resourceVersion, .metadata.uid,
+              .metadata.creationTimestamp, .metadata.generation,
+              .metadata.managedFields, .metadata.selfLink)
+        | .metadata.annotations |= ((. // {})
+            | with_entries(select(.key | startswith("kubectl.kubernetes.io") | not))) ] }')
+
+  echo "[ctl_api startup] saving scale state"
+  echo "$deployments" | jq -r '.[] | "  \(.name): \(.replicas)"'
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  printf '%s' "$deployments" > "$tmpdir/deployments.json"
+  printf '%s' "$hpas" > "$tmpdir/hpas.json"
+  kubectl create configmap -n "$namespace" "$state_configmap" \
+    --from-file="$tmpdir/deployments.json" \
+    --from-file="$tmpdir/hpas.json"
+  rm -rf "$tmpdir"
+}
+
+scale_down() {
+  local names_json hpa_names
+  names_json=$(state_get deployments.json | jq -c '[ .[].name ]')
+
+  # an hpa cannot have minReplicas=0 on EKS/GKE, so it has to be deleted outright or
+  # it scales the deployment straight back up within ~15s.
+  hpa_names=$(state_get hpas.json | jq -r --argjson names "$names_json" '
+    .items[]
+    | .spec.scaleTargetRef.name as $target
+    | select($names | index($target))
+    | .metadata.name')
+
+  echo "[ctl_api startup] deleting hpas"
+  for name in $hpa_names; do
+    kubectl delete hpa -n "$namespace" "$name" --ignore-not-found
+  done
+
+  echo "[ctl_api startup] scaling deployments to 0"
+  for name in $(echo "$names_json" | jq -r '.[]'); do
+    kubectl scale -n "$namespace" --replicas=0 "deployment/$name"
+  done
+
+  echo "[ctl_api startup] waiting up to ${drain_timeout}s for pods to terminate"
+  local deadline=$((SECONDS + drain_timeout))
+  while :; do
+    local pending
+    pending=$(kubectl get deploy -n "$namespace" -o json | jq -r --argjson names "$names_json" '
+      [ .items[]
+        | .metadata.name as $name
+        | select($names | index($name))
+        | select((.status.replicas // 0) > 0)
+        | "\($name)=\(.status.replicas)" ] | join(" ")')
+
+    if [ -z "$pending" ]; then
+      echo "[ctl_api startup] drained"
+      return 0
+    fi
+
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "[ctl_api startup] WARN: still running: $pending"
+      echo "[ctl_api startup] WARN: migrating anyway, expect lock contention"
+      return 0
+    fi
+
+    sleep 5
+  done
+}
+
+# best effort throughout: a half-restored ctl-api is worse than a noisy log.
+restore_state() {
+  if ! state_exists; then
+    return 0
+  fi
+
+  local deployments hpas
+  deployments=$(state_get deployments.json)
+  hpas=$(state_get hpas.json)
+
+  # replicas first, then hpas: a native hpa will not scale a deployment up off 0 (no pods
+  # means no metrics), so the deployments have to be seeded explicitly.
+  echo "[ctl_api startup] restoring replicas"
+  echo "$deployments" | jq -r '.[] | "\(.name) \(.replicas)"' | while read -r name replicas; do
+    kubectl scale -n "$namespace" --replicas="$replicas" "deployment/$name" || true
+  done
+
+  if [ "$(echo "$hpas" | jq '.items | length')" -gt 0 ]; then
+    echo "[ctl_api startup] restoring hpas"
+    echo "$hpas" | kubectl apply -f - || true
+  fi
+
+  kubectl delete configmap -n "$namespace" "$state_configmap" --ignore-not-found
+}
+
+on_exit() {
+  local rc="${1:-$?}"
+  # drop every trap first: exit below would otherwise re-enter this via the EXIT trap.
+  trap - EXIT INT TERM
+
+  if [ -n "${migrate_pid:-}" ]; then
+    kill "$migrate_pid" 2>/dev/null || true
+  fi
+
+  echo "[ctl_api startup] scaling ctl-api back up (exit=$rc)"
+  restore_state || true
+  kubectl scale -n "$namespace" --replicas=0 "deployment/$deployment_name" || true
+
+  exit "$rc"
+}
 
 echo "[ctl_api startup] kubectl auth whoami"
 kubectl auth whoami -o json | jq -c
+
+trap on_exit EXIT
+trap 'on_exit 143' INT TERM
 
 echo "[ctl_api startup] scale up the deployment"
 # NOTE(fd): this is only stricktly necessary when we run this action manually. during the normal
@@ -25,10 +178,26 @@ kubectl wait deployment -n ctl-api $deployment_name --for condition=Available=Tr
 echo "[ctl_api startup] get a pod from the deployment"
 pod=`kubectl -n ctl-api get pods --selector app.nuon.co/name="$deployment_name" -o json | jq -r '.items[0].metadata.name'`
 
-echo "[ctl_api startup] preparing to initialize"
-kubectl --namespace=ctl-api exec  -i $pod -- \
-  env "LOG_LEVEL=$log_level" "DB_LOG_QUERIES=$db_log_queries" \
-  /bin/service startup
+# this pod sits on the public nodepool alongside the api deployments. scaling those to 0
+# leaves the node underutilized, and karpenter consolidates it out from under the migration
+# (consolidateAfter: 1m) - the pod is evicted and the migration dies with exit 137. the
+# annotation blocks voluntary disruption of the node for as long as this pod exists.
+echo "[ctl_api startup] protecting the pod from karpenter consolidation"
+kubectl annotate pod -n "$namespace" "$pod" karpenter.sh/do-not-disrupt=true --overwrite
 
-echo "[ctl_api startup] scale down the deployment"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 "deployment/$deployment_name"
+if [ "$scale_down_enabled" = "true" ]; then
+  save_state
+  scale_down
+else
+  echo "[ctl_api startup] SCALE_DOWN not enabled, migrating against live traffic"
+fi
+
+# backgrounded, then waited on: bash defers a trapped signal until the foreground child
+# returns, so with the exec in the foreground a SIGTERM would not restore scale until the
+# migration finished - long after the action has been killed.
+echo "[ctl_api startup] preparing to initialize"
+kubectl --namespace=ctl-api exec -i "$pod" -- \
+  env "LOG_LEVEL=$log_level" "DB_LOG_QUERIES=$db_log_queries" \
+  /bin/service startup &
+migrate_pid=$!
+wait "$migrate_pid"

--- a/byoc-nuon-gcp/actions/ctl_api/inspect_migrations/inspect_migrations.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/inspect_migrations/inspect_migrations.toml
@@ -1,6 +1,6 @@
 # action
-# description: lists ctl-api schema migrations (last 20 by updated_at) for the
-# README Migrations section, via the admin API.
+# description: lists ctl-api schema migrations for the README Migrations section, via
+# the admin API. Count is MIGRATIONS_LIMIT, newest last.
 name    = "inspect_migrations"
 labels  = { service = "ctl-api", type = "report" }
 timeout = "5m"
@@ -24,13 +24,22 @@ inline_contents = '''
 # Inspect ctl-api schema migrations via the admin API (GET /v1/general/migrations).
 # Emits one JSON object per migration keyed by "<created_at>_<id>" so the README
 # map-range renders them oldest -> newest; any error / in-progress migration is
-# naturally the most recent (last) row. Limited to the last 10 by created_at.
+# naturally the most recent (last) row. Shows the last MIGRATIONS_LIMIT by created_at,
+# 0 for all.
 
 set -e
 set -o pipefail
 set -u
 
 admin_api_addr="$ADMIN_API_URL"
+
+limit="${MIGRATIONS_LIMIT:-10}"
+case "$limit" in
+  ''|*[!0-9]*)
+    echo "[inspect_migrations] invalid MIGRATIONS_LIMIT '$limit', using 10" >&2
+    limit=10
+    ;;
+esac
 
 echo "[inspect_migrations] GET $admin_api_addr/v1/general/migrations"
 body_file=$(mktemp)
@@ -53,12 +62,12 @@ if ! echo "$migrations" | jq -e 'type == "array"' >/dev/null 2>&1; then
 fi
 
 count=$(echo "$migrations" | jq 'length')
-echo "[inspect_migrations] $count migration(s) returned"
+echo "[inspect_migrations] $count migration(s) returned, showing last $limit"
 
-echo "$migrations" | jq -c '
+echo "$migrations" | jq -c --argjson limit "$limit" '
   [ .[] | { id, name, status: (.status // "unknown"), created_at, updated_at } ]
   | sort_by(.created_at)
-  | .[-10:][]
+  | .[-$limit:][]
   | { ("\(.created_at)_\(.id)"): . }
 ' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
 
@@ -67,3 +76,6 @@ echo "[inspect_migrations] done"
 
 [steps.env_vars]
 ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+
+# how many migrations to report, newest last. 0 for all.
+MIGRATIONS_LIMIT = "10"

--- a/byoc-nuon-gcp/runbooks/inspect_migrations.toml
+++ b/byoc-nuon-gcp/runbooks/inspect_migrations.toml
@@ -1,5 +1,5 @@
 name        = "inspect_migrations"
-description = "Inspect ctl-api schema migrations — the last 10 by created_at, with status."
+description = "Inspect ctl-api schema migrations by created_at, with status. Count is set by MIGRATIONS_LIMIT."
 readme      = "./runbooks/inspect_migrations.md"
 labels      = { service = "ctl-api", type = "debug" }
 

--- a/byoc-nuon/actions/ctl_api/ctl_api_post_deploy_startup/ctl_api_post_deploy_startup.toml
+++ b/byoc-nuon/actions/ctl_api/ctl_api_post_deploy_startup/ctl_api_post_deploy_startup.toml
@@ -1,7 +1,7 @@
 # action
 name    = "ctl_api_post_deploy_startup"
 labels  = { service = "ctl-api", type = "step" }
-timeout = "1m30s"
+timeout = "20m"
 
 [[triggers]]
 type           = "post-deploy-component"
@@ -20,3 +20,7 @@ SECRET_ARN = "{{ .nuon.components.rds_cluster_nuon.outputs.db_instance_master_us
 DB_ADDR    = "{{ .nuon.components.rds_cluster_nuon.outputs.address }}"
 DB_PORT    = "5432"
 REGION     = "{{ .nuon.install_stack.outputs.region }}"
+
+# off by default: scaling to 0 takes the whole control plane down for the migration.
+# flip to "true" for a deploy with a heavy index migration that live writes would block.
+SCALE_DOWN = "false"

--- a/byoc-nuon/actions/ctl_api/ctl_api_post_deploy_startup/startup.sh
+++ b/byoc-nuon/actions/ctl_api/ctl_api_post_deploy_startup/startup.sh
@@ -4,18 +4,169 @@ set -e
 set -o pipefail
 set -u
 
-db_addr="$DB_ADDR"
-db_port="$DB_PORT"
-region="$REGION"
-secret_arn="$SECRET_ARN"
 log_level="${LOG_LEVEL:-info}"
 db_log_queries="${DB_LOG_QUERIES:-false}"
 
 # internal
+namespace="ctl-api"
 deployment_name="ctl-api-startup"
+state_configmap="ctl-api-startup-scale-state"
+
+# ctl-api-startup runs the migration; ctl-api-init is the psql jump box.
+keep_deployments="ctl-api-startup ctl-api-init"
+
+drain_timeout="${DRAIN_TIMEOUT:-240}"
+
+# scaling ctl-api to 0 takes the whole control plane down, so it is opt-in: the
+# post-deploy action sets it, the manual action does not. leftover state from an aborted
+# run is still restored either way.
+scale_down_enabled="${SCALE_DOWN:-false}"
+
+state_exists() {
+  kubectl get configmap -n "$namespace" "$state_configmap" >/dev/null 2>&1
+}
+
+state_get() {
+  kubectl get configmap -n "$namespace" "$state_configmap" -o json | jq -r --arg key "$1" '.data[$key]'
+}
+
+# save_state is write-once on purpose. a run that dies after scaling down leaves the
+# configmap behind holding the real replica counts; re-saving here would record the
+# scaled-down values (0) as the originals and lose them for good.
+save_state() {
+  if state_exists; then
+    echo "[ctl_api startup] reusing scale state from a previous run"
+    state_get deployments.json | jq -r '.[] | "  \(.name): \(.replicas)"'
+    return 0
+  fi
+
+  local deployments hpas
+  deployments=$(kubectl get deploy -n "$namespace" -o json | jq -c --arg keep "$keep_deployments" '
+    ($keep | split(" ")) as $keep
+    | [ .items[]
+        | .metadata.name as $name
+        | select(($keep | index($name)) | not)
+        | { name: $name, replicas: (.spec.replicas // 0) } ]')
+
+  # strip server-managed fields so the manifest re-applies cleanly, but keep the rest of
+  # the annotations: helm ownership metadata lives there, and re-applying without it makes
+  # the next chart deploy fail on invalid ownership. matches ctl_api_pause_worker_hpas.
+  hpas=$(kubectl get hpa -n "$namespace" -o json | jq -c '
+    { apiVersion: "v1", kind: "List",
+      items: [ .items[]
+        | del(.status, .metadata.resourceVersion, .metadata.uid,
+              .metadata.creationTimestamp, .metadata.generation,
+              .metadata.managedFields, .metadata.selfLink)
+        | .metadata.annotations |= ((. // {})
+            | with_entries(select(.key | startswith("kubectl.kubernetes.io") | not))) ] }')
+
+  echo "[ctl_api startup] saving scale state"
+  echo "$deployments" | jq -r '.[] | "  \(.name): \(.replicas)"'
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  printf '%s' "$deployments" > "$tmpdir/deployments.json"
+  printf '%s' "$hpas" > "$tmpdir/hpas.json"
+  kubectl create configmap -n "$namespace" "$state_configmap" \
+    --from-file="$tmpdir/deployments.json" \
+    --from-file="$tmpdir/hpas.json"
+  rm -rf "$tmpdir"
+}
+
+scale_down() {
+  local names_json hpa_names
+  names_json=$(state_get deployments.json | jq -c '[ .[].name ]')
+
+  # an hpa cannot have minReplicas=0 on EKS/GKE, so it has to be deleted outright or
+  # it scales the deployment straight back up within ~15s.
+  hpa_names=$(state_get hpas.json | jq -r --argjson names "$names_json" '
+    .items[]
+    | .spec.scaleTargetRef.name as $target
+    | select($names | index($target))
+    | .metadata.name')
+
+  echo "[ctl_api startup] deleting hpas"
+  for name in $hpa_names; do
+    kubectl delete hpa -n "$namespace" "$name" --ignore-not-found
+  done
+
+  echo "[ctl_api startup] scaling deployments to 0"
+  for name in $(echo "$names_json" | jq -r '.[]'); do
+    kubectl scale -n "$namespace" --replicas=0 "deployment/$name"
+  done
+
+  echo "[ctl_api startup] waiting up to ${drain_timeout}s for pods to terminate"
+  local deadline=$((SECONDS + drain_timeout))
+  while :; do
+    local pending
+    pending=$(kubectl get deploy -n "$namespace" -o json | jq -r --argjson names "$names_json" '
+      [ .items[]
+        | .metadata.name as $name
+        | select($names | index($name))
+        | select((.status.replicas // 0) > 0)
+        | "\($name)=\(.status.replicas)" ] | join(" ")')
+
+    if [ -z "$pending" ]; then
+      echo "[ctl_api startup] drained"
+      return 0
+    fi
+
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "[ctl_api startup] WARN: still running: $pending"
+      echo "[ctl_api startup] WARN: migrating anyway, expect lock contention"
+      return 0
+    fi
+
+    sleep 5
+  done
+}
+
+# best effort throughout: a half-restored ctl-api is worse than a noisy log.
+restore_state() {
+  if ! state_exists; then
+    return 0
+  fi
+
+  local deployments hpas
+  deployments=$(state_get deployments.json)
+  hpas=$(state_get hpas.json)
+
+  # replicas first, then hpas: a native hpa will not scale a deployment up off 0 (no pods
+  # means no metrics), so the deployments have to be seeded explicitly.
+  echo "[ctl_api startup] restoring replicas"
+  echo "$deployments" | jq -r '.[] | "\(.name) \(.replicas)"' | while read -r name replicas; do
+    kubectl scale -n "$namespace" --replicas="$replicas" "deployment/$name" || true
+  done
+
+  if [ "$(echo "$hpas" | jq '.items | length')" -gt 0 ]; then
+    echo "[ctl_api startup] restoring hpas"
+    echo "$hpas" | kubectl apply -f - || true
+  fi
+
+  kubectl delete configmap -n "$namespace" "$state_configmap" --ignore-not-found
+}
+
+on_exit() {
+  local rc="${1:-$?}"
+  # drop every trap first: exit below would otherwise re-enter this via the EXIT trap.
+  trap - EXIT INT TERM
+
+  if [ -n "${migrate_pid:-}" ]; then
+    kill "$migrate_pid" 2>/dev/null || true
+  fi
+
+  echo "[ctl_api startup] scaling ctl-api back up (exit=$rc)"
+  restore_state || true
+  kubectl scale -n "$namespace" --replicas=0 "deployment/$deployment_name" || true
+
+  exit "$rc"
+}
 
 echo "[ctl_api startup] kubectl auth whoami"
 kubectl auth whoami -o json | jq -c
+
+trap on_exit EXIT
+trap 'on_exit 143' INT TERM
 
 echo "[ctl_api startup] scale up the deployment"
 # NOTE(fd): this is only stricktly necessary when we run this action manually. during the normal
@@ -27,10 +178,26 @@ kubectl wait deployment -n ctl-api $deployment_name --for condition=Available=Tr
 echo "[ctl_api startup] get a pod from the deployment"
 pod=`kubectl -n ctl-api get pods --selector app.nuon.co/name="$deployment_name" -o json | jq -r '.items[0].metadata.name'`
 
-echo "[ctl_api startup] preparing to initialize"
-kubectl --namespace=ctl-api exec  -i $pod -- \
-  env "LOG_LEVEL=$log_level" "DB_LOG_QUERIES=$db_log_queries" \
-  /bin/service startup
+# this pod sits on the public nodepool alongside the api deployments. scaling those to 0
+# leaves the node underutilized, and karpenter consolidates it out from under the migration
+# (consolidateAfter: 1m) - the pod is evicted and the migration dies with exit 137. the
+# annotation blocks voluntary disruption of the node for as long as this pod exists.
+echo "[ctl_api startup] protecting the pod from karpenter consolidation"
+kubectl annotate pod -n "$namespace" "$pod" karpenter.sh/do-not-disrupt=true --overwrite
 
-echo "[ctl_api startup] scale down the deployment"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 "deployment/$deployment_name"
+if [ "$scale_down_enabled" = "true" ]; then
+  save_state
+  scale_down
+else
+  echo "[ctl_api startup] SCALE_DOWN not enabled, migrating against live traffic"
+fi
+
+# backgrounded, then waited on: bash defers a trapped signal until the foreground child
+# returns, so with the exec in the foreground a SIGTERM would not restore scale until the
+# migration finished - long after the action has been killed.
+echo "[ctl_api startup] preparing to initialize"
+kubectl --namespace=ctl-api exec -i "$pod" -- \
+  env "LOG_LEVEL=$log_level" "DB_LOG_QUERIES=$db_log_queries" \
+  /bin/service startup &
+migrate_pid=$!
+wait "$migrate_pid"

--- a/byoc-nuon/actions/ctl_api/inspect_migrations/inspect-migrations.sh
+++ b/byoc-nuon/actions/ctl_api/inspect_migrations/inspect-migrations.sh
@@ -4,13 +4,21 @@
 # Emits one JSON object per migration to $NUON_ACTIONS_OUTPUT_FILEPATH, keyed by
 # "<created_at>_<id>" so the README map-range renders them oldest -> newest.
 # Migrations run in sequence, so any error / in-progress migration is naturally
-# the most recent (last) row. Limited to the last 10 by created_at.
+# the most recent (last) row. Shows the last MIGRATIONS_LIMIT by created_at, 0 for all.
 
 set -e
 set -o pipefail
 set -u
 
 admin_api_addr="$ADMIN_API_URL"
+
+limit="${MIGRATIONS_LIMIT:-10}"
+case "$limit" in
+  ''|*[!0-9]*)
+    echo "[inspect_migrations] invalid MIGRATIONS_LIMIT '$limit', using 10" >&2
+    limit=10
+    ;;
+esac
 
 echo "[inspect_migrations] GET $admin_api_addr/v1/general/migrations"
 migrations=$(curl --max-time 30 -s "$admin_api_addr/v1/general/migrations")
@@ -21,12 +29,12 @@ if ! echo "$migrations" | jq -e 'type == "array"' >/dev/null 2>&1; then
 fi
 
 count=$(echo "$migrations" | jq 'length')
-echo "[inspect_migrations] $count migration(s) returned"
+echo "[inspect_migrations] $count migration(s) returned, showing last $limit"
 
-echo "$migrations" | jq -c '
+echo "$migrations" | jq -c --argjson limit "$limit" '
   [ .[] | { id, name, status: (.status // "unknown"), created_at, updated_at } ]
   | sort_by(.created_at)
-  | .[-10:][]
+  | .[-$limit:][]
   | { ("\(.created_at)_\(.id)"): . }
 ' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
 

--- a/byoc-nuon/actions/ctl_api/inspect_migrations/inspect_migrations.toml
+++ b/byoc-nuon/actions/ctl_api/inspect_migrations/inspect_migrations.toml
@@ -1,6 +1,6 @@
 # action
-# description: lists ctl-api schema migrations (last 20 by updated_at) for the
-# README Migrations section, via the admin API.
+# description: lists ctl-api schema migrations for the README Migrations section, via
+# the admin API. Count is MIGRATIONS_LIMIT, newest last.
 name    = "inspect_migrations"
 labels  = { service = "ctl-api", type = "report" }
 timeout = "5m"
@@ -22,3 +22,6 @@ inline_contents = "./ctl_api/inspect_migrations/inspect-migrations.sh"
 
 [steps.env_vars]
 ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+
+# how many migrations to report, newest last. 0 for all.
+MIGRATIONS_LIMIT = "10"

--- a/byoc-nuon/runbooks/inspect_migrations.toml
+++ b/byoc-nuon/runbooks/inspect_migrations.toml
@@ -1,5 +1,5 @@
 name        = "inspect_migrations"
-description = "Inspect ctl-api schema migrations — the last 10 by created_at, with status."
+description = "Inspect ctl-api schema migrations by created_at, with status. Count is set by MIGRATIONS_LIMIT."
 readme      = "./runbooks/inspect_migrations.md"
 labels      = { service = "ctl-api", type = "debug" }
 


### PR DESCRIPTION
Came out of the 0.19.1074 upgrade, where a CREATE INDEX on queue_signals kept dying during post-deploy startup. Only ctl_api_post_deploy_startup is touched, the manual ctl_api_startup action is left alone.

The action timeout was 90s while the migrator's own context allows 5m, and the startup command sleeps 60s at the end for the datadog agent, so migrations effectively had ~25s. It is 20m now.

Adds an optional migration window behind SCALE_DOWN, off by default because it takes the whole control plane down. When enabled it saves replica counts and HPA manifests to a configmap, deletes the HPAs, scales everything to 0, migrates against a quiet database, then restores. HPAs have to be deleted rather than zeroed, minReplicas cannot be 0 on EKS or GKE and the HPA scales the deployment straight back up within ~15s.

A few things that took a couple of runs to get right:

The state configmap is write-once. A run that dies after scaling down leaves it behind holding the real replica counts, and re-saving would record the scaled-down 0s as the originals and lose them.

Restore runs from a trap on EXIT, INT and TERM. EXIT alone does not fire on SIGTERM. And the migration exec is backgrounded and waited on, because bash defers a trapped signal until the foreground child returns, so with the exec in the foreground the restore would not happen until the migration finished, long after the action was killed.

The startup pod gets karpenter.sh/do-not-disrupt. It shares the public nodepool with the api deployments, so scaling those to 0 left the node underutilized and karpenter consolidated it out from under the migration (consolidateAfter 1m), killing it with exit 137.

Replicas are restored before the HPAs go back, since a native HPA will not scale a deployment up off 0.

Separately, inspect_migrations only ever showed the last 10 by created_at, which hid a migration that had been failing since 2025. That count is MIGRATIONS_LIMIT now, 0 for all.

Image tag bumps in the working tree are left alone for the tag-bump automation.