### PR TITLE
feat: add input-gated OIDC federation toggle for ctl-api

### DIFF
--- a/byoc-nuon-gcp/components/images/nuon_ctl_api.toml
+++ b/byoc-nuon-gcp/components/images/nuon_ctl_api.toml
@@ -3,6 +3,6 @@ type = "container_image"
 
 [aws_ecr]
 image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/ctl-api"
-tag          = "0.19.1093"
+tag          = "0.19.1103"
 region       = "us-west-2"
 iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"

--- a/byoc-nuon-gcp/components/images/nuon_dashboard_ui.toml
+++ b/byoc-nuon-gcp/components/images/nuon_dashboard_ui.toml
@@ -3,6 +3,6 @@ type = "container_image"
 
 [aws_ecr]
 image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/dashboard-ui"
-tag          = "0.19.1093"
+tag          = "0.19.1103"
 region       = "us-west-2"
 iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"

--- a/byoc-nuon-gcp/components/values/ctl-api.yaml
+++ b/byoc-nuon-gcp/components/values/ctl-api.yaml
@@ -126,6 +126,8 @@ env:
   QUEUE_CONTINUE_AS_NEW_HISTORY_MAX: "1500"
   QUEUE_SIGNAL_CLEANUP_ENABLED: "true"
 
+  OIDC_FEDERATION_ENABLED: '{{ or .nuon.inputs.inputs.oidc_federation_enabled "false" }}'
+
 envSecrets:
   - name: "GITHUB_APP_KEY"
     valueFrom:

--- a/byoc-nuon-gcp/inputs/nuon/oidc_federation_enabled.toml
+++ b/byoc-nuon-gcp/inputs/nuon/oidc_federation_enabled.toml
@@ -1,0 +1,9 @@
+name         = "oidc_federation_enabled"
+description  = "Enable OIDC federation, letting CI/CD workloads exchange an OIDC token for a short-lived Nuon API token instead of a stored static token."
+default      = "false"
+display_name = "OIDC Federation Enabled"
+required     = false
+group        = "nuon"
+type         = "bool"
+
+user_configurable = false

--- a/byoc-nuon/components/values/ctl-api.yaml
+++ b/byoc-nuon/components/values/ctl-api.yaml
@@ -126,6 +126,8 @@ env:
   QUEUE_CONTINUE_AS_NEW_HISTORY_MAX: "1500"
   QUEUE_SIGNAL_CLEANUP_ENABLED: "true"
 
+  OIDC_FEDERATION_ENABLED: '{{ or .nuon.inputs.inputs.oidc_federation_enabled "false" }}'
+
 envSecrets:
   - name: "GITHUB_APP_KEY"
     valueFrom:

--- a/byoc-nuon/inputs/nuon/oidc_federation_enabled.toml
+++ b/byoc-nuon/inputs/nuon/oidc_federation_enabled.toml
@@ -1,0 +1,9 @@
+name         = "oidc_federation_enabled"
+description  = "Enable OIDC federation, letting CI/CD workloads exchange an OIDC token for a short-lived Nuon API token instead of a stored static token."
+default      = "false"
+display_name = "OIDC Federation Enabled"
+required     = false
+group        = "nuon"
+type         = "bool"
+
+user_configurable = false

--- a/shared/components/images/nuon_ctl_api.toml
+++ b/shared/components/images/nuon_ctl_api.toml
@@ -4,6 +4,6 @@ type = "container_image"
 
 [aws_ecr]
 image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/ctl-api"
-tag          = "0.19.1083"
+tag          = "0.19.1103"
 region       = "us-west-2"
 iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"

--- a/shared/components/images/nuon_dashboard_ui.toml
+++ b/shared/components/images/nuon_dashboard_ui.toml
@@ -4,6 +4,6 @@ type = "container_image"
 
 [aws_ecr]
 image_url    = "431927561584.dkr.ecr.us-west-2.amazonaws.com/mono/dashboard-ui"
-tag          = "0.19.1083"
+tag          = "0.19.1103"
 region       = "us-west-2"
 iam_role_arn = "arn:aws:iam::431927561584:role/nuon-ecr-access"


### PR DESCRIPTION
## Summary

Adds an internal `oidc_federation_enabled` bool input (default `false`) to the AWS and GCP byoc-nuon app configs. It's wired into the ctl-api env as `OIDC_FEDERATION_ENABLED`.