### PR TITLE
chore: move ctl-api actions from deployment to job

### DIFF
--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_grant_wi/ctl_api_grant_wi.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_grant_wi/ctl_api_grant_wi.toml
@@ -4,7 +4,9 @@
 # and ctl_api_wi (which creates the IAM user in Cloud SQL).
 name    = "ctl_api_grant_wi"
 labels  = { service = "ctl-api", type = "step" }
-timeout = "2m"
+# covers a cold ctl-api-worker node-pool scale-up (2-5m on GKE) plus the
+# 300s pod-ready wait inside the script
+timeout = "10m"
 
 [[triggers]]
 type           = "pre-deploy-component"
@@ -15,29 +17,10 @@ index          = 5
 type = "manual"
 
 [[steps]]
-name = "Grant ctl_api role to WI user"
-inline_contents = """
-#!/usr/bin/env bash
-set -euo pipefail
+name            = "Grant ctl_api role to WI user"
+inline_contents = "./ctl_api/ctl_api_grant_wi/grant-wi.sh"
 
-PGHOST="{{ .nuon.components.cloudsql_nuon.outputs.address }}"
-PGUSER=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
-PGPASSWORD=$(kubectl get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
-WI_USER="{{ .nuon.components.ctl_api_wi.outputs.db_user }}"
-
-echo "[ctl-api-grant-wi] scale up ctl-api-init"
-kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
-kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
-
-pod=$(kubectl -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name')
-
-echo "[ctl-api-grant-wi] granting ctl_api role to $WI_USER"
-kubectl --namespace=ctl-api exec -i $pod -- \
-  env "PGHOST=$PGHOST" "PGPORT=5432" "PGUSER=$PGUSER" "PGPASSWORD=$PGPASSWORD" \
-  psql --no-psqlrc -d ctl_api -c "GRANT ctl_api TO \\\"${WI_USER}\\\";"
-
-echo "[ctl-api-grant-wi] scale down ctl-api-init"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
-
-echo "[ctl-api-grant-wi] done"
-"""
+[steps.env_vars]
+PGHOST  = "{{ .nuon.components.cloudsql_nuon.outputs.address }}"
+PGPORT  = "5432"
+WI_USER = "{{ .nuon.components.ctl_api_wi.outputs.db_user }}"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_grant_wi/grant-wi.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_grant_wi/grant-wi.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+pg_host="$PGHOST"
+pg_port="$PGPORT"
+wi_user="$WI_USER"
+
+# Run a kubectl command, retrying ONLY on transient GKE control-plane
+# connectivity errors. The public API endpoint can drop a connection
+# mid-deploy (endpoint warm-up, brief LB/SNAT reconvergence), so any single
+# kubectl call can i/o-timeout. Real errors (auth failures, psql errors,
+# missing resources) don't match the connectivity patterns, so they fail fast
+# on the first attempt and are never masked.
+kubectl_retry() {
+  attempts=5
+  i=1
+  while true; do
+    out=$(kubectl "$@" 2>&1) && { printf '%s\n' "$out"; return 0; }
+    status=$?
+    case "$out" in
+      *"Unable to connect to the server"* | *"i/o timeout"* | *"dial tcp"* | \
+      *"TLS handshake timeout"* | *"connection refused"* | *"unexpected EOF"* | \
+      *"http2: client connection lost"* | *"EOF"*)
+        if [ "$i" -ge "$attempts" ]; then
+          printf '%s\n' "$out" >&2
+          echo "[ctl-api-grant-wi] ERROR: 'kubectl $*' failed after ${attempts} attempts (transient API-server connectivity)." >&2
+          return "$status"
+        fi
+        echo "[ctl-api-grant-wi] transient API-server error on 'kubectl $*' (attempt ${i}/${attempts}), retrying in 5s..." >&2
+        i=$((i + 1))
+        sleep 5
+        ;;
+      *)
+        printf '%s\n' "$out" >&2
+        return "$status"
+        ;;
+    esac
+  done
+}
+
+# One-shot psql jump pod, stamped out of the suspended CronJob template that
+# the ctl-api-init chart deploys. Each run gets its own job so back-to-back
+# actions can never grab each other's pods (the old shared-deployment race).
+suffix="$(head -c 64 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)"
+job_name="ctl-api-grant-wi-$(date -u +%Y%m%d-%H%M%S)-${suffix}"
+
+cleanup() {
+  kubectl delete job -n ctl-api "$job_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# the job template's sleep/activeDeadlineSeconds/ttlSecondsAfterFinished
+# backstops reap the job if the runner dies before this fires
+trap cleanup EXIT
+
+echo "[ctl-api-grant-wi] creating job $job_name"
+# a retried create can land after a first attempt already reached the server,
+# so on failure re-check whether the job exists before giving up
+if ! kubectl_retry create job -n ctl-api "$job_name" --from=cronjob/ctl-api-psql; then
+  kubectl_retry get job -n ctl-api "$job_name" >/dev/null
+fi
+
+# no action-run/workflow id is exposed to action steps, so attribute the job
+# with what the runner env does provide
+kubectl_retry annotate job -n ctl-api "$job_name" --overwrite \
+  "nuon.co/action=ctl-api-grant-wi" \
+  "nuon.co/install-id=${NUON_INSTALL_ID:-unknown}" \
+  "nuon.co/runner-id=${RUNNER_ID:-unknown}"
+
+echo "[ctl-api-grant-wi] waiting for the job pod"
+# the job controller creates the pod asynchronously: poll for the object
+# first, then wait for readiness (a cold node pool can take minutes)
+pod=""
+for _ in $(seq 1 30); do
+  pod=$(kubectl get pods -n ctl-api -l "job-name=${job_name}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) && [ -n "$pod" ] && break
+  sleep 2
+done
+if [ -z "$pod" ]; then
+  echo "[ctl-api-grant-wi] ERROR: job pod never appeared" >&2
+  kubectl describe job -n ctl-api "$job_name" >&2 || true
+  exit 1
+fi
+if ! kubectl_retry wait -n ctl-api "pod/${pod}" --for=condition=Ready --timeout=300s; then
+  kubectl describe pod -n ctl-api "$pod" >&2 || true
+  exit 1
+fi
+echo "[ctl-api-grant-wi] using pod: $pod"
+
+echo "[ctl-api-grant-wi] reading db access secrets from k8s"
+pg_user=$(kubectl_retry get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
+pg_password=$(kubectl_retry get -n ctl-api secret nuon-db -o jsonpath='{.data.password}' | base64 -d)
+
+echo "[ctl-api-grant-wi] granting ctl_api role to $wi_user"
+kubectl_retry --namespace=ctl-api exec -i "$pod" -- \
+  env "PGHOST=$pg_host" "PGPORT=$pg_port" "PGUSER=$pg_user" "PGPASSWORD=$pg_password" \
+  psql --no-psqlrc -d ctl_api -c "GRANT ctl_api TO \"${wi_user}\";"
+
+echo "[ctl-api-grant-wi] done"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_init_db/init-db.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_init_db/init-db.sh
@@ -76,12 +76,53 @@ echo "[ctl_api init] kubectl auth whoami"
 echo "pwd: "`pwd`
 kubectl_retry auth whoami -o json | jq -c
 
-echo "[ctl_api init] scale up the deployment"
-kubectl_retry scale -n ctl-api --replicas=1 deployment/ctl-api-init
-kubectl_retry wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
+# One-shot psql jump pod, stamped out of the suspended CronJob template that
+# the ctl-api-init chart deploys (it mounts the same /var/init-config
+# ConfigMap). Each run gets its own job so back-to-back actions can never
+# grab each other's pods (the old shared-deployment race).
+suffix="$(head -c 64 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)"
+job_name="ctl-api-init-db-$(date -u +%Y%m%d-%H%M%S)-${suffix}"
 
-echo "[ctl_api init] get a pod from the deployment"
-pod=`kubectl_retry -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name'`
+cleanup() {
+  kubectl delete job -n ctl-api "$job_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# the job template's sleep/activeDeadlineSeconds/ttlSecondsAfterFinished
+# backstops reap the job if the runner dies before this fires
+trap cleanup EXIT
+
+echo "[ctl_api init] creating job $job_name"
+# a retried create can land after a first attempt already reached the server,
+# so on failure re-check whether the job exists before giving up
+if ! kubectl_retry create job -n ctl-api "$job_name" --from=cronjob/ctl-api-psql; then
+  kubectl_retry get job -n ctl-api "$job_name" >/dev/null
+fi
+
+# no action-run/workflow id is exposed to action steps, so attribute the job
+# with what the runner env does provide
+kubectl_retry annotate job -n ctl-api "$job_name" --overwrite \
+  "nuon.co/action=ctl-api-init-db" \
+  "nuon.co/install-id=${NUON_INSTALL_ID:-unknown}" \
+  "nuon.co/runner-id=${RUNNER_ID:-unknown}"
+
+echo "[ctl_api init] waiting for the job pod"
+# the job controller creates the pod asynchronously: poll for the object
+# first, then wait for readiness (a cold node pool can take minutes)
+pod=""
+for _ in $(seq 1 30); do
+  pod=$(kubectl get pods -n ctl-api -l "job-name=${job_name}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) && [ -n "$pod" ] && break
+  sleep 2
+done
+if [ -z "$pod" ]; then
+  echo "[ctl_api init] ERROR: job pod never appeared" >&2
+  kubectl describe job -n ctl-api "$job_name" >&2 || true
+  exit 1
+fi
+if ! kubectl_retry wait -n ctl-api "pod/${pod}" --for=condition=Ready --timeout=300s; then
+  kubectl describe pod -n ctl-api "$pod" >&2 || true
+  exit 1
+fi
+echo "[ctl_api init] using pod: $pod"
 
 echo "[ctl_api init] reading db access secrets from k8s"
 admin_username=$(kubectl_retry get -n ctl-api secret nuon-db -o jsonpath='{.data.username}' | base64 -d)
@@ -137,5 +178,4 @@ kubectl_retry \
   env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$admin_username" "PGPASSWORD=$admin_password" \
   psql --no-psqlrc -d "ctl_api" -c "\du"
 
-echo "[ctl_api init] scale down the deployment"
-kubectl_retry scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
+echo "[ctl_api init] done (job cleaned up by the EXIT trap)"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_build/ctl_api_query_build.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_build/ctl_api_query_build.toml
@@ -1,7 +1,7 @@
 # action
 name    = "ctl_api_query_build"
 labels  = { service = "ctl-api", type = "tool" }
-timeout = "5m"
+timeout = "10m" # covers a cold ctl-api-worker node-pool scale-up plus the 300s pod-ready wait
 
 [[triggers]]
 type = "manual"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_build/query-build.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_build/query-build.sh
@@ -88,27 +88,42 @@ if [[ -z "$db_token" ]]; then
   exit 1
 fi
 
-# Ensure ctl-api-init is scaled back down even if the query fails partway
-# through (set -e would otherwise skip the explicit scale-down below and leave
-# a DB-access pod running). The flag keeps the trap a no-op until we scale up.
-scaled_up=0
+# One-shot psql jump pod, stamped out of the suspended CronJob template that
+# the ctl-api-init chart deploys. Each run gets its own job so concurrent
+# actions can never grab each other's pods.
+suffix="$(head -c 64 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)"
+job_name="ctl-api-query-build-$(date -u +%Y%m%d-%H%M%S)-${suffix}"
+
 cleanup() {
-  if [[ "$scaled_up" == "1" ]]; then
-    echo "[query build] cleanup: scaling down ctl-api-init"
-    kubectl scale -n ctl-api --replicas=0 deployment/ctl-api-init >/dev/null 2>&1 || true
-  fi
+  kubectl delete job -n ctl-api "$job_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
 }
+# the job template's sleep/activeDeadlineSeconds/ttlSecondsAfterFinished
+# backstops reap the job if the runner dies before this fires
 trap cleanup EXIT
 
-echo "[query build] scale up ctl-api-init"
-kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
-scaled_up=1
-kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
+echo "[query build] creating job $job_name"
+kubectl create job -n ctl-api "$job_name" --from=cronjob/ctl-api-psql
+kubectl annotate job -n ctl-api "$job_name" --overwrite \
+  "nuon.co/action=ctl-api-query-build" \
+  "nuon.co/install-id=${NUON_INSTALL_ID:-unknown}" \
+  "nuon.co/runner-id=${RUNNER_ID:-unknown}"
 
-pod=$(kubectl -n ctl-api get pods --selector app=ctl-api-init --field-selector=status.phase=Running -o json \
-  | jq -r '[.items[] | select(.metadata.deletionTimestamp == null)] | sort_by(.metadata.creationTimestamp) | last | .metadata.name')
-if [[ -z "$pod" || "$pod" == "null" ]]; then
-  echo "[query build] ERROR: no running ctl-api-init pod found" >&2
+echo "[query build] waiting for the job pod"
+# the job controller creates the pod asynchronously: poll for the object
+# first, then wait for readiness (a cold node pool can take minutes)
+pod=""
+for _ in $(seq 1 30); do
+  pod=$(kubectl get pods -n ctl-api -l "job-name=${job_name}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) && [ -n "$pod" ] && break
+  sleep 2
+done
+if [[ -z "$pod" ]]; then
+  echo "[query build] ERROR: job pod never appeared" >&2
+  kubectl describe job -n ctl-api "$job_name" >&2 || true
+  exit 1
+fi
+if ! kubectl wait -n ctl-api "pod/${pod}" --for=condition=Ready --timeout=300s; then
+  kubectl describe pod -n ctl-api "$pod" >&2 || true
   exit 1
 fi
 echo "[query build] using pod: $pod"
@@ -258,10 +273,6 @@ rows_json=$(kubectl --namespace=ctl-api exec -i "$pod" -- \
   env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$DB_USER" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -A -t -q -c "$sql" \
   | tr -d '\r' | { grep -E '^\[' || true; } | tail -n 1)
-
-echo "[query build] scale down ctl-api-init"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
-scaled_up=0
 
 if [[ -z "$rows_json" ]]; then
   rows_json='[]'

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_builds/ctl_api_query_builds.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_builds/ctl_api_query_builds.toml
@@ -2,7 +2,7 @@
 name    = "ctl_api_query_builds"
 labels  = { service = "ctl-api", type = "report" }
 label   = "query"
-timeout = "5m"
+timeout = "10m" # covers a cold ctl-api-worker node-pool scale-up plus the 300s pod-ready wait
 
 [[triggers]]
 type          = "cron"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_builds/query-builds.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_builds/query-builds.sh
@@ -80,27 +80,42 @@ if [[ -z "$db_token" ]]; then
   exit 1
 fi
 
-# Ensure ctl-api-init is scaled back down even if the query fails partway
-# through (set -e would otherwise skip the explicit scale-down below and leave
-# a DB-access pod running). The flag keeps the trap a no-op until we scale up.
-scaled_up=0
+# One-shot psql jump pod, stamped out of the suspended CronJob template that
+# the ctl-api-init chart deploys. Each run gets its own job so concurrent
+# actions can never grab each other's pods.
+suffix="$(head -c 64 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)"
+job_name="ctl-api-query-builds-$(date -u +%Y%m%d-%H%M%S)-${suffix}"
+
 cleanup() {
-  if [[ "$scaled_up" == "1" ]]; then
-    echo "[query builds] cleanup: scaling down ctl-api-init"
-    kubectl scale -n ctl-api --replicas=0 deployment/ctl-api-init >/dev/null 2>&1 || true
-  fi
+  kubectl delete job -n ctl-api "$job_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
 }
+# the job template's sleep/activeDeadlineSeconds/ttlSecondsAfterFinished
+# backstops reap the job if the runner dies before this fires
 trap cleanup EXIT
 
-echo "[query builds] scale up ctl-api-init"
-kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
-scaled_up=1
-kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
+echo "[query builds] creating job $job_name"
+kubectl create job -n ctl-api "$job_name" --from=cronjob/ctl-api-psql
+kubectl annotate job -n ctl-api "$job_name" --overwrite \
+  "nuon.co/action=ctl-api-query-builds" \
+  "nuon.co/install-id=${NUON_INSTALL_ID:-unknown}" \
+  "nuon.co/runner-id=${RUNNER_ID:-unknown}"
 
-pod=$(kubectl -n ctl-api get pods --selector app=ctl-api-init --field-selector=status.phase=Running -o json \
-  | jq -r '[.items[] | select(.metadata.deletionTimestamp == null)] | sort_by(.metadata.creationTimestamp) | last | .metadata.name')
-if [[ -z "$pod" || "$pod" == "null" ]]; then
-  echo "[query builds] ERROR: no running ctl-api-init pod found" >&2
+echo "[query builds] waiting for the job pod"
+# the job controller creates the pod asynchronously: poll for the object
+# first, then wait for readiness (a cold node pool can take minutes)
+pod=""
+for _ in $(seq 1 30); do
+  pod=$(kubectl get pods -n ctl-api -l "job-name=${job_name}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) && [ -n "$pod" ] && break
+  sleep 2
+done
+if [[ -z "$pod" ]]; then
+  echo "[query builds] ERROR: job pod never appeared" >&2
+  kubectl describe job -n ctl-api "$job_name" >&2 || true
+  exit 1
+fi
+if ! kubectl wait -n ctl-api "pod/${pod}" --for=condition=Ready --timeout=300s; then
+  kubectl describe pod -n ctl-api "$pod" >&2 || true
   exit 1
 fi
 echo "[query builds] using pod: $pod"
@@ -152,10 +167,6 @@ builds_json=$(kubectl --namespace=ctl-api exec -i "$pod" -- \
   env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$DB_USER" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -A -t -q -c "$sql" \
   | tr -d '\r' | { grep -E '^[[\{]' || true; } | tail -n 1)
-
-echo "[query builds] scale down ctl-api-init"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
-scaled_up=0
 
 if [[ -z "$builds_json" ]]; then
   builds_json='[]'

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_db/ctl_api_query_db.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_db/ctl_api_query_db.toml
@@ -1,7 +1,7 @@
 # action
 name    = "ctl_api_query_db"
 labels  = { service = "ctl-api", type = "tool" }
-timeout = "30s"
+timeout = "10m" # covers a cold ctl-api-worker node-pool scale-up plus the 300s pod-ready wait
 
 [[triggers]]
 type = "manual"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_db/query-db.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_db/query-db.sh
@@ -17,12 +17,45 @@ echo "pwd: "`pwd`
 kubectl auth whoami -o json | jq -c
 
 
-echo "[ctl_api query] scale up the deployment"
-kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
-kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
+# One-shot psql jump pod, stamped out of the suspended CronJob template that
+# the ctl-api-init chart deploys. Each run gets its own job so concurrent
+# actions can never grab each other's pods.
+suffix="$(head -c 64 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)"
+job_name="ctl-api-query-db-$(date -u +%Y%m%d-%H%M%S)-${suffix}"
 
-echo "[ctl_api query] get a pod from the deployment"
-pod=`kubectl -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name'`
+cleanup() {
+  kubectl delete job -n ctl-api "$job_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# the job template's sleep/activeDeadlineSeconds/ttlSecondsAfterFinished
+# backstops reap the job if the runner dies before this fires
+trap cleanup EXIT
+
+echo "[ctl_api query] creating job $job_name"
+kubectl create job -n ctl-api "$job_name" --from=cronjob/ctl-api-psql
+kubectl annotate job -n ctl-api "$job_name" --overwrite \
+  "nuon.co/action=ctl-api-query-db" \
+  "nuon.co/install-id=${NUON_INSTALL_ID:-unknown}" \
+  "nuon.co/runner-id=${RUNNER_ID:-unknown}"
+
+echo "[ctl_api query] waiting for the job pod"
+# the job controller creates the pod asynchronously: poll for the object
+# first, then wait for readiness (a cold node pool can take minutes)
+pod=""
+for _ in $(seq 1 30); do
+  pod=$(kubectl get pods -n ctl-api -l "job-name=${job_name}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) && [ -n "$pod" ] && break
+  sleep 2
+done
+if [[ -z "$pod" ]]; then
+  echo "[ctl_api query] ERROR: job pod never appeared" >&2
+  kubectl describe job -n ctl-api "$job_name" >&2 || true
+  exit 1
+fi
+if ! kubectl wait -n ctl-api "pod/${pod}" --for=condition=Ready --timeout=300s; then
+  kubectl describe pod -n ctl-api "$pod" >&2 || true
+  exit 1
+fi
+echo "[ctl_api query] using pod: $pod"
 
 # Query as the ctl-api IAM role (the table owner) via Cloud SQL IAM auth. The
 # nuon-db admin user is NOT the owner and gets "permission denied". Impersonate
@@ -53,5 +86,4 @@ sleep 1
 
 execute_query "$query"
 
-echo "[ctl_api query] scale down the deployment"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
+echo "[ctl_api query] done (job cleaned up by the EXIT trap)"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_phone_home/ctl_api_query_phone_home.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_phone_home/ctl_api_query_phone_home.toml
@@ -1,7 +1,7 @@
 # action
 name    = "ctl_api_query_phone_home"
 labels  = { service = "ctl-api", type = "tool" }
-timeout = "120s"
+timeout = "10m" # covers a cold ctl-api-worker node-pool scale-up plus the 300s pod-ready wait
 
 [[triggers]]
 type = "manual"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_phone_home/query-phone-home.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_phone_home/query-phone-home.sh
@@ -20,11 +20,44 @@ install_id="$INSTALL_ID"
 echo "[query phone-home] kubectl auth whoami"
 kubectl auth whoami -o json | jq -c
 
-echo "[query phone-home] scale up ctl-api-init"
-kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
-kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
+# One-shot psql jump pod, stamped out of the suspended CronJob template that
+# the ctl-api-init chart deploys. Each run gets its own job so concurrent
+# actions can never grab each other's pods.
+suffix="$(head -c 64 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)"
+job_name="ctl-api-query-phone-home-$(date -u +%Y%m%d-%H%M%S)-${suffix}"
 
-pod=$(kubectl -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name')
+cleanup() {
+  kubectl delete job -n ctl-api "$job_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# the job template's sleep/activeDeadlineSeconds/ttlSecondsAfterFinished
+# backstops reap the job if the runner dies before this fires
+trap cleanup EXIT
+
+echo "[query phone-home] creating job $job_name"
+kubectl create job -n ctl-api "$job_name" --from=cronjob/ctl-api-psql
+kubectl annotate job -n ctl-api "$job_name" --overwrite \
+  "nuon.co/action=ctl-api-query-phone-home" \
+  "nuon.co/install-id=${NUON_INSTALL_ID:-unknown}" \
+  "nuon.co/runner-id=${RUNNER_ID:-unknown}"
+
+echo "[query phone-home] waiting for the job pod"
+# the job controller creates the pod asynchronously: poll for the object
+# first, then wait for readiness (a cold node pool can take minutes)
+pod=""
+for _ in $(seq 1 30); do
+  pod=$(kubectl get pods -n ctl-api -l "job-name=${job_name}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) && [ -n "$pod" ] && break
+  sleep 2
+done
+if [[ -z "$pod" ]]; then
+  echo "[query phone-home] ERROR: job pod never appeared" >&2
+  kubectl describe job -n ctl-api "$job_name" >&2 || true
+  exit 1
+fi
+if ! kubectl wait -n ctl-api "pod/${pod}" --for=condition=Ready --timeout=300s; then
+  kubectl describe pod -n ctl-api "$pod" >&2 || true
+  exit 1
+fi
 echo "[query phone-home] using pod: $pod"
 
 # Query as the ctl-api IAM role (the table owner) via Cloud SQL IAM auth. The
@@ -75,9 +108,6 @@ echo "[query phone-home] running query"
 output=$(kubectl --namespace=ctl-api exec -i "$pod" -- \
   env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$db_user" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -A -t -c "$sql" | tr -d '\r' | grep -v '^$' | tail -n 1)
-
-echo "[query phone-home] scale down ctl-api-init"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
 
 if [[ -z "$output" ]]; then
   echo "[query phone-home] ERROR: empty result from db" >&2

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflow_steps/ctl_api_query_workflow_steps.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflow_steps/ctl_api_query_workflow_steps.toml
@@ -1,7 +1,7 @@
 # action
 name    = "ctl_api_query_workflow_steps"
 labels  = { service = "ctl-api", type = "tool" }
-timeout = "5m"
+timeout = "10m" # covers a cold ctl-api-worker node-pool scale-up plus the 300s pod-ready wait
 
 [[triggers]]
 type = "manual"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflow_steps/query-workflow-steps.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflow_steps/query-workflow-steps.sh
@@ -36,14 +36,42 @@ fi
 echo "[query workflow steps] kubectl auth whoami"
 kubectl auth whoami -o json | jq -c
 
-echo "[query workflow steps] scale up ctl-api-init"
-kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
-kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
+# One-shot psql jump pod, stamped out of the suspended CronJob template that
+# the ctl-api-init chart deploys. Each run gets its own job so concurrent
+# actions can never grab each other's pods.
+suffix="$(head -c 64 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)"
+job_name="ctl-api-query-wf-steps-$(date -u +%Y%m%d-%H%M%S)-${suffix}"
 
-pod=$(kubectl -n ctl-api get pods --selector app=ctl-api-init --field-selector=status.phase=Running -o json \
-  | jq -r '[.items[] | select(.metadata.deletionTimestamp == null)] | sort_by(.metadata.creationTimestamp) | last | .metadata.name')
-if [[ -z "$pod" || "$pod" == "null" ]]; then
-  echo "[query workflow steps] ERROR: no running ctl-api-init pod found" >&2
+cleanup() {
+  kubectl delete job -n ctl-api "$job_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# the job template's sleep/activeDeadlineSeconds/ttlSecondsAfterFinished
+# backstops reap the job if the runner dies before this fires
+trap cleanup EXIT
+
+echo "[query workflow steps] creating job $job_name"
+kubectl create job -n ctl-api "$job_name" --from=cronjob/ctl-api-psql
+kubectl annotate job -n ctl-api "$job_name" --overwrite \
+  "nuon.co/action=ctl-api-query-wf-steps" \
+  "nuon.co/install-id=${NUON_INSTALL_ID:-unknown}" \
+  "nuon.co/runner-id=${RUNNER_ID:-unknown}"
+
+echo "[query workflow steps] waiting for the job pod"
+# the job controller creates the pod asynchronously: poll for the object
+# first, then wait for readiness (a cold node pool can take minutes)
+pod=""
+for _ in $(seq 1 30); do
+  pod=$(kubectl get pods -n ctl-api -l "job-name=${job_name}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) && [ -n "$pod" ] && break
+  sleep 2
+done
+if [[ -z "$pod" ]]; then
+  echo "[query workflow steps] ERROR: job pod never appeared" >&2
+  kubectl describe job -n ctl-api "$job_name" >&2 || true
+  exit 1
+fi
+if ! kubectl wait -n ctl-api "pod/${pod}" --for=condition=Ready --timeout=300s; then
+  kubectl describe pod -n ctl-api "$pod" >&2 || true
   exit 1
 fi
 echo "[query workflow steps] using pod: $pod"
@@ -204,9 +232,6 @@ rows_json=$(kubectl --namespace=ctl-api exec -i "$pod" -- \
   env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$db_user" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -A -t -q -c "$sql" \
   | tr -d '\r' | { grep -E '^\[' || true; } | tail -n 1)
-
-echo "[query workflow steps] scale down ctl-api-init"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
 
 if [[ -z "$rows_json" ]]; then
   rows_json='[]'

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflows_by_type/ctl_api_query_workflows_by_type.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflows_by_type/ctl_api_query_workflows_by_type.toml
@@ -2,7 +2,7 @@
 name    = "ctl_api_query_workflows_by_type"
 labels  = { service = "ctl-api", type = "tool" }
 label   = "query"
-timeout = "5m"
+timeout = "10m" # covers a cold ctl-api-worker node-pool scale-up plus the 300s pod-ready wait
 
 [[triggers]]
 type          = "cron"

--- a/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflows_by_type/query-workflows-by-type.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/ctl_api_query_workflows_by_type/query-workflows-by-type.sh
@@ -72,11 +72,44 @@ if [[ -z "$db_token" ]]; then
   exit 1
 fi
 
-echo "[query workflows] scale up ctl-api-init"
-kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
-kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
+# One-shot psql jump pod, stamped out of the suspended CronJob template that
+# the ctl-api-init chart deploys. Each run gets its own job so concurrent
+# actions can never grab each other's pods.
+suffix="$(head -c 64 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)"
+job_name="ctl-api-query-wf-by-type-$(date -u +%Y%m%d-%H%M%S)-${suffix}"
 
-pod=$(kubectl -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name')
+cleanup() {
+  kubectl delete job -n ctl-api "$job_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# the job template's sleep/activeDeadlineSeconds/ttlSecondsAfterFinished
+# backstops reap the job if the runner dies before this fires
+trap cleanup EXIT
+
+echo "[query workflows] creating job $job_name"
+kubectl create job -n ctl-api "$job_name" --from=cronjob/ctl-api-psql
+kubectl annotate job -n ctl-api "$job_name" --overwrite \
+  "nuon.co/action=ctl-api-query-wf-by-type" \
+  "nuon.co/install-id=${NUON_INSTALL_ID:-unknown}" \
+  "nuon.co/runner-id=${RUNNER_ID:-unknown}"
+
+echo "[query workflows] waiting for the job pod"
+# the job controller creates the pod asynchronously: poll for the object
+# first, then wait for readiness (a cold node pool can take minutes)
+pod=""
+for _ in $(seq 1 30); do
+  pod=$(kubectl get pods -n ctl-api -l "job-name=${job_name}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) && [ -n "$pod" ] && break
+  sleep 2
+done
+if [[ -z "$pod" ]]; then
+  echo "[query workflows] ERROR: job pod never appeared" >&2
+  kubectl describe job -n ctl-api "$job_name" >&2 || true
+  exit 1
+fi
+if ! kubectl wait -n ctl-api "pod/${pod}" --for=condition=Ready --timeout=300s; then
+  kubectl describe pod -n ctl-api "$pod" >&2 || true
+  exit 1
+fi
 echo "[query workflows] using pod: $pod"
 
 sql="
@@ -189,9 +222,6 @@ workflows_json=$(kubectl --namespace=ctl-api exec -i "$pod" -- \
   env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$DB_USER" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -A -t -q -c "$sql" \
   | tr -d '\r' | { grep -E '^[[\{]' || true; } | tail -n 1)
-
-echo "[query workflows] scale down ctl-api-init"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
 
 if [[ -z "$workflows_json" ]]; then
   workflows_json='[]'

--- a/byoc-nuon-gcp/actions/ctl_api/temporal_hard_reset_cancel_queued_workflows/cancel-queued-workflows.sh
+++ b/byoc-nuon-gcp/actions/ctl_api/temporal_hard_reset_cancel_queued_workflows/cancel-queued-workflows.sh
@@ -35,11 +35,44 @@ if [[ -z "$db_token" ]]; then
   exit 1
 fi
 
-echo "[cancel-queued-workflows] scale up ctl-api-init"
-kubectl scale -n ctl-api --replicas=1 deployment/ctl-api-init
-kubectl wait deployment -n ctl-api ctl-api-init --for condition=Available=True --timeout=300s
+# One-shot psql jump pod, stamped out of the suspended CronJob template that
+# the ctl-api-init chart deploys. Each run gets its own job so concurrent
+# actions can never grab each other's pods.
+suffix="$(head -c 64 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)"
+job_name="ctl-api-cancel-queued-workflows-$(date -u +%Y%m%d-%H%M%S)-${suffix}"
 
-pod=$(kubectl -n ctl-api get pods --selector app=ctl-api-init -o json | jq -r '.items[0].metadata.name')
+cleanup() {
+  kubectl delete job -n ctl-api "$job_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# the job template's sleep/activeDeadlineSeconds/ttlSecondsAfterFinished
+# backstops reap the job if the runner dies before this fires
+trap cleanup EXIT
+
+echo "[cancel-queued-workflows] creating job $job_name"
+kubectl create job -n ctl-api "$job_name" --from=cronjob/ctl-api-psql
+kubectl annotate job -n ctl-api "$job_name" --overwrite \
+  "nuon.co/action=ctl-api-cancel-queued-workflows" \
+  "nuon.co/install-id=${NUON_INSTALL_ID:-unknown}" \
+  "nuon.co/runner-id=${RUNNER_ID:-unknown}"
+
+echo "[cancel-queued-workflows] waiting for the job pod"
+# the job controller creates the pod asynchronously: poll for the object
+# first, then wait for readiness (a cold node pool can take minutes)
+pod=""
+for _ in $(seq 1 30); do
+  pod=$(kubectl get pods -n ctl-api -l "job-name=${job_name}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) && [ -n "$pod" ] && break
+  sleep 2
+done
+if [[ -z "$pod" ]]; then
+  echo "[cancel-queued-workflows] ERROR: job pod never appeared" >&2
+  kubectl describe job -n ctl-api "$job_name" >&2 || true
+  exit 1
+fi
+if ! kubectl wait -n ctl-api "pod/${pod}" --for=condition=Ready --timeout=300s; then
+  kubectl describe pod -n ctl-api "$pod" >&2 || true
+  exit 1
+fi
 echo "[cancel-queued-workflows] using pod: $pod"
 
 sql="
@@ -67,7 +100,4 @@ kubectl --namespace=ctl-api exec -i "$pod" -- \
   env "PGHOST=$db_addr" "PGPORT=$db_port" "PGUSER=$DB_USER" "PGPASSWORD=$db_token" "PGSSLMODE=require" \
   psql --no-psqlrc -d "$db_name" -c "$sql"
 
-echo "[cancel-queued-workflows] scale down ctl-api-init"
-kubectl scale -n ctl-api --current-replicas=1 --replicas=0 deployment/ctl-api-init
-
-echo "[cancel-queued-workflows] done"
+echo "[cancel-queued-workflows] done (job cleaned up by the EXIT trap)"

--- a/byoc-nuon-gcp/actions/ctl_api/temporal_hard_reset_cancel_queued_workflows/temporal_hard_reset_cancel_queued_workflows.toml
+++ b/byoc-nuon-gcp/actions/ctl_api/temporal_hard_reset_cancel_queued_workflows/temporal_hard_reset_cancel_queued_workflows.toml
@@ -3,7 +3,7 @@
 # composite status is "queued" by updating status->>'status' to "cancelled".
 name    = "temporal_hard_reset_cancel_queued_workflows"
 labels  = { service = "ctl-api", type = "step" }
-timeout = "5m"
+timeout = "10m" # covers a cold ctl-api-worker node-pool scale-up plus the 300s pod-ready wait
 
 [[triggers]]
 type = "manual"

--- a/shared/src/components/ctl_api_init_db/Chart.yaml
+++ b/shared/src/components/ctl_api_init_db/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: ctl-api-init
 description: A helm chart for initializing the database for the ctl-api.
 type: application
-version: v0.0.2
-appVersion: "0.0.2"
+version: v0.0.3
+appVersion: "0.0.3"
 
 dependencies: []

--- a/shared/src/components/ctl_api_init_db/templates/cronjob.tpl
+++ b/shared/src/components/ctl_api_init_db/templates/cronjob.tpl
@@ -1,0 +1,59 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ctl-api-psql
+  namespace: ctl-api
+  labels:
+    app: ctl-api-psql
+spec:
+  # Template-only: this CronJob never fires on its own (suspended; the schedule
+  # is a required placeholder). Actions stamp out per-run Jobs from it with
+  #   kubectl create job -n ctl-api <unique-name> --from=cronjob/ctl-api-psql
+  # then exec psql into the job's pod. Per-run parameters (DB host, users,
+  # short-lived IAM tokens) are passed via `kubectl exec` env, never through
+  # the template — Jobs created with --from copy this spec immutably.
+  suspend: true
+  schedule: "0 0 1 1 *"
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      # Backstops for runs whose action died before cleaning up: the container
+      # exits on its own (sleep), activeDeadlineSeconds kills a wedged pod, and
+      # the TTL controller garbage-collects the finished Job and its pod.
+      activeDeadlineSeconds: 900
+      ttlSecondsAfterFinished: 600
+      template:
+        metadata:
+          labels:
+            # Deliberately NOT app=ctl-api-init: actions that still use the
+            # deployment select pods on that label and must never grab these.
+            nuon.co/oneshot: "true"
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: psql
+              image: "postgres:15-alpine3.20"
+              command: [ "sleep", "900" ]
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 70
+                allowPrivilegeEscalation: false
+              volumeMounts:
+              - name: init-config
+                mountPath: "/var/init-config"
+          volumes:
+            - name: init-config
+              configMap:
+                # Mount every key (no items:) so the template is insensitive
+                # to conditional keys like grant_user_iam.sql.
+                name: ctl-api-init
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}


### PR DESCRIPTION
### Description

Modify the `ctl_api_init_db` deployment to deploy a CronJob which actions can use as a template to stand up a dedicated pod for action executions.

This is a better approach than scaling a single deployment up/down because it avoids the race condition between concurrent actions.
