### PR TITLE
chore: new inputs for ph auth

### DIFF
--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -101,6 +101,12 @@ env:
   MANAGEMENT_GCP_ORG_RUNNER_SA_EMAIL: "{{ .nuon.install_stack.outputs.custom_sa_emails.org_runner }}"
   MANAGEMENT_ACCOUNT_ID: "{{ .nuon.install_stack.outputs.project_id }}"
 
+  # for GCP: management region must be the region in which the phone home secret resources live
+  MANAGEMENT_REGION: "{{ .nuon.inputs.inputs.phone_home_region }}"
+
+  AWS_PHONE_HOME_CMK_ARN: "{{ .nuon.inputs.inputs.phone_home_cmk_arn }}"
+  AWS_PHONE_HOME_SECRETS_ROLE_ARN: "{{ .nuon.inputs.inputs.phone_home_secret_role_arn }}"
+
   DNS_ROOT_DOMAIN: "{{ .nuon.components.management.outputs.dns_zone.domain }}"
   DNS_ZONE_ID: "{{ .nuon.components.management.outputs.dns_zone.name }}"
 

--- a/byoc-nuon-gcp/input_groups/phone_home.toml
+++ b/byoc-nuon-gcp/input_groups/phone_home.toml
@@ -1,0 +1,3 @@
+name         = "phone_home"
+description  = "AWS Resources for AWS Lambda phone home auth."
+display_name = "Phone Home"

--- a/byoc-nuon-gcp/inputs/phone_home/cmk_arn.toml
+++ b/byoc-nuon-gcp/inputs/phone_home/cmk_arn.toml
@@ -1,0 +1,8 @@
+name         = "phone_home_cmk_arn"
+description  = "CMK ARN for Phone Home Secrets"
+default      = ""
+display_name = "Phone Home CMK ARK"
+required     = false
+group        = "phone_home"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/phone_home/region.toml
+++ b/byoc-nuon-gcp/inputs/phone_home/region.toml
@@ -1,0 +1,8 @@
+name         = "phone_home_region"
+description  = "AWS Region for Phone Home Secrets"
+default      = ""
+display_name = "Phone Home AWS Resources Region"
+required     = false
+group        = "phone_home"
+
+user_configurable = false

--- a/byoc-nuon-gcp/inputs/phone_home/secrets_role_arn.toml
+++ b/byoc-nuon-gcp/inputs/phone_home/secrets_role_arn.toml
@@ -1,0 +1,8 @@
+name         = "phone_home_secret_role_arn"
+description  = "Role ARN for provisioning and confifuring Install Phone Home Secrets"
+default      = ""
+display_name = "Phone Home Secret Role ARN"
+required     = false
+group        = "phone_home"
+
+user_configurable = false


### PR DESCRIPTION
### Description

New inputs, not user-configurable at this time.

### Notes

We can now support a new flow where the resources that rely on the `ctl_api_wi`
unique id can be created immediately after the install stack is applied. this
saves us a lot of time.

- **chore: new input for aws phone home resource configs**
- **chore: include phone home inputs in ctl-api values**
- **chore: new inputs for ph auth secrets**
