### PR TITLE
feat(byoc-nuon-gcp): toggle Datadog from the platform

### DIFF
--- a/byoc-nuon-gcp/components/99-tf-datadog.toml
+++ b/byoc-nuon-gcp/components/99-tf-datadog.toml
@@ -2,6 +2,8 @@ name              = "datadog"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 dependencies      = ["temporal", "ctl_api", "dashboard_ui"]
+toggleable        = true
+default_enabled   = true
 
 [public_repo]
 repo      = "nuonco/byoc"
@@ -20,7 +22,6 @@ install_id   = "{{ .nuon.install.id }}"
 org_id       = "{{ .nuon.org.id }}"
 org_name     = "{{ .nuon.org.name }}"
 
-datadog_enabled = "{{ .nuon.inputs.inputs.datadog_enabled }}"
 datadog_api_key = "{{ .nuon.inputs.inputs.datadog_api_key }}"
 datadog_app_key = "{{ .nuon.inputs.inputs.datadog_app_key }}"
 

--- a/byoc-nuon-gcp/inputs/datadog/datadog_enabled.toml
+++ b/byoc-nuon-gcp/inputs/datadog/datadog_enabled.toml
@@ -1,5 +1,0 @@
-name         = "datadog_enabled"
-description  = "Enable or disable the Datadog component"
-default      = "false"
-display_name = "Enable Datadog"
-group        = "datadog"

--- a/byoc-nuon-gcp/src/components/datadog/variables.tf
+++ b/byoc-nuon-gcp/src/components/datadog/variables.tf
@@ -1,24 +1,8 @@
 locals {
-  name            = "datadog-agent"
-  namespace       = "datadog"
-  datadog_enabled = lower(var.datadog_enabled) == "true"
-  has_keys        = (var.datadog_api_key != "" && var.datadog_app_key != "")
-  enabled         = local.datadog_enabled && local.has_keys
-}
-
-variable "datadog_enabled" {
-  type    = string
-  default = "false"
-
-  validation {
-    condition     = !(lower(var.datadog_enabled) == "true" && var.datadog_api_key == "")
-    error_message = "datadog_enabled is true but datadog_api_key is not set."
-  }
-
-  validation {
-    condition     = !(lower(var.datadog_enabled) == "true" && var.datadog_app_key == "")
-    error_message = "datadog_enabled is true but datadog_app_key is not set."
-  }
+  name      = "datadog-agent"
+  namespace = "datadog"
+  has_keys  = (var.datadog_api_key != "" && var.datadog_app_key != "")
+  enabled   = local.has_keys
 }
 
 variable "datadog_api_key" {


### PR DESCRIPTION
Make the GCP Datadog component toggleable (enabled by default) and drop the `datadog_enabled` input, matching the AWS app; the module still no-ops unless both Datadog keys are set.