### PR TITLE
feat: manage org feature flags from runbooks

### DIFF
--- a/byoc-nuon-gcp/actions/ctl_api/enable_org_feature_flag/enable-org-feature-flag.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/enable_org_feature_flag/enable-org-feature-flag.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FEATURE_FLAG:?FEATURE_FLAG is required}"
+: "${CONFIRMATION:?CONFIRMATION is required}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+api_get() {
+  local path="$1" destination="$2" status
+  status="$(curl --silent --show-error --connect-timeout 10 --max-time 30 --output "$destination" --write-out '%{http_code}' \
+    -H 'Accept: application/json' -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" "$ADMIN_API_URL$path")"
+  if [[ "$status" != "200" ]]; then
+    echo "ERROR: GET $path returned HTTP $status" >&2; cat "$destination" >&2; echo >&2; return 1
+  fi
+  if ! jq -e . "$destination" >/dev/null 2>&1; then
+    echo "ERROR: GET $path returned invalid JSON:" >&2; cat "$destination" >&2; echo >&2; return 1
+  fi
+}
+
+fetch_orgs_once() {
+  local destination="$1" scan="$2" limit=100 offset=0 page count
+  printf '[]' >"$destination"
+  while :; do
+    page="$tmp_dir/$scan-page-$offset.json"
+    api_get "/v1/orgs?type=all&limit=$limit&offset=$offset" "$page"
+    if ! jq -e 'type == "array" and all(.[]; type == "object" and (.id | type == "string" and length > 0) and (.name | type == "string") and (.features | type == "object"))' "$page" >/dev/null; then
+      echo "ERROR: org page at offset $offset has an unexpected shape" >&2; jq -c . "$page" >&2; return 1
+    fi
+    count="$(jq 'length' "$page")"
+    jq -s '.[0] + .[1]' "$destination" "$page" >"$destination.next"; mv "$destination.next" "$destination"
+    (( count < limit )) && break
+    offset=$((offset + limit))
+  done
+  if ! jq -e '([.[].id] | length) == ([.[].id] | unique | length)' "$destination" >/dev/null; then
+    echo "ERROR: paginated org response contains duplicate IDs" >&2; return 1
+  fi
+  jq 'sort_by(.id)' "$destination" >"$destination.sorted"; mv "$destination.sorted" "$destination"
+}
+
+fetch_stable_orgs() {
+  local destination="$1" attempt first second
+  for attempt in 1 2 3; do
+    first="$tmp_dir/stable-$attempt-first.json"; second="$tmp_dir/stable-$attempt-second.json"
+    fetch_orgs_once "$first" "$attempt-first"; fetch_orgs_once "$second" "$attempt-second"
+    if cmp -s <(jq -c '[.[].id]' "$first") <(jq -c '[.[].id]' "$second"); then cp "$second" "$destination"; return 0; fi
+    echo "WARN: org ID set changed during pagination scan (attempt $attempt/3); retrying" >&2
+  done
+  echo "ERROR: could not obtain two consecutive org scans with identical ID sets" >&2; return 1
+}
+
+feature_count() { jq --arg feature "$2" '[.[] | select(.features[$feature] == true)] | length' "$1"; }
+invariant_count() { jq '[.[] | select(.features["control-plane-builds"] == true and .features["org-runner"] == true)] | length' "$1"; }
+
+log_post_state() {
+  local orgs="$1" total enabled disabled
+  total="$(jq 'length' "$orgs")"; enabled="$(feature_count "$orgs" "$FEATURE_FLAG")"; disabled=$((total - enabled))
+  echo "Post-PATCH state for $FEATURE_FLAG: enabled=$enabled disabled=$disabled" >&2
+  if (( disabled > 0 )); then
+    echo "Organizations still disabled for $FEATURE_FLAG:" >&2
+    jq -r --arg feature "$FEATURE_FLAG" '.[] | select(.features[$feature] != true) | "id=\(.id[0:1000]) name=\(.name[0:1000] | @json)"' "$orgs" >&2
+  fi
+}
+
+if [[ ! "$FEATURE_FLAG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then echo "ERROR: invalid feature flag format" >&2; exit 1; fi
+if [[ "$CONFIRMATION" != "$FEATURE_FLAG" ]]; then echo "ERROR: confirmation must exactly equal the feature key" >&2; exit 1; fi
+
+catalog="$tmp_dir/catalog.json"; api_get "/v1/orgs/admin-features" "$catalog"
+if ! jq -e 'type == "array" and all(.[]; type == "object" and (.name | type == "string" and length > 0) and (.description | type == "string")) and ([.[].name] | length == (unique | length))' "$catalog" >/dev/null; then
+  echo "ERROR: feature catalog has an unexpected shape or duplicate names" >&2; exit 1
+fi
+if ! jq -e --arg feature "$FEATURE_FLAG" 'any(.[]; .name == $feature)' "$catalog" >/dev/null; then echo "ERROR: feature flag is not present in the ctl-api feature catalog" >&2; exit 1; fi
+description="$(jq -r --arg feature "$FEATURE_FLAG" '.[] | select(.name == $feature) | .description' "$catalog")"
+
+before="$tmp_dir/before.json"; fetch_stable_orgs "$before"
+total_before="$(jq 'length' "$before")"; enabled_before="$(feature_count "$before" "$FEATURE_FLAG")"; disabled_before=$((total_before - enabled_before))
+cpb_before="$(feature_count "$before" control-plane-builds)"; runner_before="$(feature_count "$before" org-runner)"
+invariant_before="$(invariant_count "$before")"
+if (( invariant_before != 0 )) && [[ "$FEATURE_FLAG" != "control-plane-builds" && "$FEATURE_FLAG" != "org-runner" ]]; then
+  echo "ERROR: $invariant_before org(s) already violate control-plane-builds/org-runner mutual exclusion; refusing unrelated mutation" >&2; exit 1
+fi
+
+status="enabled"; after="$tmp_dir/after.json"
+if (( disabled_before == 0 && invariant_before == 0 )); then
+  status="noop"; cp "$before" "$after"
+else
+  payload="$tmp_dir/payload.json"; response="$tmp_dir/patch-response.json"
+  jq -nc --arg feature "$FEATURE_FLAG" '{features: {($feature): true}}' >"$payload"
+  patch_ok=true; http_status="000"
+  if ! http_status="$(curl --silent --show-error --connect-timeout 10 --max-time 300 --request PATCH \
+    --output "$response" --write-out '%{http_code}' -H 'Accept: application/json' -H 'Content-Type: application/json' \
+    -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" --data-binary "@$payload" "$ADMIN_API_URL/v1/orgs/admin-features")"; then
+    patch_ok=false; echo "ERROR: PATCH /v1/orgs/admin-features failed during transport" >&2
+  elif [[ "$http_status" != "200" ]]; then
+    patch_ok=false; echo "ERROR: PATCH /v1/orgs/admin-features returned HTTP $http_status" >&2; cat "$response" >&2; echo >&2
+  elif ! jq -e 'type == "object"' "$response" >/dev/null 2>&1; then
+    patch_ok=false; echo "ERROR: PATCH /v1/orgs/admin-features returned invalid JSON or the wrong shape" >&2; cat "$response" >&2; echo >&2
+  fi
+  # PATCH is deliberately never retried. Always inspect its possibly-partial post-state.
+  fetch_stable_orgs "$after"
+  log_post_state "$after"
+  [[ "$patch_ok" == true ]] || exit 1
+fi
+
+total_after="$(jq 'length' "$after")"; enabled_after="$(feature_count "$after" "$FEATURE_FLAG")"; disabled_after=$((total_after - enabled_after))
+cpb_after="$(feature_count "$after" control-plane-builds)"; runner_after="$(feature_count "$after" org-runner)"
+invariant_after="$(invariant_count "$after")"
+if (( disabled_after != 0 )); then log_post_state "$after"; echo "ERROR: verification failed: $disabled_after org(s) still have $FEATURE_FLAG disabled" >&2; exit 1; fi
+if (( invariant_after != 0 )); then echo "ERROR: verification failed: $invariant_after org(s) have both control-plane-builds and org-runner enabled" >&2; exit 1; fi
+
+jq -nc --arg feature "$FEATURE_FLAG" --arg description "$description" --arg status "$status" \
+  --argjson total_before "$total_before" --argjson enabled_before "$enabled_before" --argjson disabled_before "$disabled_before" \
+  --argjson total_after "$total_after" --argjson enabled_after "$enabled_after" --argjson disabled_after "$disabled_after" \
+  --argjson cpb_before "$cpb_before" --argjson cpb_after "$cpb_after" --argjson runner_before "$runner_before" --argjson runner_after "$runner_after" \
+  --argjson changed "$((enabled_after - enabled_before))" --argjson invariant_before "$invariant_before" --argjson invariant_after "$invariant_after" '
+  {feature: $feature, description: $description, status: $status,
+   before: {total_orgs: $total_before, enabled: $enabled_before, disabled: $disabled_before},
+   after: {total_orgs: $total_after, enabled: $enabled_after, disabled: $disabled_after}, changed: $changed,
+   coupled_flags: {before: {"control-plane-builds": $cpb_before, "org-runner": $runner_before}, after: {"control-plane-builds": $cpb_after, "org-runner": $runner_after}},
+   invariant_before: $invariant_before, invariant_count: $invariant_after}' >>"$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon-gcp/actions/ctl_api/enable_org_feature_flag/enable_org_feature_flag.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/enable_org_feature_flag/enable_org_feature_flag.toml
@@ -1,0 +1,14 @@
+name    = "enable_org_feature_flag"
+labels  = { service = "ctl-api", type = "sop" }
+timeout = "10m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "enable org feature flag"
+inline_contents = "./ctl_api/enable_org_feature_flag/enable-org-feature-flag.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+ADMIN_EMAIL   = "feature-flags-runbook@nuon.co"

--- a/byoc-nuon-gcp/actions/ctl_api/inspect_org_feature_flags/inspect-org-feature-flags.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/inspect_org_feature_flags/inspect-org-feature-flags.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+case "${OUTPUT_MODE:-}" in
+  summary|orgs) ;;
+  *) echo "ERROR: OUTPUT_MODE must be summary or orgs" >&2; exit 1 ;;
+esac
+
+api_get() {
+  local path="$1" destination="$2" status
+  status="$(curl --silent --show-error --connect-timeout 10 --max-time 30 \
+    --output "$destination" --write-out '%{http_code}' \
+    -H 'Accept: application/json' \
+    -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" \
+    "$ADMIN_API_URL$path")"
+  if [[ "$status" != "200" ]]; then
+    echo "ERROR: GET $path returned HTTP $status" >&2
+    cat "$destination" >&2; echo >&2
+    return 1
+  fi
+  if ! jq -e . "$destination" >/dev/null 2>&1; then
+    echo "ERROR: GET $path returned invalid JSON:" >&2
+    cat "$destination" >&2; echo >&2
+    return 1
+  fi
+}
+
+fetch_orgs_once() {
+  local destination="$1" scan="$2" limit=100 offset=0 page count
+  printf '[]' >"$destination"
+  while :; do
+    page="$tmp_dir/$scan-page-$offset.json"
+    api_get "/v1/orgs?type=all&limit=$limit&offset=$offset" "$page"
+    if ! jq -e 'type == "array" and all(.[]; type == "object" and (.id | type == "string" and length > 0) and (.name | type == "string") and (.features | type == "object"))' "$page" >/dev/null; then
+      echo "ERROR: org page at offset $offset has an unexpected shape" >&2
+      jq -c . "$page" >&2
+      return 1
+    fi
+    count="$(jq 'length' "$page")"
+    jq -s '.[0] + .[1]' "$destination" "$page" >"$destination.next"
+    mv "$destination.next" "$destination"
+    (( count < limit )) && break
+    offset=$((offset + limit))
+  done
+  if ! jq -e '([.[].id] | length) == ([.[].id] | unique | length)' "$destination" >/dev/null; then
+    echo "ERROR: paginated org response contains duplicate IDs" >&2
+    return 1
+  fi
+  jq 'sort_by(.id)' "$destination" >"$destination.sorted"
+  mv "$destination.sorted" "$destination"
+}
+
+fetch_stable_orgs() {
+  local destination="$1" attempt first second
+  for attempt in 1 2 3; do
+    first="$tmp_dir/stable-$attempt-first.json"
+    second="$tmp_dir/stable-$attempt-second.json"
+    fetch_orgs_once "$first" "$attempt-first"
+    fetch_orgs_once "$second" "$attempt-second"
+    if cmp -s <(jq -c '[.[].id]' "$first") <(jq -c '[.[].id]' "$second"); then
+      cp "$second" "$destination"
+      return 0
+    fi
+    echo "WARN: org ID set changed during pagination scan (attempt $attempt/3); retrying" >&2
+  done
+  echo "ERROR: could not obtain two consecutive org scans with identical ID sets" >&2
+  return 1
+}
+
+emit_line() {
+  local line="$1" byte_count
+  byte_count="$(LC_ALL=C printf '%s\n' "$line" | wc -c | tr -d '[:space:]')"
+  if (( byte_count >= 65536 )); then
+    echo "ERROR: action output line would exceed the runner's 64 KiB limit" >&2
+    return 1
+  fi
+  printf '%s\n' "$line" >>"$NUON_ACTIONS_OUTPUT_FILEPATH"
+}
+
+catalog="$tmp_dir/catalog.json"
+api_get "/v1/orgs/admin-features" "$catalog"
+if ! jq -e 'type == "array" and all(.[]; type == "object" and (.name | type == "string" and length > 0) and (.description | type == "string")) and ([.[].name] | length == (unique | length))' "$catalog" >/dev/null; then
+  echo "ERROR: feature catalog has an unexpected shape or duplicate names" >&2
+  jq -c . "$catalog" >&2
+  exit 1
+fi
+
+orgs="$tmp_dir/orgs.json"
+fetch_stable_orgs "$orgs"
+
+if [[ "$OUTPUT_MODE" == "summary" ]]; then
+  summary="$(jq -nc --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" --slurpfile catalog "$catalog" --slurpfile orgs "$orgs" '
+    ($catalog[0]) as $catalog | ($orgs[0]) as $orgs | {
+      updated_at: $updated_at,
+      total_orgs: ($orgs | length),
+      features: [$catalog[] as $feature |
+        ([ $orgs[] | select(.features[$feature.name] == true) ] | length) as $enabled |
+        {name: $feature.name, description: $feature.description, enabled: $enabled, disabled: (($orgs | length) - $enabled)}]
+    }')"
+  emit_line "$summary"
+else
+  while IFS= read -r org; do
+    emit_line "$org"
+  done < <(jq -c '.[] | {(.id): {id, name, features: (.features // {})}}' "$orgs")
+fi

--- a/byoc-nuon-gcp/actions/ctl_api/inspect_org_feature_flags/inspect_org_feature_flags.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/inspect_org_feature_flags/inspect_org_feature_flags.toml
@@ -1,0 +1,24 @@
+name    = "inspect_org_feature_flags"
+labels  = { service = "ctl-api", type = "report" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "summary"
+inline_contents = "./ctl_api/inspect_org_feature_flags/inspect-org-feature-flags.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+ADMIN_EMAIL   = "feature-flags-runbook@nuon.co"
+OUTPUT_MODE   = "summary"
+
+[[steps]]
+name            = "orgs"
+inline_contents = "./ctl_api/inspect_org_feature_flags/inspect-org-feature-flags.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+ADMIN_EMAIL   = "feature-flags-runbook@nuon.co"
+OUTPUT_MODE   = "orgs"

--- a/byoc-nuon-gcp/runbooks/enable_org_feature_flag.md
+++ b/byoc-nuon-gcp/runbooks/enable_org_feature_flag.md
@@ -1,0 +1,39 @@
+# Enable an organization feature flag globally
+
+<nuon-banner theme="warn"><strong>Warning:</strong> This enables the selected feature for every non-deleted organization. Type the feature key again in the confirmation field. The flags are bidirectionally coupled: enabling <code>control-plane-builds</code> disables <code>org-runner</code>, and enabling <code>org-runner</code> disables <code>control-plane-builds</code>.</nuon-banner>
+
+The action validates the key against the live ctl-api feature catalog, records before/after counts, applies one bulk ADMIN API PATCH when needed, and verifies every organization afterward.
+
+{{ $action := default dict (index (default dict .nuon.actions.workflows) "enable_org_feature_flag") }}
+{{ $output := default dict (dig "outputs" dict $action) }}
+{{ if and $action (dig "populated" false $action) (eq (dig "status" "" $action) "finished") }}
+
+## Result
+
+<table><tbody>
+  <tr><td>Feature</td><td><code>{{ dig "feature" "—" $output }}</code></td></tr>
+  <tr><td>Description</td><td>{{ dig "description" "—" $output }}</td></tr>
+  <tr><td>Status</td><td><nuon-label-badge theme="{{ if eq (dig "status" "" $output) "noop" }}info{{ else }}success{{ end }}" label="{{ dig "status" "—" $output }}"></nuon-label-badge></td></tr>
+  <tr><td>Changed organizations</td><td>{{ dig "changed" 0 $output }}</td></tr>
+  <tr><td>Mutual-exclusion invariant count</td><td>{{ dig "invariant_count" 0 $output }}</td></tr>
+</tbody></table>
+
+<table>
+  <thead><tr><th>State</th><th>Total orgs</th><th>Enabled</th><th>Disabled</th></tr></thead>
+  <tbody>
+    {{ $before := dig "before" (dict) $output }}{{ $after := dig "after" (dict) $output }}
+    <tr><td>Before</td><td>{{ dig "total_orgs" 0 $before }}</td><td>{{ dig "enabled" 0 $before }}</td><td>{{ dig "disabled" 0 $before }}</td></tr>
+    <tr><td>After</td><td>{{ dig "total_orgs" 0 $after }}</td><td>{{ dig "enabled" 0 $after }}</td><td>{{ dig "disabled" 0 $after }}</td></tr>
+  </tbody>
+</table>
+
+{{ $coupled := dig "coupled_flags" (dict) $output }}{{ $coupledBefore := dig "before" (dict) $coupled }}{{ $coupledAfter := dig "after" (dict) $coupled }}
+<h3>Coupled flag side effects</h3>
+<table><thead><tr><th>Feature</th><th>Before enabled</th><th>After enabled</th></tr></thead><tbody>
+  <tr><td><code>control-plane-builds</code></td><td>{{ dig "control-plane-builds" 0 $coupledBefore }}</td><td>{{ dig "control-plane-builds" 0 $coupledAfter }}</td></tr>
+  <tr><td><code>org-runner</code></td><td>{{ dig "org-runner" 0 $coupledBefore }}</td><td>{{ dig "org-runner" 0 $coupledAfter }}</td></tr>
+</tbody></table>
+
+{{ else }}
+<nuon-banner theme="info">Provide the feature key and type the feature key again to run this SOP.</nuon-banner>
+{{ end }}

--- a/byoc-nuon-gcp/runbooks/enable_org_feature_flag.toml
+++ b/byoc-nuon-gcp/runbooks/enable_org_feature_flag.toml
@@ -1,0 +1,27 @@
+name        = "enable_org_feature_flag"
+description = "Enable one ctl-api feature flag for every non-deleted organization."
+readme      = "./runbooks/enable_org_feature_flag.md"
+labels      = { service = "ctl-api", type = "sop" }
+
+[[input]]
+name         = "feature_flag"
+display_name = "Feature key"
+description  = "Exact feature key from the ctl-api feature catalog."
+required     = true
+type         = "string"
+
+[[input]]
+name         = "confirmation"
+display_name = "Confirmation"
+description  = "Type the feature key again. It must match exactly."
+required     = true
+type         = "string"
+
+[[steps]]
+name        = "Enable org feature flag"
+type        = "action"
+action_name = "enable_org_feature_flag"
+
+[steps.env_vars]
+FEATURE_FLAG = "{{ .runbook_inputs.feature_flag }}"
+CONFIRMATION = "{{ .runbook_inputs.confirmation }}"

--- a/byoc-nuon-gcp/runbooks/inspect_org_feature_flags.md
+++ b/byoc-nuon-gcp/runbooks/inspect_org_feature_flags.md
@@ -1,0 +1,46 @@
+# Organization feature flags
+
+This report reads feature state from the ctl-api ADMIN API for every non-deleted organization.
+
+{{ $action := default dict (index (default dict .nuon.actions.workflows) "inspect_org_feature_flags") }}
+{{ $output := default dict (dig "outputs" dict $action) }}
+{{ $orgs := dig "steps" "orgs" (dict) $output }}
+{{ $actionID := dig "id" "" $action }}
+
+{{ if and $action (dig "populated" false $action) (eq (dig "status" "" $action) "finished") }}
+
+<nuon-group gap="2" align="center" justify="start"><nuon-label-badge theme="info" label="{{ dig "total_orgs" 0 $output }} orgs"></nuon-label-badge>{{ with dig "updated_at" "" $output }}<span style="margin-left:auto;font-size:0.85em;">Last updated by <a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/actions/{{ $actionID }}">inspect_org_feature_flags</a> <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</nuon-group>
+
+## Feature summary
+
+<table>
+  <thead><tr><th>Feature</th><th>Description</th><th>Enabled</th><th>Disabled</th></tr></thead>
+  <tbody>
+  {{ range dig "features" (list) $output }}
+    <tr><td><code>{{ dig "name" "—" . }}</code></td><td>{{ dig "description" "—" . }}</td><td>{{ dig "enabled" 0 . }}</td><td>{{ dig "disabled" 0 . }}</td></tr>
+  {{ end }}
+  </tbody>
+</table>
+
+## Organization details
+
+<table>
+  <thead><tr><th>Organization</th><th>ID</th><th>Features</th></tr></thead>
+  <tbody>
+  {{ range $id, $org := $orgs }}
+    <tr>
+      <td>{{ dig "name" "—" $org }}</td>
+      <td><code>{{ dig "id" "—" $org }}</code></td>
+      <td><nuon-panel heading="Features: {{ dig "name" "—" $org }}" trigger="View full map" size="1/2">
+        <table><thead><tr><th>Feature</th><th>Enabled</th></tr></thead><tbody>
+        {{ range $key, $enabled := dig "features" (dict) $org }}<tr><td><code>{{ $key }}</code></td><td>{{ $enabled }}</td></tr>{{ end }}
+        </tbody></table>
+      </nuon-panel></td>
+    </tr>
+  {{ end }}
+  </tbody>
+</table>
+
+{{ else }}
+<nuon-banner theme="warn">Run <code>inspect_org_feature_flags</code> to populate this report.</nuon-banner>
+{{ end }}

--- a/byoc-nuon-gcp/runbooks/inspect_org_feature_flags.toml
+++ b/byoc-nuon-gcp/runbooks/inspect_org_feature_flags.toml
@@ -1,0 +1,9 @@
+name        = "inspect_org_feature_flags"
+description = "Inspect every non-deleted organization's ctl-api feature flags."
+readme      = "./runbooks/inspect_org_feature_flags.md"
+labels      = { service = "ctl-api", type = "debug" }
+
+[[steps]]
+name        = "Inspect org feature flags"
+type        = "action"
+action_name = "inspect_org_feature_flags"

--- a/byoc-nuon/actions/ctl_api/enable_org_feature_flag/enable-org-feature-flag.sh
+++ b/byoc-nuon/actions/ctl_api/enable_org_feature_flag/enable-org-feature-flag.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FEATURE_FLAG:?FEATURE_FLAG is required}"
+: "${CONFIRMATION:?CONFIRMATION is required}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+api_get() {
+  local path="$1" destination="$2" status
+  status="$(curl --silent --show-error --connect-timeout 10 --max-time 30 --output "$destination" --write-out '%{http_code}' \
+    -H 'Accept: application/json' -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" "$ADMIN_API_URL$path")"
+  if [[ "$status" != "200" ]]; then
+    echo "ERROR: GET $path returned HTTP $status" >&2; cat "$destination" >&2; echo >&2; return 1
+  fi
+  if ! jq -e . "$destination" >/dev/null 2>&1; then
+    echo "ERROR: GET $path returned invalid JSON:" >&2; cat "$destination" >&2; echo >&2; return 1
+  fi
+}
+
+fetch_orgs_once() {
+  local destination="$1" scan="$2" limit=100 offset=0 page count
+  printf '[]' >"$destination"
+  while :; do
+    page="$tmp_dir/$scan-page-$offset.json"
+    api_get "/v1/orgs?type=all&limit=$limit&offset=$offset" "$page"
+    if ! jq -e 'type == "array" and all(.[]; type == "object" and (.id | type == "string" and length > 0) and (.name | type == "string") and (.features | type == "object"))' "$page" >/dev/null; then
+      echo "ERROR: org page at offset $offset has an unexpected shape" >&2; jq -c . "$page" >&2; return 1
+    fi
+    count="$(jq 'length' "$page")"
+    jq -s '.[0] + .[1]' "$destination" "$page" >"$destination.next"; mv "$destination.next" "$destination"
+    (( count < limit )) && break
+    offset=$((offset + limit))
+  done
+  if ! jq -e '([.[].id] | length) == ([.[].id] | unique | length)' "$destination" >/dev/null; then
+    echo "ERROR: paginated org response contains duplicate IDs" >&2; return 1
+  fi
+  jq 'sort_by(.id)' "$destination" >"$destination.sorted"; mv "$destination.sorted" "$destination"
+}
+
+fetch_stable_orgs() {
+  local destination="$1" attempt first second
+  for attempt in 1 2 3; do
+    first="$tmp_dir/stable-$attempt-first.json"; second="$tmp_dir/stable-$attempt-second.json"
+    fetch_orgs_once "$first" "$attempt-first"; fetch_orgs_once "$second" "$attempt-second"
+    if cmp -s <(jq -c '[.[].id]' "$first") <(jq -c '[.[].id]' "$second"); then cp "$second" "$destination"; return 0; fi
+    echo "WARN: org ID set changed during pagination scan (attempt $attempt/3); retrying" >&2
+  done
+  echo "ERROR: could not obtain two consecutive org scans with identical ID sets" >&2; return 1
+}
+
+feature_count() { jq --arg feature "$2" '[.[] | select(.features[$feature] == true)] | length' "$1"; }
+invariant_count() { jq '[.[] | select(.features["control-plane-builds"] == true and .features["org-runner"] == true)] | length' "$1"; }
+
+log_post_state() {
+  local orgs="$1" total enabled disabled
+  total="$(jq 'length' "$orgs")"; enabled="$(feature_count "$orgs" "$FEATURE_FLAG")"; disabled=$((total - enabled))
+  echo "Post-PATCH state for $FEATURE_FLAG: enabled=$enabled disabled=$disabled" >&2
+  if (( disabled > 0 )); then
+    echo "Organizations still disabled for $FEATURE_FLAG:" >&2
+    jq -r --arg feature "$FEATURE_FLAG" '.[] | select(.features[$feature] != true) | "id=\(.id[0:1000]) name=\(.name[0:1000] | @json)"' "$orgs" >&2
+  fi
+}
+
+if [[ ! "$FEATURE_FLAG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then echo "ERROR: invalid feature flag format" >&2; exit 1; fi
+if [[ "$CONFIRMATION" != "$FEATURE_FLAG" ]]; then echo "ERROR: confirmation must exactly equal the feature key" >&2; exit 1; fi
+
+catalog="$tmp_dir/catalog.json"; api_get "/v1/orgs/admin-features" "$catalog"
+if ! jq -e 'type == "array" and all(.[]; type == "object" and (.name | type == "string" and length > 0) and (.description | type == "string")) and ([.[].name] | length == (unique | length))' "$catalog" >/dev/null; then
+  echo "ERROR: feature catalog has an unexpected shape or duplicate names" >&2; exit 1
+fi
+if ! jq -e --arg feature "$FEATURE_FLAG" 'any(.[]; .name == $feature)' "$catalog" >/dev/null; then echo "ERROR: feature flag is not present in the ctl-api feature catalog" >&2; exit 1; fi
+description="$(jq -r --arg feature "$FEATURE_FLAG" '.[] | select(.name == $feature) | .description' "$catalog")"
+
+before="$tmp_dir/before.json"; fetch_stable_orgs "$before"
+total_before="$(jq 'length' "$before")"; enabled_before="$(feature_count "$before" "$FEATURE_FLAG")"; disabled_before=$((total_before - enabled_before))
+cpb_before="$(feature_count "$before" control-plane-builds)"; runner_before="$(feature_count "$before" org-runner)"
+invariant_before="$(invariant_count "$before")"
+if (( invariant_before != 0 )) && [[ "$FEATURE_FLAG" != "control-plane-builds" && "$FEATURE_FLAG" != "org-runner" ]]; then
+  echo "ERROR: $invariant_before org(s) already violate control-plane-builds/org-runner mutual exclusion; refusing unrelated mutation" >&2; exit 1
+fi
+
+status="enabled"; after="$tmp_dir/after.json"
+if (( disabled_before == 0 && invariant_before == 0 )); then
+  status="noop"; cp "$before" "$after"
+else
+  payload="$tmp_dir/payload.json"; response="$tmp_dir/patch-response.json"
+  jq -nc --arg feature "$FEATURE_FLAG" '{features: {($feature): true}}' >"$payload"
+  patch_ok=true; http_status="000"
+  if ! http_status="$(curl --silent --show-error --connect-timeout 10 --max-time 300 --request PATCH \
+    --output "$response" --write-out '%{http_code}' -H 'Accept: application/json' -H 'Content-Type: application/json' \
+    -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" --data-binary "@$payload" "$ADMIN_API_URL/v1/orgs/admin-features")"; then
+    patch_ok=false; echo "ERROR: PATCH /v1/orgs/admin-features failed during transport" >&2
+  elif [[ "$http_status" != "200" ]]; then
+    patch_ok=false; echo "ERROR: PATCH /v1/orgs/admin-features returned HTTP $http_status" >&2; cat "$response" >&2; echo >&2
+  elif ! jq -e 'type == "object"' "$response" >/dev/null 2>&1; then
+    patch_ok=false; echo "ERROR: PATCH /v1/orgs/admin-features returned invalid JSON or the wrong shape" >&2; cat "$response" >&2; echo >&2
+  fi
+  # PATCH is deliberately never retried. Always inspect its possibly-partial post-state.
+  fetch_stable_orgs "$after"
+  log_post_state "$after"
+  [[ "$patch_ok" == true ]] || exit 1
+fi
+
+total_after="$(jq 'length' "$after")"; enabled_after="$(feature_count "$after" "$FEATURE_FLAG")"; disabled_after=$((total_after - enabled_after))
+cpb_after="$(feature_count "$after" control-plane-builds)"; runner_after="$(feature_count "$after" org-runner)"
+invariant_after="$(invariant_count "$after")"
+if (( disabled_after != 0 )); then log_post_state "$after"; echo "ERROR: verification failed: $disabled_after org(s) still have $FEATURE_FLAG disabled" >&2; exit 1; fi
+if (( invariant_after != 0 )); then echo "ERROR: verification failed: $invariant_after org(s) have both control-plane-builds and org-runner enabled" >&2; exit 1; fi
+
+jq -nc --arg feature "$FEATURE_FLAG" --arg description "$description" --arg status "$status" \
+  --argjson total_before "$total_before" --argjson enabled_before "$enabled_before" --argjson disabled_before "$disabled_before" \
+  --argjson total_after "$total_after" --argjson enabled_after "$enabled_after" --argjson disabled_after "$disabled_after" \
+  --argjson cpb_before "$cpb_before" --argjson cpb_after "$cpb_after" --argjson runner_before "$runner_before" --argjson runner_after "$runner_after" \
+  --argjson changed "$((enabled_after - enabled_before))" --argjson invariant_before "$invariant_before" --argjson invariant_after "$invariant_after" '
+  {feature: $feature, description: $description, status: $status,
+   before: {total_orgs: $total_before, enabled: $enabled_before, disabled: $disabled_before},
+   after: {total_orgs: $total_after, enabled: $enabled_after, disabled: $disabled_after}, changed: $changed,
+   coupled_flags: {before: {"control-plane-builds": $cpb_before, "org-runner": $runner_before}, after: {"control-plane-builds": $cpb_after, "org-runner": $runner_after}},
+   invariant_before: $invariant_before, invariant_count: $invariant_after}' >>"$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/byoc-nuon/actions/ctl_api/enable_org_feature_flag/enable_org_feature_flag.toml
+++ b/byoc-nuon/actions/ctl_api/enable_org_feature_flag/enable_org_feature_flag.toml
@@ -1,0 +1,14 @@
+name    = "enable_org_feature_flag"
+labels  = { service = "ctl-api", type = "sop" }
+timeout = "10m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "enable org feature flag"
+inline_contents = "./ctl_api/enable_org_feature_flag/enable-org-feature-flag.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+ADMIN_EMAIL   = "feature-flags-runbook@nuon.co"

--- a/byoc-nuon/actions/ctl_api/inspect_org_feature_flags/inspect-org-feature-flags.sh
+++ b/byoc-nuon/actions/ctl_api/inspect_org_feature_flags/inspect-org-feature-flags.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+case "${OUTPUT_MODE:-}" in
+  summary|orgs) ;;
+  *) echo "ERROR: OUTPUT_MODE must be summary or orgs" >&2; exit 1 ;;
+esac
+
+api_get() {
+  local path="$1" destination="$2" status
+  status="$(curl --silent --show-error --connect-timeout 10 --max-time 30 \
+    --output "$destination" --write-out '%{http_code}' \
+    -H 'Accept: application/json' \
+    -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" \
+    "$ADMIN_API_URL$path")"
+  if [[ "$status" != "200" ]]; then
+    echo "ERROR: GET $path returned HTTP $status" >&2
+    cat "$destination" >&2; echo >&2
+    return 1
+  fi
+  if ! jq -e . "$destination" >/dev/null 2>&1; then
+    echo "ERROR: GET $path returned invalid JSON:" >&2
+    cat "$destination" >&2; echo >&2
+    return 1
+  fi
+}
+
+fetch_orgs_once() {
+  local destination="$1" scan="$2" limit=100 offset=0 page count
+  printf '[]' >"$destination"
+  while :; do
+    page="$tmp_dir/$scan-page-$offset.json"
+    api_get "/v1/orgs?type=all&limit=$limit&offset=$offset" "$page"
+    if ! jq -e 'type == "array" and all(.[]; type == "object" and (.id | type == "string" and length > 0) and (.name | type == "string") and (.features | type == "object"))' "$page" >/dev/null; then
+      echo "ERROR: org page at offset $offset has an unexpected shape" >&2
+      jq -c . "$page" >&2
+      return 1
+    fi
+    count="$(jq 'length' "$page")"
+    jq -s '.[0] + .[1]' "$destination" "$page" >"$destination.next"
+    mv "$destination.next" "$destination"
+    (( count < limit )) && break
+    offset=$((offset + limit))
+  done
+  if ! jq -e '([.[].id] | length) == ([.[].id] | unique | length)' "$destination" >/dev/null; then
+    echo "ERROR: paginated org response contains duplicate IDs" >&2
+    return 1
+  fi
+  jq 'sort_by(.id)' "$destination" >"$destination.sorted"
+  mv "$destination.sorted" "$destination"
+}
+
+fetch_stable_orgs() {
+  local destination="$1" attempt first second
+  for attempt in 1 2 3; do
+    first="$tmp_dir/stable-$attempt-first.json"
+    second="$tmp_dir/stable-$attempt-second.json"
+    fetch_orgs_once "$first" "$attempt-first"
+    fetch_orgs_once "$second" "$attempt-second"
+    if cmp -s <(jq -c '[.[].id]' "$first") <(jq -c '[.[].id]' "$second"); then
+      cp "$second" "$destination"
+      return 0
+    fi
+    echo "WARN: org ID set changed during pagination scan (attempt $attempt/3); retrying" >&2
+  done
+  echo "ERROR: could not obtain two consecutive org scans with identical ID sets" >&2
+  return 1
+}
+
+emit_line() {
+  local line="$1" byte_count
+  byte_count="$(LC_ALL=C printf '%s\n' "$line" | wc -c | tr -d '[:space:]')"
+  if (( byte_count >= 65536 )); then
+    echo "ERROR: action output line would exceed the runner's 64 KiB limit" >&2
+    return 1
+  fi
+  printf '%s\n' "$line" >>"$NUON_ACTIONS_OUTPUT_FILEPATH"
+}
+
+catalog="$tmp_dir/catalog.json"
+api_get "/v1/orgs/admin-features" "$catalog"
+if ! jq -e 'type == "array" and all(.[]; type == "object" and (.name | type == "string" and length > 0) and (.description | type == "string")) and ([.[].name] | length == (unique | length))' "$catalog" >/dev/null; then
+  echo "ERROR: feature catalog has an unexpected shape or duplicate names" >&2
+  jq -c . "$catalog" >&2
+  exit 1
+fi
+
+orgs="$tmp_dir/orgs.json"
+fetch_stable_orgs "$orgs"
+
+if [[ "$OUTPUT_MODE" == "summary" ]]; then
+  summary="$(jq -nc --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" --slurpfile catalog "$catalog" --slurpfile orgs "$orgs" '
+    ($catalog[0]) as $catalog | ($orgs[0]) as $orgs | {
+      updated_at: $updated_at,
+      total_orgs: ($orgs | length),
+      features: [$catalog[] as $feature |
+        ([ $orgs[] | select(.features[$feature.name] == true) ] | length) as $enabled |
+        {name: $feature.name, description: $feature.description, enabled: $enabled, disabled: (($orgs | length) - $enabled)}]
+    }')"
+  emit_line "$summary"
+else
+  while IFS= read -r org; do
+    emit_line "$org"
+  done < <(jq -c '.[] | {(.id): {id, name, features: (.features // {})}}' "$orgs")
+fi

--- a/byoc-nuon/actions/ctl_api/inspect_org_feature_flags/inspect_org_feature_flags.toml
+++ b/byoc-nuon/actions/ctl_api/inspect_org_feature_flags/inspect_org_feature_flags.toml
@@ -1,0 +1,24 @@
+name    = "inspect_org_feature_flags"
+labels  = { service = "ctl-api", type = "report" }
+timeout = "5m"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "summary"
+inline_contents = "./ctl_api/inspect_org_feature_flags/inspect-org-feature-flags.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+ADMIN_EMAIL   = "feature-flags-runbook@nuon.co"
+OUTPUT_MODE   = "summary"
+
+[[steps]]
+name            = "orgs"
+inline_contents = "./ctl_api/inspect_org_feature_flags/inspect-org-feature-flags.sh"
+
+[steps.env_vars]
+ADMIN_API_URL = "http://admin.{{ .nuon.sandbox.outputs.nuon_dns.internal_domain.name }}"
+ADMIN_EMAIL   = "feature-flags-runbook@nuon.co"
+OUTPUT_MODE   = "orgs"

--- a/byoc-nuon/runbooks/enable_org_feature_flag.md
+++ b/byoc-nuon/runbooks/enable_org_feature_flag.md
@@ -1,0 +1,39 @@
+# Enable an organization feature flag globally
+
+<nuon-banner theme="warn"><strong>Warning:</strong> This enables the selected feature for every non-deleted organization. Type the feature key again in the confirmation field. The flags are bidirectionally coupled: enabling <code>control-plane-builds</code> disables <code>org-runner</code>, and enabling <code>org-runner</code> disables <code>control-plane-builds</code>.</nuon-banner>
+
+The action validates the key against the live ctl-api feature catalog, records before/after counts, applies one bulk ADMIN API PATCH when needed, and verifies every organization afterward.
+
+{{ $action := default dict (index (default dict .nuon.actions.workflows) "enable_org_feature_flag") }}
+{{ $output := default dict (dig "outputs" dict $action) }}
+{{ if and $action (dig "populated" false $action) (eq (dig "status" "" $action) "finished") }}
+
+## Result
+
+<table><tbody>
+  <tr><td>Feature</td><td><code>{{ dig "feature" "—" $output }}</code></td></tr>
+  <tr><td>Description</td><td>{{ dig "description" "—" $output }}</td></tr>
+  <tr><td>Status</td><td><nuon-label-badge theme="{{ if eq (dig "status" "" $output) "noop" }}info{{ else }}success{{ end }}" label="{{ dig "status" "—" $output }}"></nuon-label-badge></td></tr>
+  <tr><td>Changed organizations</td><td>{{ dig "changed" 0 $output }}</td></tr>
+  <tr><td>Mutual-exclusion invariant count</td><td>{{ dig "invariant_count" 0 $output }}</td></tr>
+</tbody></table>
+
+<table>
+  <thead><tr><th>State</th><th>Total orgs</th><th>Enabled</th><th>Disabled</th></tr></thead>
+  <tbody>
+    {{ $before := dig "before" (dict) $output }}{{ $after := dig "after" (dict) $output }}
+    <tr><td>Before</td><td>{{ dig "total_orgs" 0 $before }}</td><td>{{ dig "enabled" 0 $before }}</td><td>{{ dig "disabled" 0 $before }}</td></tr>
+    <tr><td>After</td><td>{{ dig "total_orgs" 0 $after }}</td><td>{{ dig "enabled" 0 $after }}</td><td>{{ dig "disabled" 0 $after }}</td></tr>
+  </tbody>
+</table>
+
+{{ $coupled := dig "coupled_flags" (dict) $output }}{{ $coupledBefore := dig "before" (dict) $coupled }}{{ $coupledAfter := dig "after" (dict) $coupled }}
+<h3>Coupled flag side effects</h3>
+<table><thead><tr><th>Feature</th><th>Before enabled</th><th>After enabled</th></tr></thead><tbody>
+  <tr><td><code>control-plane-builds</code></td><td>{{ dig "control-plane-builds" 0 $coupledBefore }}</td><td>{{ dig "control-plane-builds" 0 $coupledAfter }}</td></tr>
+  <tr><td><code>org-runner</code></td><td>{{ dig "org-runner" 0 $coupledBefore }}</td><td>{{ dig "org-runner" 0 $coupledAfter }}</td></tr>
+</tbody></table>
+
+{{ else }}
+<nuon-banner theme="info">Provide the feature key and type the feature key again to run this SOP.</nuon-banner>
+{{ end }}

--- a/byoc-nuon/runbooks/enable_org_feature_flag.toml
+++ b/byoc-nuon/runbooks/enable_org_feature_flag.toml
@@ -1,0 +1,27 @@
+name        = "enable_org_feature_flag"
+description = "Enable one ctl-api feature flag for every non-deleted organization."
+readme      = "./runbooks/enable_org_feature_flag.md"
+labels      = { service = "ctl-api", type = "sop" }
+
+[[input]]
+name         = "feature_flag"
+display_name = "Feature key"
+description  = "Exact feature key from the ctl-api feature catalog."
+required     = true
+type         = "string"
+
+[[input]]
+name         = "confirmation"
+display_name = "Confirmation"
+description  = "Type the feature key again. It must match exactly."
+required     = true
+type         = "string"
+
+[[steps]]
+name        = "Enable org feature flag"
+type        = "action"
+action_name = "enable_org_feature_flag"
+
+[steps.env_vars]
+FEATURE_FLAG = "{{ .runbook_inputs.feature_flag }}"
+CONFIRMATION = "{{ .runbook_inputs.confirmation }}"

--- a/byoc-nuon/runbooks/inspect_org_feature_flags.md
+++ b/byoc-nuon/runbooks/inspect_org_feature_flags.md
@@ -1,0 +1,46 @@
+# Organization feature flags
+
+This report reads feature state from the ctl-api ADMIN API for every non-deleted organization.
+
+{{ $action := default dict (index (default dict .nuon.actions.workflows) "inspect_org_feature_flags") }}
+{{ $output := default dict (dig "outputs" dict $action) }}
+{{ $orgs := dig "steps" "orgs" (dict) $output }}
+{{ $actionID := dig "id" "" $action }}
+
+{{ if and $action (dig "populated" false $action) (eq (dig "status" "" $action) "finished") }}
+
+<nuon-group gap="2" align="center" justify="start"><nuon-label-badge theme="info" label="{{ dig "total_orgs" 0 $output }} orgs"></nuon-label-badge>{{ with dig "updated_at" "" $output }}<span style="margin-left:auto;font-size:0.85em;">Last updated by <a href="/{{ $.nuon.org.id }}/installs/{{ $.nuon.install.id }}/actions/{{ $actionID }}">inspect_org_feature_flags</a> <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}</nuon-group>
+
+## Feature summary
+
+<table>
+  <thead><tr><th>Feature</th><th>Description</th><th>Enabled</th><th>Disabled</th></tr></thead>
+  <tbody>
+  {{ range dig "features" (list) $output }}
+    <tr><td><code>{{ dig "name" "—" . }}</code></td><td>{{ dig "description" "—" . }}</td><td>{{ dig "enabled" 0 . }}</td><td>{{ dig "disabled" 0 . }}</td></tr>
+  {{ end }}
+  </tbody>
+</table>
+
+## Organization details
+
+<table>
+  <thead><tr><th>Organization</th><th>ID</th><th>Features</th></tr></thead>
+  <tbody>
+  {{ range $id, $org := $orgs }}
+    <tr>
+      <td>{{ dig "name" "—" $org }}</td>
+      <td><code>{{ dig "id" "—" $org }}</code></td>
+      <td><nuon-panel heading="Features: {{ dig "name" "—" $org }}" trigger="View full map" size="1/2">
+        <table><thead><tr><th>Feature</th><th>Enabled</th></tr></thead><tbody>
+        {{ range $key, $enabled := dig "features" (dict) $org }}<tr><td><code>{{ $key }}</code></td><td>{{ $enabled }}</td></tr>{{ end }}
+        </tbody></table>
+      </nuon-panel></td>
+    </tr>
+  {{ end }}
+  </tbody>
+</table>
+
+{{ else }}
+<nuon-banner theme="warn">Run <code>inspect_org_feature_flags</code> to populate this report.</nuon-banner>
+{{ end }}

--- a/byoc-nuon/runbooks/inspect_org_feature_flags.toml
+++ b/byoc-nuon/runbooks/inspect_org_feature_flags.toml
@@ -1,0 +1,9 @@
+name        = "inspect_org_feature_flags"
+description = "Inspect every non-deleted organization's ctl-api feature flags."
+readme      = "./runbooks/inspect_org_feature_flags.md"
+labels      = { service = "ctl-api", type = "debug" }
+
+[[steps]]
+name        = "Inspect org feature flags"
+type        = "action"
+action_name = "inspect_org_feature_flags"


### PR DESCRIPTION
### Summary

Operators can inspect feature-flag rollout across every non-deleted organization and safely enable a validated flag globally from AWS and GCP BYOC runbooks.

### What you can do after this PR

**Inspect feature coverage across all organizations.** The report shows enabled and disabled counts for every available feature, with each organization’s complete feature map available for inspection.

**Enable one feature globally with an explicit confirmation.** The runbook validates the key against the live feature catalog and requires the operator to type it twice before applying the change.

**See and verify the complete outcome.** Global updates report before and after counts, skip unnecessary changes, and verify every organization afterward. The runbook also shows the coupled effects between `control-plane-builds` and `org-runner`.

### What stays the same

Inspection is read-only and uses the admin API rather than direct database access. The enable action sends one bulk update and never retries an uncertain request automatically. Existing feature values remain unchanged unless an operator explicitly runs the enable runbook.

### Mechanics worth flagging for review

Organization scans require two consecutive matching ID sets to reduce offset-pagination gaps. Action output is split into bounded records so large organization lists remain compatible with existing runners.

Validation passed for shell syntax, TOML parsing, AWS/GCP parity, both app configurations, mock pagination, bulk updates, no-op behavior, and coupled-flag verification.
